### PR TITLE
kmsdrm: change SDL and Skia to work with KMS/DRM

### DIFF
--- a/TotalCrossVM/src/init/tcsdl.cpp
+++ b/TotalCrossVM/src/init/tcsdl.cpp
@@ -27,6 +27,7 @@ static SDL_Texture* texture;
  * - true on success
  */
 bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen) {
+SDL_Init( 0 );
 
 	std::cout << "Testing video drivers..." << '\n';
 	std::vector< bool > drivers(SDL_GetNumVideoDrivers());
@@ -86,9 +87,9 @@ bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen) {
 							 title,
 							 SDL_WINDOWPOS_UNDEFINED,
 							 SDL_WINDOWPOS_UNDEFINED,
-							 width,
-							 height,
-							 (getenv("TC_FULLSCREEN") == NULL) ?  SDL_WINDOW_FULLSCREEN : SDL_WINDOW_SHOWN
+							 640,
+							 400,
+							 SDL_WINDOW_SHOWN
 						 ))) {
 		std::cerr << "SDL_CreateWindow(): " << SDL_GetError() << '\n';
 		return false;
@@ -103,7 +104,7 @@ bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen) {
 	std::cout << '\n';
 
 	// Create a 2D rendering context for a window
-	if (IS_NULL(renderer = SDL_CreateRenderer(window, -1, NO_FLAGS))) {
+	if (IS_NULL(renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED))) {
 		std::cerr << "SDL_CreateRenderer(): " << SDL_GetError() << '\n';
 		std::cout << '\n' << "HINT: try to export SDL_RENDER_DRIVER environment variable with an available render driver!" << '\n';
 		return false;
@@ -116,7 +117,89 @@ bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen) {
 		return 0;
 	}
 	std::cout << "SDL_RENDER_DRIVER selected : " << rendererInfo.name << '\n';
+//     bool running = true;
+//     unsigned char i = 0;
+//     while( running )
+//     {
+//         SDL_SetRenderDrawColor( renderer, i, i, i, SDL_ALPHA_OPAQUE );
+//         SDL_RenderClear( renderer );
+//         SDL_RenderPresent( renderer );
+//         i+=5;
+//     }
 
+//     SDL_DestroyRenderer( renderer );
+//     SDL_DestroyWindow( window );
+//     SDL_Quit();
+
+
+//   // Only init video (without audio)
+//   if(NOT_SUCCESS(SDL_Init(SDL_INIT_VIDEO))) {
+//     printf("SDL_Init failed: %s\n", SDL_GetError());
+//     return false;
+//   }
+
+//   // Get the desktop area represented by a display, with the primary
+//   // display located at 0,0 based on viewport allocated on initial position
+//   int (*TCSDL_GetDisplayBounds)(int, SDL_Rect*) = 
+// #ifdef __arm__                  
+//     &SDL_GetDisplayBounds;
+// #else                           
+//     &SDL_GetDisplayUsableBounds;
+// #endif
+
+//   SDL_Rect viewport;
+//   if(NOT_SUCCESS(TCSDL_GetDisplayBounds(DISPLAY_INDEX, &viewport))) {
+//     printf("SDL_GetDisplayBounds failed: %s\n", SDL_GetError());
+//     return false;
+//   }
+
+//   // Adjust height on desktop, it should not affect fullscreen (y should be 0)
+//   viewport.h -= viewport.y;
+
+//   // Create the window
+//   if(IS_NULL(window = SDL_CreateWindow(
+//                                 title, 
+//                                 viewport.x,
+//                                 viewport.y, 
+//                                 viewport.w, 
+//                                 viewport.h, 
+//                                 (fullScreen ? SDL_WINDOW_FULLSCREEN : SDL_WINDOW_MAXIMIZED)
+//                                 ))) {
+//     printf("SDL_CreateWindow failed: %s\n", SDL_GetError());
+//     return false;
+//   }
+
+//   // Get the size of the window's client area
+//   SDL_GetWindowSize(window, &viewport.w, &viewport.h);
+
+//   // Create a 2D rendering context for a window
+//   if(IS_NULL(renderer = SDL_CreateRenderer(window, -1, NO_FLAGS))) {
+//     printf("SDL_CreateRenderer failed: %s\n", SDL_GetError());
+//     return false;
+//   }
+
+//   // Get renderer driver information
+//   SDL_RendererInfo rendererInfo;
+//   if (NOT_SUCCESS(SDL_GetRendererInfo(renderer, &rendererInfo))) {
+//     printf("SDL_GetRendererInfo failed: %s\n", SDL_GetError());
+//     return 0;
+//   } else {
+//     // Set render driver 
+//     if ((SDL_SetHint(SDL_HINT_RENDER_DRIVER, rendererInfo.name)) == SDL_FALSE) {
+//       printf("SDL_SetHint failed: %s\n", SDL_GetError());
+//       return false;
+//     }
+//   }
+
+//   // Set renderer dimensions
+//   if (NOT_SUCCESS(SDL_GetRendererOutputSize(
+//                                 renderer, 
+//                                 &viewport.w, 
+//                                 &viewport.h))) {
+//     printf("SDL_GetRendererOutputSize failed: %s\n", SDL_GetError());
+//     return false;
+//   }
+  
 	// Get window pixel format
 	Uint32 windowPixelFormat;
 	if (SDL_PIXELFORMAT_UNKNOWN == (windowPixelFormat = SDL_GetWindowPixelFormat(window))) {
@@ -129,8 +212,8 @@ bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen) {
 							  renderer,
 							  windowPixelFormat,
 							  SDL_TEXTUREACCESS_STREAMING,
-							  width,
-							  height))) {
+							  640,
+							  400))) {
 		std::cerr << "SDL_CreateTexturet(): " << SDL_GetError() << '\n';
 		return false;
 	}
