### PR TITLE
Fix unintentional debug from tccodesign.sh

### DIFF
--- a/TotalCrossSDK/etc/tools/iOSCodesign/tccodesign.sh
+++ b/TotalCrossSDK/etc/tools/iOSCodesign/tccodesign.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 # Parse variables
 POSITIONAL=()


### PR DESCRIPTION
## Description:

Removed -x from #!/bin/bash in tccodesign.sh that produced unintentional debug on the bash script. When necessary, the user can achieve the same result by typing bash -x tccodesign.sh.

## Motivation and Context:
When using the user deploys and application and has to resign this application using tccodesign.sh the script procuced unintentional debug.  

## Benefited Devices:
 - Device: Apple devices
 - OS: iOS
