### PR TITLE
Native methods: adds PortConnector readWriteBytes func into header

### DIFF
--- a/TotalCrossVM/src/nm/NativeMethods.h
+++ b/TotalCrossVM/src/nm/NativeMethods.h
@@ -384,6 +384,7 @@ TC_API void tidPC_create_iiiii(NMParams p);
 TC_API void tidPC_nativeClose(NMParams p);
 TC_API void tidPC_setFlowControl_b(NMParams p);
 TC_API void tidPC_readCheck(NMParams p);
+TC_API void tidPC_readWriteBytes_Biib(NMParams p);
 TC_API void tidbDA_nativeDiscoveryAgent(NMParams p);
 TC_API void tidbDA_cancelInquiry_d(NMParams p);
 TC_API void tidbDA_cancelServiceSearch_i(NMParams p);


### PR DESCRIPTION
Fix error: `'tidPC_readWriteBytes_Biib' undeclared` from:

```log
error: 'tidPC_readWriteBytes_Biib' undeclared (first use in this function); did you mean 'tiPDBF_readWriteBytes_Biib'?
    htPutPtr(&htNativeProcAddresses, hashCode("tidPC_readWriteBytes_Biib"), &tidPC_readWriteBytes_Biib);
```
in TCVM build process for Linux