### PR TITLE
FileChannel: fixes leakage of native file descriptors

### DIFF
--- a/TotalCrossSDK/src/main/java/jdkcompat/io/FileInputStream4D.java
+++ b/TotalCrossSDK/src/main/java/jdkcompat/io/FileInputStream4D.java
@@ -10,7 +10,6 @@ import java.io.InputStream;
 
 import jdkcompat.nio.channels.FileChannelImpl4D;
 
-
 public class FileInputStream4D extends InputStream {
     FileChannelImpl4D fileChannel;
 
@@ -43,5 +42,8 @@ public class FileInputStream4D extends InputStream {
         return fileChannel.available();
     }
 
-    
+    @Override
+    protected void finalize() throws IOException {
+        this.close();
+    }
 }

--- a/TotalCrossSDK/src/main/java/jdkcompat/io/FileOutputStream4D.java
+++ b/TotalCrossSDK/src/main/java/jdkcompat/io/FileOutputStream4D.java
@@ -20,7 +20,7 @@ public class FileOutputStream4D extends OutputStream {
 
     @Override
     public void write(int b) throws IOException {
-        
+
     }
 
     @Override
@@ -28,4 +28,13 @@ public class FileOutputStream4D extends OutputStream {
         fileChannel.write(b, off, len);
     }
 
+    @Override
+    public void close() throws IOException {
+        fileChannel.close();
+    }
+
+    @Override
+    protected void finalize() throws IOException {
+        this.close();
+    }
 }

--- a/TotalCrossSDK/src/main/java/jdkcompat/nio/channels/FileChannel4D.java
+++ b/TotalCrossSDK/src/main/java/jdkcompat/nio/channels/FileChannel4D.java
@@ -5,9 +5,8 @@
 
 package jdkcompat.nio.channels;
 
-import java.io.Closeable;
+import java.nio.channels.spi.AbstractInterruptibleChannel;
 
