### PR TITLE
Removes wrong debugging on totalcross.game.Animation

### DIFF
--- a/TotalCrossSDK/src/main/java/totalcross/game/Animation.java
+++ b/TotalCrossSDK/src/main/java/totalcross/game/Animation.java
@@ -234,11 +234,6 @@ public class Animation extends Control {
       
       framesBuffer.setCurrentFrame(curFrame);
     }
-    
-    System.out.println("W:" + framesBuffer.getWidth());
-    System.out.println("H:" + framesBuffer.getHeight());
-    System.out.println("N:" + framesBuffer.getFrameCount());
-    System.out.println("C:" + framesBuffer.getCurrentFrame());
 
     // flsobral@tc100b5_6: argument doClip is now true, this avoids exceptions when the image is larger than the screen.
     gfx.drawImage(framesBuffer, 0, 0, true);


### PR DESCRIPTION
## Motivation and Context:
At onPaint of the class totalacross.game.Animation, there were some unnecessary printlns. This was producing some annoying and unnecessary logs.

## Benefited Devices:
 - Device: all
 - OS: all

## How Has This Been Tested?
 - running it on the simulator 
## Tested Devices:
 - Device: Simulator
 - OS: any
