### PR TITLE
java build fixes and cleanup

### DIFF
--- a/TotalCrossSDK/build.gradle
+++ b/TotalCrossSDK/build.gradle
@@ -1,6 +1,3 @@
-import java.util.regex.*
-import org.apache.tools.ant.filters.*
-
 buildscript {
   repositories {
     maven {
@@ -48,12 +45,6 @@ task wrapper(type: Wrapper) {
    gradleVersion = '4.0.1'
 }
 
-class RemoveFromSdkFilter extends FilterReader {
-    RemoveFromSdkFilter(Reader input) {
-        super(new StringReader(Pattern.compile('//\\$START:REMOVE-ON-SDK-GENERATION.*?//\\$END:REMOVE-ON-SDK-GENERATION\\$', Pattern.DOTALL).matcher(input.text).replaceAll('')))
-    }
-}
-
 sourceSets {
     main {
         java {
@@ -81,7 +72,6 @@ task prepareSources(type: Copy) {
         exclude 'samples/**', 'litebase/android/**', '**/*4D.java'
     }
     into('build/src/desktop/java')
-    filter(RemoveFromSdkFilter)
 }
 
 // Prepare sources, before compile

--- a/TotalCrossSDK/build.gradle
+++ b/TotalCrossSDK/build.gradle
@@ -48,35 +48,15 @@ task wrapper(type: Wrapper) {
 sourceSets {
     main {
         java {
-            exclude 'ras/UtilsInfoProviderImpl.java'
         }
     }
-    desktop {
+    litebase {
         java {
-            srcDirs = ['build/src/desktop/java']
-        }
-        resources {
-            srcDirs = ['src/main/resources']
+            srcDirs = [new File(project.rootDir, '../LitebaseSDK/src/java')]
+            exclude 'samples/**', 'litebase/android/**', '**/*4D.java'
         }
         compileClasspath += sourceSets.main.runtimeClasspath
     }
-}
-
-// Prepare sources for compilation
-task prepareSources(type: Copy) {
-    from('src/main/java') {
-        exclude 'tc/samples/**', 'tc/tools/InvalidateIPA*'
-		exclude { FileTreeElement elem -> (elem.path.contains('ras/') && !elem.path.contains('ras/ActivationClient.java') && !elem.path.contains('ras/ActivationException.java'))}    	
-    }
-    from(new File(project.rootDir, '../LitebaseSDK/src/java')) {
-        exclude 'samples/**', 'litebase/android/**', '**/*4D.java'
-    }
-    into('build/src/desktop/java')
-}
-
-// Prepare sources, before compile
-compileJava {
-    dependsOn prepareSources
 }
 
 buildscript {
@@ -190,16 +170,17 @@ publishing {
 task sourcesJar(type: Jar, dependsOn: classes) {
 	baseName = "totalcross-sdk"
     classifier = 'sources'
-    from (sourceSets.desktop.allSource) { 
-    	exclude 'tc/**', 'ras/**', '**/*4A.java', '**/*4D.java'
+    from (sourceSets.main.allSource) { 
+    	exclude 'tc/**', '**/*4A.java', '**/*4D.java'
     }
+    from (sourceSets.litebase.allSource)
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
 	baseName = "totalcross-sdk"
     classifier = 'javadoc'
     from (javadoc.destinationDir) {
-    	exclude 'jdkcompat*/**', 'tc/**', 'ras/**', '**/*4A.java', '**/*4D.java'
+    	exclude 'jdkcompat*/**', 'tc/**', '**/*4A.java', '**/*4D.java'
     }
 }
 
@@ -208,9 +189,10 @@ task totalcrossJar(type: Jar) {
     baseName = "totalcross-sdk"
     // classifier = 'intermediate'
     
-    from(sourceSets.desktop.output) {
+    from(sourceSets.main.output) {
         exclude 'totalcross/res/mp3/**', 'totalcross/chartypes.bin'
     }
+    from(sourceSets.litebase.output)
     from new File(project.rootDir, 'etc/fonts/TCFont.tcz')
     from new File(project.rootDir, 'etc/fonts/Material Icons.tcz')
     into("META-INF/maven/$project.group/$baseName") {
@@ -264,7 +246,7 @@ task signJar {
 task tcbaseJar(type: Jar) {
     baseName = "tcbase"
     from(sourceSets.main.output) {
-        exclude '**/*4A.*', '**/*4B.*', '**/*4B$*', 'PostInstall.*', 'totalcross/Launcher*', 'totalcross/TCEventThread*', 'totalcross/TotalCrossApplication.*', 'tc/**', 'totalcross/res/**', 'totalcross/ui/**', 'totalcross/sql/sqlite4j/**', 'totalcross/android/**', 'totalcross/zxing/**', 'tc/tools/InvalidateIPA.java'
+        exclude '**/*4A.*', 'totalcross/Launcher*', 'totalcross/TCEventThread*', 'totalcross/TotalCrossApplication.*', 'tc/**', 'totalcross/res/**', 'totalcross/ui/**', 'totalcross/sql/sqlite4j/**', 'totalcross/android/**', 'totalcross/zxing/**', 'tc/tools/InvalidateIPA*'
     }
 }
 

--- a/TotalCrossSDK/src/main/java/tc/Deploy.java
+++ b/TotalCrossSDK/src/main/java/tc/Deploy.java
@@ -285,14 +285,12 @@ public class Deploy {
                 "Invalid /a format. The arguments must be passed between \"\", like in /a \"all the arguments to be passed to the callee application\"");
           }
           break;
-        //$START:REMOVE-ON-SDK-GENERATION$                         
         case 'd':
           J2TC.dump = true;
           if (op.length() == 3 && op.charAt(2) == '2') {
             J2TC.dumpBytecodes = true;
           }
           break;
-        //$END:REMOVE-ON-SDK-GENERATION$
         case 's':
           DeploySettings.autoSign = true;
           if (i < args.length - 1) {
@@ -416,30 +414,27 @@ public class Deploy {
         + "\n" + "You can also use the options:\n"
         + "   /a ApId : Assigns the application id; can only be used for libraries or passing a tcz file\n"
         + "   /autostart: automatically starts the application after a boot is completed. Currently works for Android only.\n"
-        + "   /c cmd  : Specify a command line to be passed to the application");
-    //$START:REMOVE-ON-SDK-GENERATION$                         
-    System.out.println("   /d      : Dump generated opcodes for the program\n"
-        + "   /d2     : Dump generated opcodes, including java bytecodes");
-    //$END:REMOVE-ON-SDK-GENERATION$
-    System.out.println(
-        "   /i platforms : install the file after generating it; platforms is a list of comma-separated platforms. Supports: android. E.G.: /i android\n"
-            + "   /k      : Keep the exe and other temporary files during wince generation\n"
-            + "   /kn     : As /k, but does not create the cab files for wince\n"
-            + "   /m path : Specifies a path to the mobileprovision and certificate store to deploy an ipa file for iOS. You should also provide a splash.png image with 640x1136.\n"
-            + "   /n name : Override the name of the tcz file with the given name\n"
-            + "   /o path : Override the output folder with the given path (defaults to the current folder)\n"
-            + "   /p      : Package the vm and litebase with the application, creating a single installation file. "
-            + "The SDK must be in the path or in the TOTALCROSS3_HOME environment variable. "
-            + "The files are always installed at the same folder of the application, so each application will have its own vm.\n"
-            + "   /t      : Just test the classes to see if there are any invalid references. Images are not converted, and nothing is written to disk.\n"
-            + "   /v      : Verbose output for information messages\n"
-            + "   /w      : Waits for a key press if an error occurs\n"
-            + "   /x list : Comma-separated list of class names that must be excluded (in a starts-with manner). E.G.: \"/x com/framework/\" \n"
-            + "\n" + "   The easiest way to create an icon is to provide an 'appicon.png' file of SQUARED size 256x256"
-            + "which will be automatically converted to the target icon sizes. Put the file in the src folder."
-            + "If your icon source is VECTOR-based, you may create better icons by exporting to png at the following sizes: "
-            + "icon76x76.png, icon96x96.png, icon120x120.png, icon144x144.png, icon152x152.png, icon192x192. "
-            + "Note that TotalCross' algorithm used to downscale the icons, CATMULL-ROM, is the best of the world for that."
-            + "");
+        + "   /c cmd  : Specify a command line to be passed to the application\n"
+        + "   /d      : Dump generated opcodes for the program\n"
+        + "   /d2     : Dump generated opcodes, including java bytecodes\n"
+        + "   /i platforms : install the file after generating it; platforms is a list of comma-separated platforms. Supports: android. E.G.: /i android\n"
+        + "   /k      : Keep the exe and other temporary files during wince generation\n"
+        + "   /kn     : As /k, but does not create the cab files for wince\n"
+        + "   /m path : Specifies a path to the mobileprovision and certificate store to deploy an ipa file for iOS. You should also provide a splash.png image with 640x1136.\n"
+        + "   /n name : Override the name of the tcz file with the given name\n"
+        + "   /o path : Override the output folder with the given path (defaults to the current folder)\n"
+        + "   /p      : Package the vm and litebase with the application, creating a single installation file. "
+        + "The SDK must be in the path or in the TOTALCROSS3_HOME environment variable. "
+        + "The files are always installed at the same folder of the application, so each application will have its own vm.\n"
+        + "   /t      : Just test the classes to see if there are any invalid references. Images are not converted, and nothing is written to disk.\n"
+        + "   /v      : Verbose output for information messages\n"
+        + "   /w      : Waits for a key press if an error occurs\n"
+        + "   /x list : Comma-separated list of class names that must be excluded (in a starts-with manner). E.G.: \"/x com/framework/\" \n"
+        + "\n" + "   The easiest way to create an icon is to provide an 'appicon.png' file of SQUARED size 256x256"
+        + "which will be automatically converted to the target icon sizes. Put the file in the src folder."
+        + "If your icon source is VECTOR-based, you may create better icons by exporting to png at the following sizes: "
+        + "icon76x76.png, icon96x96.png, icon120x120.png, icon144x144.png, icon152x152.png, icon192x192. "
+        + "Note that TotalCross' algorithm used to downscale the icons, CATMULL-ROM, is the best of the world for that."
+        + "");
   }
 }


### PR DESCRIPTION
## Description:
Removes a "gambiarra" that removed sensitive code from the sources publicly available. This code is no longer is necessary, neither is the source filtering.
Some cleanup and fixing of the build.gradle file. Building should be faster and use less disk space.
This also fixes automatic IDE integration through the build.gradle file - vscode for example couldn't handle it properly because of the duplicate source files.

## Motivation and Context:
Removing old proprietary code and some "gambiarras" made at the time. Also fixing the vscode support to allow debugging the SDK.

## How Has This Been Tested?
Compared all the output generated by gradle using the command `gradlew clean dist -x test` before and after the changes to make sure the output is the same.
The only difference is that `InvalidateIPA` is no longer artificially removed, which is no longer necessary.