### PR TITLE
cicd: starting the commit check

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -1,0 +1,49 @@
+name: 'Commit Message Check'
+on: [push]
+
+jobs:
+  check-commit-message:
+    name: Check Commit Message
+    runs-on: ubuntu-20.04
+    steps:
+
+      - name: Check Commit Type
+        uses: gsactions/commit-message-checker@v1
+        with:
+          pattern: '^[a-z0-9,\s]+: .+(?:\n(?:\n.+)+)?(?:\n\n.+)?$'
+          error: 'Your message must have the correct format "<scope>: <subject>" with an optional body and footer separated by blank lines.'
+
+      - name: Check Title Capitalize
+        uses: gsactions/commit-message-checker@v1
+        with:
+          pattern: '^[^A-Z]'
+          flags: ''
+          error: 'Your title should not capitalize first word.'
+
+      - name: Check Title Length
+        uses: gsactions/commit-message-checker@v1
+        with:
+          pattern: '^[^\s]+([ \t]+[^\s]+){2,}[ \t]*(\n.*)?$'
+          flags: 's'
+          error: 'A meaningful title should contain at least 3 words.'
+
+      - name: Check Title Line Length
+        uses: gsactions/commit-message-checker@v1
+        with:
+          pattern: '^([^\n]{1,80}|Merge pull request.*)(\n.*)?$'
+          flags: 's'
+          error: 'The maximum title line length of 80 characters is exceeded.'
+
+      - name: Check Title Line Separator
+        uses: gsactions/commit-message-checker@v1
+        with:
+          pattern: '^[^\n]+(\n\n.+)?$'
+          flags: 's'
+          error: 'Should leave an empty line after title.'
+
+      - name: Check Line Length
+        uses: gsactions/commit-message-checker@v1
+        with:
+          pattern: '^[^\n]+(\n[^\n]{0,80})*$'
+          flags: 's'
+          error: 'The maximum line length of 80 characters is exceeded.'


### PR DESCRIPTION
## Description:
Add commit checker job and start the github actions.

### Related Issue:
 - N/A

## Motivation and Context:
We need to check the commit before accept it.

## Benefited Devices:
 - N/A

## How Has This Been Tested?
 - Check the actions link: https://github.com/TotalCross/totalcross/actions

## Tested Devices:
 - N/A

## Screenshots or videos: 

![image](https://user-images.githubusercontent.com/95132/89315442-36e69e80-d651-11ea-882b-fa315d145909.png)