@@ -142,9 +225,9 @@ bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen) {
 	}
 
 	// Adjusts screen width to the viewport
-	screen->screenW = width;
+	screen->screenW = 640;
 	// Adjusts screen height to the viewport
-	screen->screenH = height;
+	screen->screenH = 400;
 	// Adjusts screen's BPP
 	screen->bpp = pixelformat->BitsPerPixel;
 	// Set surface pitch
@@ -167,6 +250,31 @@ bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen) {
 	SCREEN_EX(screen)->texture = texture;
 
 	SDL_FreeFormat(pixelformat);
+
+    // bool running = true;
+    // unsigned char i = 0;
+
+    // printf("teste kappa 2\n");
+    // while( running )
+    // {
+
+
+    //     for (int y = 0; y < screen->screenH; ++y)
+    //     {
+    //         for (int x = 0; x < screen->screenW; ++x)
+    //         {
+    //             screen->pixels[x + y * screen->screenW] = 0xffffff;
+    //         }
+    //     }
+
+    //     // SDL_SetRenderDrawColor( renderer, i, i, i, SDL_ALPHA_OPAQUE );
+        
+    //     SDL_UpdateTexture(texture, NULL, screen->pixels, screen->pitch);
+    //     SDL_RenderCopy(renderer, texture, NULL, NULL);
+    //     SDL_RenderPresent( renderer );
+    //     SDL_RenderClear( renderer );
+    //     i+=5;
+    // }
 
 	return true;
 }


### PR DESCRIPTION
## Description:
Adjusts SDL initialization for work with KMS/DRM backend. This is a **DRAFT** pull request for #55 rebase.

### Related Issue:
- #55 helper.

## Motivation and Context:
Bypass X11 or Wayland to (try) some graphical enhancement of low-end devices. 

## Benefited Devices:
 - Device: i.MX6ULL, Beaglebone Black and any devices with/without GPU
 - OS: Built with Yocto and Torizon 

## How Has This Been Tested?
Tested on i.MX6DL with Torizon.
