### PR TITLE
libgpiod: fixes crash when running on a system without libgpiod

### DIFF
--- a/TotalCrossVM/src/nm/io/device/gpiod/posix/gpiodLib.c
+++ b/TotalCrossVM/src/nm/io/device/gpiod/posix/gpiodLib.c
@@ -25,17 +25,18 @@ bool initGpiod()
     gpiodLib = dlopen("libgpiod.so", RTLD_LAZY);
     
     if (gpiodLib == null) {
-           glob_t globbuf;
-           int i;
+        glob_t globbuf;
+        int i;
 
-           glob("/usr/lib/libgpiod.so*", GLOB_DOOFFS, NULL, &globbuf);
-           for (i = globbuf.gl_pathc - 1 ; i >= 0 ; i--) {
-            gpiodLib = dlopen(globbuf.gl_pathv[i], RTLD_LAZY);
-            if (gpiodLib != null) {
-                break;
+        if (glob("/usr/lib/libgpiod.so*", GLOB_DOOFFS, NULL, &globbuf) == 0) {
+            for (i = globbuf.gl_pathc - 1 ; i >= 0 ; i--) {
+                gpiodLib = dlopen(globbuf.gl_pathv[i], RTLD_LAZY);
+                if (gpiodLib != null) {
+                    break;
+                }
             }
-         }
-         globfree(&globbuf);
+            globfree(&globbuf);
+        }
     }
 
     if (gpiodLib != null) {


### PR DESCRIPTION
## Description:
Using globfree when glob fails crashes de tcvm.
That's why having libgpiod fixed the crash.

### Related Issue:
Closes #96 

## Benefited Devices:
- Linux ARM systems