### PR TITLE
Added printf() inside write to debugConsole.txt method

### DIFF
--- a/TotalCrossVM/src/util/posix/debug_c.h
+++ b/TotalCrossVM/src/util/posix/debug_c.h
@@ -59,7 +59,9 @@ static bool privateDebug(char* str)
       }
       else
       {
-         fputs(str,fdebug);
+         fputs(str,fdebug);   
+         printf(str);
+         printf("\n");
          err = (fputs("\n",fdebug) >= 0);
          fflush(fdebug);
          fsync(fileno(fdebug));


### PR DESCRIPTION
System.out.prinft now only prints log stuff in debugConsole.txt, with these changes log will be redirect both to console.