### PR TITLE
simulator: correctly skips the key arg

### DIFF
--- a/TotalCrossSDK/src/main/java/totalcross/Launcher.java
+++ b/TotalCrossSDK/src/main/java/totalcross/Launcher.java
@@ -513,8 +513,8 @@ final public class Launcher extends java.applet.Applet implements WindowListener
             }
           }
           System.out.println("Screen is " + toWidth + "x" + toHeight + "x" + toBpp);
-        } else if (args[i++].equalsIgnoreCase("/r")) {
-          // Ignore next argument
+        } else if (args[i].equalsIgnoreCase("/r")) {
+          ++i;
         } else if (args[i].equalsIgnoreCase("/pos")) /* x,y */
         {
           String[] scr = tokenizeString(args[++i].toLowerCase(), ',');


### PR DESCRIPTION
## Remnants of the activation key deletion

The */r* argument was the argument that referenced TotalCross's serial license number. To keep backwards compatibility, we just skipped what it would do, but we didn't do it the right way. This patch adjust the argument iterator, it has no effect when being incremented within the `if`.  Bug reported on #94.