### PR TITLE
jsonobject: removes printStackTrace from opt methods

### DIFF
--- a/TotalCrossSDK/src/main/java/totalcross/json/JSONObject.java
+++ b/TotalCrossSDK/src/main/java/totalcross/json/JSONObject.java
@@ -805,7 +805,6 @@ public class JSONObject {
     try {
       return this.getBoolean(key);
     } catch (Exception e) {
-      e.printStackTrace();
       return defaultValue;
     }
   }
@@ -838,7 +837,6 @@ public class JSONObject {
     try {
       return this.getDouble(key);
     } catch (Exception e) {
-      e.printStackTrace();
       return defaultValue;
     }
   }
@@ -871,7 +869,6 @@ public class JSONObject {
     try {
       return this.getInt(key);
     } catch (Exception e) {
-      e.printStackTrace();
       return defaultValue;
     }
   }
@@ -930,7 +927,6 @@ public class JSONObject {
     try {
       return this.getLong(key);
     } catch (Exception e) {
-      e.printStackTrace();
       return defaultValue;
     }
   }


### PR DESCRIPTION
## Description:
Instead of only returning a value passed through argument on `opt##TYPE(String key, ##TYPE value)`  the methods were also throwing exceptions when the key object didn't exist in the JSONObject. To solve this, we removed all throws from these methods.

## Benefited Devices:
All devices