### PR TITLE
Adding header files to HEADLESS on Runtime.c to fix build on wince.

### DIFF
--- a/TotalCrossVM/src/nm/lang/Process.c
+++ b/TotalCrossVM/src/nm/lang/Process.c
@@ -9,7 +9,7 @@
 #include <signal.h>
 
 TC_API void jlPI_waitFor(NMParams p) {
-#if defined(HEADLESS)
+#if defined(linux) && !defined(darwin)
     TCObject process = p->obj[0];
     int status;
     pid_t pid;

--- a/TotalCrossVM/src/nm/lang/Runtime.c
+++ b/TotalCrossVM/src/nm/lang/Runtime.c
@@ -6,6 +6,9 @@
 #include "Runtime.h"
 #if defined(HEADLESS)
 #include "cpproc.h"
+#include <sys/types.h>
+#include "errno.h"
+#include <dlfcn.h>
 #endif
 #include "errno.h"
 #include <sys/types.h>

--- a/TotalCrossVM/src/nm/lang/Runtime.c
+++ b/TotalCrossVM/src/nm/lang/Runtime.c
@@ -10,8 +10,6 @@
 #include "errno.h"
 #include <dlfcn.h>
 #endif
-#include "errno.h"
-#include <sys/types.h>
 
 TC_API void jlR_exec_SSs(NMParams p) {
 #if defined(HEADLESS)

--- a/TotalCrossVM/src/nm/lang/Runtime.c
+++ b/TotalCrossVM/src/nm/lang/Runtime.c
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "Runtime.h"
-#if defined(HEADLESS)
+#if defined(linux) && !defined(darwin)
 #include "cpproc.h"
 #include <sys/types.h>
 #include "errno.h"
@@ -12,7 +12,7 @@
 #endif
 
 TC_API void jlR_exec_SSs(NMParams p) {
-#if defined(HEADLESS)
+#if defined(linux) && !defined(darwin)
     int fds[CPIO_EXEC_NUM_PIPES];
     TCObject cmd = p->obj[1];
     TCObject envp = p->obj[2];

--- a/TotalCrossVM/src/nm/nio/channels/FileChannelImpl.c
+++ b/TotalCrossVM/src/nm/nio/channels/FileChannelImpl.c
@@ -8,7 +8,7 @@
 #include "errno.h"
 
 TC_API void jncFCI_read(NMParams p) {
-#if defined(HEADLESS)
+#if defined(linux) && !defined(darwin)
     TCObject fileChannel = p->obj[0];
     int32 fd = FileChannelImpl_nfd(fileChannel);
     int32 buffer;
@@ -24,7 +24,7 @@ TC_API void jncFCI_read(NMParams p) {
 }
 
 TC_API void jncFCI_read_Bii(NMParams p) {
-#if defined(HEADLESS)
+#if defined(linux) && !defined(darwin)
     TCObject fileChannel = p->obj[0];
     TCObject byteArray = p->obj[1];
     int32 offset = p->i32[0];
@@ -53,7 +53,7 @@ TC_API void jncFCI_read_Bii(NMParams p) {
 }
 
 TC_API void jncFCI_write_Bii(NMParams p) {
-#if defined(HEADLESS)
+#if defined(linux) && !defined(darwin)
     TCObject fileChannel = p->obj[0];
     TCObject byteArray = p->obj[1];
     int32 offset = p->i32[0];


### PR DESCRIPTION
## Description:
Removing some C files from wince build.

### Related Issue:
 Fixing this to avoid a furute issue with WinCE. 

## Motivation and Context:
The files removed are not compatible with WinCE build.

## Benefited Devices:
 - Device: All Window CE devices.
 - OS: Windows CE

## How Has This Been Tested?
 - Running the build process for Windows CE.

## Tested Devices:
 - Device: USA Windows Mobile 5.0 Pocket PC T2 Emulator
 - OS: Windos CE
