### PR TITLE
Dynamically linking SDL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "TotalCrossVM/deps/SDL"]
-	path = TotalCrossVM/deps/SDL
-	url = https://github.com/SDL-mirror/SDL.git

--- a/TotalCrossVM/builders/gcc-linux-arm/docker-builder-image/Dockerfile
+++ b/TotalCrossVM/builders/gcc-linux-arm/docker-builder-image/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get install -y build-essential mercurial make cmake autoconf automake \
 RUN apt-get install -y libwayland-dev libxkbcommon-dev wayland-protocols
 RUN apt-get install -y libgles1-mesa-dev || apt-get -f install
 RUN apt-get install -y build-essential libgtk-3-dev
+RUN apt-get install -y libsdl2-dev
 ENV BUILD_FOLDER /build
 
 WORKDIR ${BUILD_FOLDER}

--- a/TotalCrossVM/builders/gcc-linux-arm/docker-builder-image/build.sh
+++ b/TotalCrossVM/builders/gcc-linux-arm/docker-builder-image/build.sh
@@ -2,6 +2,6 @@
 export DOCKER_CLI_EXPERIMENTAL=enabled
 export DOCKER_BUILDKIT=1
 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-sudo docker buildx create --use --name armbuilder
-sudo docker buildx inspect --bootstrap
-sudo docker buildx build --platform linux/arm/v7 --load -t totalcross/cross-compile .
+docker buildx create --use --name armbuilder
+docker buildx inspect --bootstrap
+docker buildx build --platform linux/arm/v7 --load -t totalcross/cross-compile .

--- a/TotalCrossVM/builders/gcc-linux-arm/tcvm/Makefile
+++ b/TotalCrossVM/builders/gcc-linux-arm/tcvm/Makefile
@@ -84,11 +84,7 @@ NM_LANG_FILES =                               \
 	$(SRCDIR)/nm/lang/StringBuffer.c        \
 	$(SRCDIR)/nm/lang/Thread.c              \
 	$(SRCDIR)/nm/lang/Throwable.c           \
-	$(SRCDIR)/nm/lang/Reflection.c			\
-	${SRCDIR}/nm/lang/Runtime.c				\
-	${SRCDIR}/nm/lang/cpproc.c 				\
-	${SRCDIR}/nm/nio/channels/FileChannelImpl.c \
-	${SRCDIR}/nm/lang/Process.c
+	$(SRCDIR)/nm/lang/Reflection.c
 
 NM_NET_FILES =                         \
 	$(SRCDIR)/nm/net/ssl_SSL.c       \

--- a/TotalCrossVM/builders/gcc-linux-arm/tcvm/Makefile
+++ b/TotalCrossVM/builders/gcc-linux-arm/tcvm/Makefile
@@ -4,32 +4,20 @@ ifndef BLDDIR
 BLDDIR = /build
 endif
 
-ifndef SDLDIR
-SDLDIR=/sdl
-endif
-
-ifndef SDL_INC
-SDL_INC=/
-endif
-$(info SDL inc is: [${SDL_INC}])
-ifndef SRCDIR
-SRCDIR = /src
-endif
-
 ifndef SKIADIR
 SKIADIR = /skia
 endif
 
 ifndef LIBS