-public abstract class FileChannel4D implements Closeable{
-    
+public abstract class FileChannel4D extends AbstractInterruptibleChannel {
 
 }

--- a/TotalCrossSDK/src/main/java/jdkcompat/nio/channels/FileChannelImpl4D.java
+++ b/TotalCrossSDK/src/main/java/jdkcompat/nio/channels/FileChannelImpl4D.java
@@ -32,9 +32,9 @@ public class FileChannelImpl4D extends FileChannel {
     }
 
     @Override
-   public int read(ByteBuffer dst) throws IOException {
-      return 0;
-   }
+    public int read(ByteBuffer dst) throws IOException {
+        return 0;
+    }
 
     native public int read(byte[] dst, int offset, int length) throws IOException;
 
@@ -44,7 +44,6 @@ public class FileChannelImpl4D extends FileChannel {
         return 0;
     }
 
-    
     native public int write(byte[] src, int offset, int length) throws IOException;
 
     @Override
@@ -102,7 +101,7 @@ public class FileChannelImpl4D extends FileChannel {
     }
 
     @Override
-      public int read(ByteBuffer dst, long position) throws IOException {
+    public int read(ByteBuffer dst, long position) throws IOException {
         // TODO Auto-generated method stub
         return 0;
     }
@@ -132,9 +131,5 @@ public class FileChannelImpl4D extends FileChannel {
     }
 
     @Override
-    protected void implCloseChannel() throws IOException {
-        // TODO Auto-generated method stub
-
-    }
-
+    protected native void implCloseChannel() throws IOException;
 }

--- a/TotalCrossSDK/src/main/java/jdkcompat/nio/channels/spi/AbstractInterruptibleChannel4D.java
+++ b/TotalCrossSDK/src/main/java/jdkcompat/nio/channels/spi/AbstractInterruptibleChannel4D.java
@@ -1,0 +1,38 @@
+// Copyright (C) 2020 TotalCross Global Mobile Platform Ltda.
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+package jdkcompat.nio.channels.spi;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import totalcross.util.concurrent.Lock;
+
+public abstract class AbstractInterruptibleChannel4D implements Closeable {
+    private boolean isOpen = true;
+    private Lock mutex = new Lock();
+
+    protected AbstractInterruptibleChannel4D() {
+    }
+
+    public final boolean isOpen() {
+        return isOpen;
+    }
+
+    public final void close() throws IOException {
+        synchronized (mutex) {
+            if (isOpen) {
+                implCloseChannel();
+            }
+            isOpen = false;
+        }
+    }
+
+    protected abstract void implCloseChannel() throws IOException;
+
+    @Override
+    protected void finalize() throws Throwable {
+        this.close();
+    }
+}

--- a/TotalCrossVM/src/init/nativeProcAddressesTC.c
+++ b/TotalCrossVM/src/init/nativeProcAddressesTC.c
@@ -75,6 +75,7 @@ void fillNativeProcAddressesTC()
    htPutPtr(&htNativeProcAddresses, hashCode("jncFCI_read"), &jncFCI_read);
    htPutPtr(&htNativeProcAddresses, hashCode("jncFCI_read_Bii"), &jncFCI_read_Bii);
    htPutPtr(&htNativeProcAddresses, hashCode("jncFCI_write_Bii"), &jncFCI_write_Bii);
+   htPutPtr(&htNativeProcAddresses, hashCode("jncFCI_implCloseChannel"), &jncFCI_implCloseChannel);
    htPutPtr(&htNativeProcAddresses, hashCode("tmGM_showAddress_sb"), &tmGM_showAddress_sb);
    htPutPtr(&htNativeProcAddresses, hashCode("tmGM_showRoute_sssi"), &tmGM_showRoute_sssi);
    htPutPtr(&htNativeProcAddresses, hashCode("tucL_create"), &tucL_create);

--- a/TotalCrossVM/src/nm/NativeMethods.h
+++ b/TotalCrossVM/src/nm/NativeMethods.h
@@ -81,6 +81,7 @@ TC_API void jlPI_destroy(NMParams p);
 TC_API void jncFCI_read(NMParams p);
 TC_API void jncFCI_read_Bii(NMParams p);
 TC_API void jncFCI_write_Bii(NMParams p);
+TC_API void jncFCI_implCloseChannel(NMParams p);
 TC_API void tmGM_showAddress_sb(NMParams p);
 TC_API void tmGM_showRoute_sssi(NMParams p);
 TC_API void tucL_create(NMParams p);

--- a/TotalCrossVM/src/nm/NativeMethods.txt
+++ b/TotalCrossVM/src/nm/NativeMethods.txt
@@ -354,6 +354,7 @@ java/lang/ProcessImpl|native public int destroy();
 java/nio/channels/FileChannelImpl|native public int read() throws IOException;
 java/nio/channels/FileChannelImpl|native public int read(byte[] b, int offset, int length) throws IOException;
 java/nio/channels/FileChannelImpl|native public int write(byte[] b, int offset, int length) throws IOException;
+java/nio/channels/FileChannelImpl|native protected void implCloseChannel() throws IOException;
 java/util/Locale|native static String getDefaultToString();
 totalcross/io/device/RadioDevice|native public static boolean isSupported(int type) throws IllegalArgumentException;
 totalcross/io/device/RadioDevice|native public static int getState(int type) throws IllegalArgumentException;

--- a/TotalCrossVM/src/nm/NativeMethodsPrototypes.txt
+++ b/TotalCrossVM/src/nm/NativeMethodsPrototypes.txt
@@ -67,6 +67,7 @@ TC_API void jlR_exec_SSs(NMParams p);
 TC_API void jncFCI_read(NMParams p);
 TC_API void jncFCI_read_Bii(NMParams p);
 TC_API void jncFCI_write_Bii(NMParams p);
+TC_API void jncFCI_implCloseChannel(NMParams p);
 TC_API void tmGM_showAddress_sb(NMParams p);
 TC_API void tmGM_showRoute_sssi(NMParams p);
 TC_API void tucL_create(NMParams p);

--- a/TotalCrossVM/src/nm/nio/channels/FileChannelImpl.c
+++ b/TotalCrossVM/src/nm/nio/channels/FileChannelImpl.c
@@ -80,3 +80,19 @@ TC_API void jncFCI_write_Bii(NMParams p) {
     throwExceptionNamed(p->currentContext, "java.lang.UnsupportedOperationException", "this method only works on linux");
 #endif
 }
+
+TC_API void jncFCI_implCloseChannel(NMParams p) {
+#if defined(linux) && !defined(darwin)
+    TCObject fileChannel = p->obj[0];
+    int32 fd = FileChannelImpl_nfd(fileChannel);
+
+    if (fd != -1) {
+        if (close(fd) != 0) {
+            throwExceptionNamed(p->currentContext, "java.io.IOException", strerror(errno));
+        }
+        FileChannelImpl_nfd(fileChannel) = -1;
+    }
+#else
+    throwExceptionNamed(p->currentContext, "java.lang.UnsupportedOperationException", "this method only works on linux");
+#endif
+}


### PR DESCRIPTION
AbstractInterruptibleChannel4D: Adds class with methods isOpen, close and implCloseChannel to match JDK interface.
FileChannel4D: Changes class hierarchy to extend AbstractInterruptibleChannel, matching the JDK interface more closely.
FileChannelImpl4D: Adds native method implCloseChannel, which is called by AbstractInterruptibleChannel.close to close the native file descriptor.
FileOutputStream4D: Implements finalize to close the stream, which closes the underlying FileChannel.
FileInputStream4D: Adds missing close method and implements finalize to close the stream.

### Related Issue:
Related to #70

## Motivation and Context:
Fixes leakage of file descriptors when using FileOutputStream/FileInputStream

## Benefited Devices:
Linux systems

## How Has This Been Tested?
Not tested yet

## Tested Devices:
Not tested yet