### PR TITLE
fix BORDER_ROUNDED on Container for linux arm devices

### DIFF
--- a/TotalCrossSDK/src/main/java/totalcross/ui/Container.java
+++ b/TotalCrossSDK/src/main/java/totalcross/ui/Container.java
@@ -19,6 +19,7 @@ import totalcross.ui.gfx.Rect;
 import totalcross.ui.image.Image;
 import totalcross.ui.image.ImageException;
 import totalcross.util.ElementNotFoundException;
+import totalcross.util.UnitsConverter;
 import totalcross.util.Vector;
 
 /**
@@ -84,6 +85,12 @@ public class Container extends Control {
    */
   public int borderColor = -1;
 
+    /**
+   * Border Radius, used when border style is @see BORDER_ROUNDED
+   * 
+   */
+  protected int borderRadius = UnitsConverter.toPixels(DP + 12);
+  
   /**
    * Defines the total transition time. Defaults to 1000 (1 second).
    * 
@@ -620,8 +627,18 @@ public class Container extends Control {
 	      break;
 	
 	    case BORDER_ROUNDED:
-	      g.drawWindowBorder(0, 0, width, height, 0, 0, borderColor != -1 ? borderColor : getForeColor(), b, b, b, 2,
-	          false);
+        if(Settings.onJavaSE) { // used on simulator
+          g.drawWindowBorder(0, 0, width, height, 0, 0, borderColor != -1 ? borderColor : getForeColor(), b, b, b, 2,
+              false);
+        }
+        else {
+          g.backColor = backColor;
+          g.fillRoundRect(0, 0, width, height, borderRadius);
+          if(borderColor != -1 ) {
+            g.foreColor = borderColor;
+            g.drawRoundRect(0, 0, width, height, borderRadius);
+          }
+        }
 	      break;
 	
 	    default:
@@ -1069,4 +1086,23 @@ public class Container extends Control {
    */
   public void onSwapFinished() {
   }
+
+  /**
+   * get border radius for border style @see BORDER_ROUNDED. Default value is 12dp.
+   * (Not used on JAVA simulator)
+   * @return
+   */
+  public int getBorderRadius() {
+    return borderRadius;
+  }
+
+  /**
+   * Set border radius for border style @see BORDER_ROUNDED. Default value is 12dp.
+   * (Not used on JAVA simulator)
+   * @param borderRadius border radius in pixels. 
+   */
+  public void setBorderRadius(int borderRadius) {
+    this.borderRadius = borderRadius;
+  }
+
 }


### PR DESCRIPTION
Problem: When using Container.setStyle(BORDER_ROUNDED), the rounded border is drawn on java side using CPU and the draw is not right on linux arm resulting in a terrible rounded rectangle draw.

Solution: now BORDER_ROUNDED is drawn using Graphics primitives fillRoundedRect and drawRoundedRect. This allows GPU to take care of this draw fixing the terrible behaviour above. The simulator side keeps the solution above because roundrect does not draw beatufil round rectangles.

## Description:
When using Container.setBorderStyle(BORDER_ROUNDED), a rounded rectangle is designed representing such a container. On linux arm devices, the draw is very creepy. In addition the draw is made on the Java side using CPU.   

### Related Issue:
- this is being fix for an example

## Motivation and Context:

This was made to get a more beautiful draw when using rounded borders on containers

## Benefited Devices:
 - Device: linux_arm devices.
 - OS: any linux based distro.

## Tested Devices:
 - Device: Raspberry pi 4
 - OS: Raspberry PI OS