-LIBS = -L. -lskia -lstdc++ -lpthread -lEGL -lfontconfig $(SDLDIR)/build/libSDL2.a
+LIBS = -L. -lskia -lstdc++ -lpthread -lEGL -lfontconfig -lSDL2main -lSDL2
 endif
 
 SKIA_INC=$(addprefix -I,$(wildcard $(SKIADIR)/*))
 INCDIR = $(BLDDIR)/inc
 
 OBJDIR = $(BLDDIR)/bin
-CFLAGS = -DHAVE_MREMAP=0 -Dlinux -fPIC -shared -c -Os -Wall -DNDEBUG -Wunused-function -Wno-import -fno-strict-aliasing -DHEADLESS -DPOSIX -D_REENTRANT -DTOTALCROSS -DFORCE_LIBC_ALLOC -DTC_EXPORTS -DSQLITE_HAS_CODEC -I$(SDL_INC) -I$(SRCDIR) -I$(SRCDIR)/tcvm -I$(SRCDIR)/util -I$(SRCDIR)/zlib -I$(SRCDIR)/nm -I$(SRCDIR)/axtls -I$(SRCDIR)/event -I$(SRCDIR)/scanner -I$(SRCDIR)/nm/ui -I$(SRCDIR)/nm/ui/linux -I$(SRCDIR)/nm/io -I$(SRCDIR)/nm/lang -I$(SRCDIR)/litebase/parser  -I$(SRCDIR)/litebase  -I$(SRCDIR)/nm/ui/android
-CXXFLAGS = -Os -Wall -fPIC -shared -DNDEBUG -DHEADLESS -DPOSIX -lpthread -std=c++11 $(SKIA_INC) -I$(SDL_INC) -I$(SRCDIR) -I$(SRCDIR)/tcvm -I$(SRCDIR)/util -I$(SRCDIR)/zlib -I$(SRCDIR)/nm -I$(SRCDIR)/axtls -I$(SRCDIR)/event -I$(SRCDIR)/scanner -I$(SRCDIR)/nm/ui -I$(SRCDIR)/nm/ui/linux -I$(SRCDIR)/nm/io -I$(SRCDIR)/nm/lang -I$(SRCDIR)/litebase/parser  -I$(SRCDIR)/litebase -I$(SRCDIR)/nm/ui/android
+CFLAGS = -DHAVE_MREMAP=0 -Dlinux -fPIC -shared -c -Os -Wall -DNDEBUG -Wunused-function -Wno-import -fno-strict-aliasing -DHEADLESS -DPOSIX -D_REENTRANT -DTOTALCROSS -DFORCE_LIBC_ALLOC -DTC_EXPORTS -DSQLITE_HAS_CODEC -I$(SRCDIR) -I$(SRCDIR)/tcvm -I$(SRCDIR)/util -I$(SRCDIR)/zlib -I$(SRCDIR)/nm -I$(SRCDIR)/axtls -I$(SRCDIR)/event -I$(SRCDIR)/scanner -I$(SRCDIR)/nm/ui -I$(SRCDIR)/nm/ui/linux -I$(SRCDIR)/nm/io -I$(SRCDIR)/nm/lang -I$(SRCDIR)/litebase/parser  -I$(SRCDIR)/litebase  -I$(SRCDIR)/nm/ui/android
+CXXFLAGS = -Os -Wall -fPIC -shared -DNDEBUG -DHEADLESS -DPOSIX -lpthread -std=c++11 $(SKIA_INC) -I$(SRCDIR) -I$(SRCDIR)/tcvm -I$(SRCDIR)/util -I$(SRCDIR)/zlib -I$(SRCDIR)/nm -I$(SRCDIR)/axtls -I$(SRCDIR)/event -I$(SRCDIR)/scanner -I$(SRCDIR)/nm/ui -I$(SRCDIR)/nm/ui/linux -I$(SRCDIR)/nm/io -I$(SRCDIR)/nm/lang -I$(SRCDIR)/litebase/parser  -I$(SRCDIR)/litebase -I$(SRCDIR)/nm/ui/android
 CXX_SOURCES = $(SRCDIR)/init/tcsdl.cpp \
 $(SRCDIR)/nm/ui/android/skia.cpp 
 
@@ -96,7 +84,11 @@ NM_LANG_FILES =                               \
 	$(SRCDIR)/nm/lang/StringBuffer.c        \
 	$(SRCDIR)/nm/lang/Thread.c              \
 	$(SRCDIR)/nm/lang/Throwable.c           \
-	$(SRCDIR)/nm/lang/Reflection.c
+	$(SRCDIR)/nm/lang/Reflection.c			\
+	${SRCDIR}/nm/lang/Runtime.c				\
+	${SRCDIR}/nm/lang/cpproc.c 				\
+	${SRCDIR}/nm/nio/channels/FileChannelImpl.c \
+	${SRCDIR}/nm/lang/Process.c
 
 NM_NET_FILES =                         \
 	$(SRCDIR)/nm/net/ssl_SSL.c       \

--- a/TotalCrossVM/builders/gcc-linux-arm/tcvm/build.sh
+++ b/TotalCrossVM/builders/gcc-linux-arm/tcvm/build.sh
@@ -9,8 +9,8 @@ sudo docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 sudo docker run \
 -v $WORKDIR:/build \
 -v $WORKDIR/../../../deps/skia:/skia \
--v $WORKDIR/../sdl:/sdl \
--v $WORKDIR/../../../deps/SDL/include:/SDL2 \
 -v $WORKDIR/../../../src:/src \
+-e SRCDIR=/../../../src \
+-e LIBS="-L. -lskia -lstdc++ -lpthread -lEGL -lfontconfig -lSDL2main -lSDL2" \
 -t totalcross/cross-compile \
 bash -c "make  -j$(($(nproc) + 2)) -f /build/Makefile"


### PR DESCRIPTION
Watching #14 we concluded that the need to change SDL linking **to dynamic**,  [FOSSA](https://app.fossa.com/)  warned us about the SDL license (GPLv3) :sleepy:. 