### PR TITLE
Image.alphaMask: adds support for alphaMask on Skia

### DIFF
--- a/TotalCrossVM/src/nm/ui/GraphicsPrimitives_c.h
+++ b/TotalCrossVM/src/nm/ui/GraphicsPrimitives_c.h
@@ -420,7 +420,7 @@ static void drawSurface(Context currentContext, TCObject dstSurf, TCObject srcSu
         dstX += Graphics_transX(dstSurf);
         dstY += Graphics_transY(dstSurf);
         skia_setClip(Get_Clip(dstSurf));
-        skia_drawSurface(0, Image_textureId(srcSurf), srcX, srcY, w, h, w, h, dstX, dstY, doClip);
+        skia_drawSurface(0, Image_textureId(srcSurf), srcX, srcY, w, h, w, h, dstX, dstY, Image_alphaMask(srcSurf), doClip);
         skia_restoreClip();
     }
     else

--- a/TotalCrossVM/src/nm/ui/android/skia.cpp
+++ b/TotalCrossVM/src/nm/ui/android/skia.cpp
@@ -83,6 +83,7 @@ sk_sp<SkSurface> surface;
 SkCanvas *canvas;
 SkPaint forePaint; // used for contours
 SkPaint backPaint; // used for fills
+SkPaint alphaPaint; // used for alphaMask
 SkBitmap bitmap;
 #define TYPEFACE_LEN 32
 sk_sp<SkTypeface> typefaces[TYPEFACE_LEN];
@@ -246,12 +247,13 @@ void skia_restoreClip()
     canvas->restore();
 }
 
-void skia_drawSurface(int32 skiaSurface, int32 id, int32 srcX, int32 srcY, int32 srcW, int32 srcH, int32 w, int32 h, int32 dstX, int32 dstY, int32 doClip)
+void skia_drawSurface(int32 skiaSurface, int32 id, int32 srcX, int32 srcY, int32 srcW, int32 srcH, int32 w, int32 h, int32 dstX, int32 dstY, int32 alphaMask, int32 doClip)
 {
     SKIA_TRACE()
 
+    alphaPaint.setAlpha(alphaMask);
     canvas->drawBitmapRect(textures[id], SkRect::MakeXYWH(srcX, srcY, w, h),
-                           SkRect::MakeXYWH(dstX, dstY, w, h), nullptr);
+                           SkRect::MakeXYWH(dstX, dstY, w, h), &alphaPaint);
 }
 
 // The getPixel call demands a 1-pixel readback from the GPU. Avoid it if possible.

--- a/TotalCrossVM/src/nm/ui/android/skia.h
+++ b/TotalCrossVM/src/nm/ui/android/skia.h
@@ -32,7 +32,7 @@ void skia_deleteBitmap(int32 id);
 void skia_setClip(int32 x1, int32 y1, int32 x2, int32 y2);
 void skia_restoreClip();
 
-void skia_drawSurface(int32 skiaSurface, int32 id, int32 srcX, int32 srcY, int32 srcW, int32 srcH, int32 w, int32 h, int32 dstX, int32 dstY, int32 doClip);
+void skia_drawSurface(int32 skiaSurface, int32 id, int32 srcX, int32 srcY, int32 srcW, int32 srcH, int32 w, int32 h, int32 dstX, int32 dstY, int32 alphaMask, int32 doClip);
 void skia_drawDottedLine(int32 skiaSurface, int32 x1, int32 y1, int32 x2, int32 y2, Pixel pixel1, Pixel pixel2);
 Pixel skia_getPixel(int32 skiaSurface, int32 x, int32 y);
 void skia_setPixel(int32 skiaSurface, int32 x, int32 y, Pixel pixel);


### PR DESCRIPTION
## Description:
Adds alphaMask argument to skia_drawSurface for usage with SkPaint.

### Related Issue:
Problem noticed when working for #73 

## Motivation and Context:
Image.alphaMask allows applying an alpha value to the entire image, without individually changing the pixels.
The implementation for this feature is missing for platforms using Skia and is needed for effects like described on #73

## Benefited Devices:
Platforms that use Skia as graphical backend, right now:
Android, iOS, Linux x86_64 and Linux ARM.

## How Has This Been Tested?
Tested with implementation of fading between two ImageControls made for #73

## Tested Devices:
MacOS (experimental build)
Raspberry Pi