### PR TITLE
Topic/support pixel format argb

### DIFF
--- a/TotalCrossVM/src/nm/ui/android/skia.cpp
+++ b/TotalCrossVM/src/nm/ui/android/skia.cpp
@@ -588,9 +588,11 @@ int32 colorType(uint32 pixelformat) {
                 return kRGB_565_SkColorType;
             }
         }
-    } else if (SDL_PIXELTYPE(pixelformat) == SDL_PIXELTYPE_PACKED32) {
-        if (SDL_PIXELORDER(pixelformat) == SDL_PACKEDORDER_XRGB) {
-            if (SDL_PIXELLAYOUT(pixelformat) == SDL_PACKEDLAYOUT_8888) {
+    }
+    else if (SDL_PIXELTYPE(pixelformat) == SDL_PIXELTYPE_PACKED32) {
+        if (SDL_PIXELLAYOUT(pixelformat) == SDL_PACKEDLAYOUT_8888) {
+            if (SDL_PIXELORDER(pixelformat) == SDL_PACKEDORDER_XRGB ||
+                SDL_PIXELORDER(pixelformat) == SDL_PACKEDORDER_ARGB) {
                 return kBGRA_8888_SkColorType;
             }
         }

--- a/TotalCrossVM/src/nm/ui/android/skia.cpp
+++ b/TotalCrossVM/src/nm/ui/android/skia.cpp
@@ -597,6 +597,7 @@ int32 colorType(uint32 pixelformat) {
             }
         }
     }
+    debug("Unsupported pixel format %s, try mapping your color format on %s - %s", SDL_GetPixelFormatName(pixelformat), __FILE__, __FUNCTION__);
     return kUnknown_SkColorType;
 }
 #endif


### PR DESCRIPTION
## Description:
Adds support for pixel format with packed order ARGB, and a debug message for devices which use an unsupported color format.

## Motivation and Context:
Adds graphical support for macbooks and devices running with KMS/DRM, both which use ARGB. Setting skia to use BGRA works fine for both XRGB and ARGB.
The debug message will help us to quickly identify when the device uses an unsupported pixel color format, instead of failing silently.

## Benefited Devices:
- MacOS
- devices running KMS/DRM

## Tested Devices:
- 2 macbooks running MacOSX 10.14 and 10.15
- Toradex imx6dl running on Torizon (ARM)
- desktop linux (Ubuntu - x86_64)
