### PR TITLE
Fix wrong FontMetrics.stringWidth(String s) on devices that use skia

### DIFF
--- a/TotalCrossVM/src/nm/ui/font_Font.c
+++ b/TotalCrossVM/src/nm/ui/font_Font.c
@@ -32,8 +32,11 @@ TC_API void tufF_fontCreate(NMParams p) // totalcross/ui/font/Font native void f
    } else {
       xstrcpy(nameTTF, name);
    }
-   xstrcat(nameTTF, ".ttf");
-   
+   int len = xstrlen(nameTTF);
+   // if it doesn't end with .ttf
+   if(!(nameTTF[len-4] == '.' && nameTTF[len-3] == 't' && nameTTF[len-2] == 't' && nameTTF[len-1] == 'f')) {
+      xstrcat(nameTTF, ".ttf");
+   }
    int32 fontIdx = skia_getTypefaceIndex(nameTTF);
    if (fontIdx == -1) {
        if ((file = tczGetFile(nameTTF, false)) != null) {


### PR DESCRIPTION
## Description:
Font.getFont("Fonts/Roboto-Bold.ttf", false, size) leads FontMetrics.stringWidth(String s) to returns almost double of the size of the font. The reason this is happening is because on the vm side it already adds .ttf the end of the name of the font making the vm look for Fonts/Roboto-Bold.ttf.ttf instead of the originally passed argument. To solve this, I check if name of the font already comes with .ttf before concatenating .ttf to the of the name.

## Motivation and Context:
Wrong Label width because when using `Font.getFont("Fonts/Roboto-Bold.ttf", false, size)` instead of `Font.getFont("Fonts/Roboto-Bold", false, size)` without `.ttf`.

## Benefited Devices:
 - Device: devices that has as OS iOS, Android and Linux/Linux_arm
 - OS: iOS, Android, Linux and Linux_arm

## How Has This Been Tested?
 - I took different ttf files and loaded them in a Test project. Then, for each font file I've made a Label and painted its background with to see the real space that Label was taking. After the fix, the was taking exactly the same size of the text drawn.
 
## Tested Devices:
 - Device: Raspberry PI 4
 - OS: Raspberry PI OS
