### PR TITLE
Changes Launcher to accept the actual name of the tcz as an argument.

### DIFF
--- a/TotalCrossVM/src/launchers/linux/Launcher.c
+++ b/TotalCrossVM/src/launchers/linux/Launcher.c
@@ -58,19 +58,25 @@ int main(int argc, const char *argv[])
 {
    char cmdline[512];
    xmemzero(cmdline,sizeof(cmdline));
+   int argvIndex = 0;
    if (argv)
    {
-      xstrcpy(cmdline, argv[0]);
+      if (argc > 1 && 
+         xstrlen(argv[0]) >= 8 &&
+         memcmp(argv[0] + xstrlen(argv[0]) - 8, "Launcher", 8) == 0) {
+         argvIndex = 1;
+      }
+      xstrcpy(cmdline, argv[argvIndex++]);
       xstrcat(cmdline, ".tcz");
    }
-   if (argc > 1 || args[0] != '1') // if there's a commandline passed by the system or one passed by the user
+   if (argc > argvIndex || args[0] != '1') // if there's a commandline passed by the system or one passed by the user
    {
       xstrcat(cmdline, " /cmd ");
       if (args[0] != '1')
          xstrcat(cmdline, args);
-      const char **p = argv + 1;
+      const char **p = argv + argvIndex;
       int n = argc;
-      while (n-- > 1)
+      while (n-- > argvIndex)
       {
          xstrcat(cmdline, " ");
          xstrcat(cmdline, *p++);


### PR DESCRIPTION
In most systems, TotalCross uses a command line application named Launcher to start an application. This is somewhat similar to the JDK, which uses the "java" application, but unlike it, the Launcher doesn't take the application entry point as an argument, instead it assumes it was renamed to match the TCZ name of the application.
This approach requires the user to  have multiple copies of the Launcher renamed for each application, which is mildly annoying, especially when debugging.

## Description:
Whenever the application being executed is named "Launcher", it checks for additional arguments and uses the first one as the name of the tcz to start the application.
This is backwards compatible because it doesn't change the original behaviour if "Launcher" is renamed and still allows the application to take additional arguments.

Well, in fairness it **_could_** break an application named Launcher that expects additional arguments, but this is a really specific scenario that in the past would only affect Windows desktop applications.

### Related Issue:
Related to #15.
It doesn't address the issue completely, but it allows us to debug applications more easily without breaking backwards compatibility.

## Motivation and Context:
Allow us to debug different applications without having to rename the Launcher for each application or keeping multiple renamed copies of the Launcher.

## Benefited Devices:
Basically Linux and Windows applications, but it can also be handy while debugging on WinCE as well.

## How Has This Been Tested?
Tested using the vscode launch.