### PR TITLE
Avoid SDL display bounds dependency

### DIFF
--- a/TotalCrossVM/src/init/tcsdl.cpp
+++ b/TotalCrossVM/src/init/tcsdl.cpp
@@ -59,15 +59,6 @@ bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen) {
   }
   std::cout << "SDL_VIDEODRIVER selected : " << SDL_GetCurrentVideoDriver() << '\n';
 
-  // Get the desktop area represented by a display, with the primary
-  // display located at 0,0 based on viewport allocated on initial position
-  int (*TCSDL_GetDisplayBounds)(int, SDL_Rect*) = 
-#ifdef __arm__                  
-    &SDL_GetDisplayBounds;
-#else                           
-    &SDL_GetDisplayUsableBounds;
-#endif
-
   // Create the window
   SDL_Window* window; 
   if(IS_NULL(window = SDL_CreateWindow(

--- a/TotalCrossVM/src/init/tcsdl.cpp
+++ b/TotalCrossVM/src/init/tcsdl.cpp
@@ -10,6 +10,7 @@
 #define SUCCESS(x)      ((x) == 0)
 
 #include "tcsdl.h"
+#include <iostream>
 
 static SDL_Renderer *renderer;
 static SDL_Texture *texture;
@@ -25,7 +26,10 @@ static SDL_Texture *texture;
  * - true on success 
  */
 bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen) {
-  SDL_Window *window;
+
+  int width = (getenv("TC_WIDTH")  == NULL) ? 640 : std::stoi(getenv("TC_WIDTH"));
+  int height= (getenv("TC_HEIGHT") == NULL) ? 400 : std::stoi(getenv("TC_HEIGHT"));
+
   // Only init video (without audio)
   if(NOT_SUCCESS(SDL_Init(SDL_INIT_VIDEO))) {
     printf("SDL_Init failed: %s\n", SDL_GetError());
@@ -51,13 +55,14 @@ bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen) {
   viewport.h -= viewport.y;
 
   // Create the window
+  SDL_Window* window; 
   if(IS_NULL(window = SDL_CreateWindow(
                                 title, 
-                                viewport.x,
-                                viewport.y, 
-                                viewport.w, 
-                                viewport.h, 
-                                (fullScreen ? SDL_WINDOW_FULLSCREEN : SDL_WINDOW_MAXIMIZED)
+                                SDL_WINDOWPOS_UNDEFINED,
+                                SDL_WINDOWPOS_UNDEFINED,
+                                width,
+                                height,
+                                (getenv("TC_FULLSCREEN") == NULL) ? SDL_WINDOW_SHOWN : SDL_WINDOW_FULLSCREEN
                                 ))) {
     printf("SDL_CreateWindow failed: %s\n", SDL_GetError());
     return false;
@@ -106,8 +111,8 @@ bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen) {
                               renderer, 
                               windowPixelFormat, 
                               SDL_TEXTUREACCESS_STREAMING, 
-                              viewport.w, 
-                              viewport.h))) {
+                              width, 
+                              height))) {
     printf("SDL_CreateTexture failed: %s\n", SDL_GetError());
     return false;
   }
@@ -119,9 +124,9 @@ bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen) {
   }
 
   // Adjusts screen width to the viewport
-  screen->screenW = viewport.w;
+  screen->screenW = width;
   // Adjusts screen height to the viewport
-  screen->screenH = viewport.h;
+  screen->screenH = height;
   // Adjusts screen's BPP
   screen->bpp = pixelformat->BitsPerPixel;
   // Set surface pitch 

--- a/TotalCrossVM/src/init/tcsdl.cpp
+++ b/TotalCrossVM/src/init/tcsdl.cpp
@@ -94,6 +94,14 @@ bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen) {
   // Get the size of the window's client area
   SDL_GetWindowSize(window, &viewport.w, &viewport.h);
 
+  std::cout << "SDL_RENDER_DRIVER available:";
+  for( int i = 0; i < SDL_GetNumRenderDrivers(); ++i ) {
+      SDL_RendererInfo info;
+      SDL_GetRenderDriverInfo( i, &info );
+      std::cout << " " << info.name;
+  }
+  std::cout << '\n';
+
   // Create a 2D rendering context for a window
   if(IS_NULL(renderer = SDL_CreateRenderer(window, -1, NO_FLAGS))) {
     printf("SDL_CreateRenderer failed: %s\n", SDL_GetError());
@@ -121,6 +129,7 @@ bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen) {
     printf("SDL_GetRendererOutputSize failed: %s\n", SDL_GetError());
     return false;
   }
+  std::cout << "SDL_RENDER_DRIVER selected : " << rendererInfo.name << '\n';
   
   // Get window pixel format
   Uint32 windowPixelFormat;

--- a/TotalCrossVM/src/init/tcsdl.cpp
+++ b/TotalCrossVM/src/init/tcsdl.cpp
@@ -92,12 +92,6 @@ bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen) {
   if (NOT_SUCCESS(SDL_GetRendererInfo(renderer, &rendererInfo))) {
     printf("SDL_GetRendererInfo failed: %s\n", SDL_GetError());
     return 0;
-  } else {
-    // Set render driver 
-    if ((SDL_SetHint(SDL_HINT_RENDER_DRIVER, rendererInfo.name)) == SDL_FALSE) {
-      printf("SDL_SetHint failed: %s\n", SDL_GetError());
-      return false;
-    }
   }
   std::cout << "SDL_RENDER_DRIVER selected : " << rendererInfo.name << '\n';
   

--- a/TotalCrossVM/src/init/tcsdl.cpp
+++ b/TotalCrossVM/src/init/tcsdl.cpp
@@ -11,6 +11,7 @@
 
 #include "tcsdl.h"
 #include <iostream>
+#include <vector>
 
 static SDL_Renderer *renderer;
 static SDL_Texture *texture;
@@ -30,11 +31,33 @@ bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen) {
   int width = (getenv("TC_WIDTH")  == NULL) ? 640 : std::stoi(getenv("TC_WIDTH"));
   int height= (getenv("TC_HEIGHT") == NULL) ? 400 : std::stoi(getenv("TC_HEIGHT"));
 
+  std::cout << "Testing video drivers..." << '\n';
+  std::vector< bool > drivers( SDL_GetNumVideoDrivers() );
+  
+  for(int i = 0; i < drivers.size(); ++i) {
+      drivers[i] = (0 == SDL_VideoInit(SDL_GetVideoDriver( i )));
+      SDL_VideoQuit();
+  }
+
+  std::cout << "SDL_VIDEODRIVER available:";
+  for( int i = 0; i < drivers.size(); ++i ) {
+      std::cout << " " << SDL_GetVideoDriver( i );
+  }
+  std::cout << '\n';
+
+  std::cout << "SDL_VIDEODRIVER usable   :";
+  for( int i = 0; i < drivers.size(); ++i ) {
+      if( !drivers[ i ] ) continue;
+      std::cout << " " << SDL_GetVideoDriver( i );
+  }
+  std::cout << '\n';
+
   // Only init video (without audio)
   if(NOT_SUCCESS(SDL_Init(SDL_INIT_VIDEO))) {
     printf("SDL_Init failed: %s\n", SDL_GetError());
     return false;
   }
+  std::cout << "SDL_VIDEODRIVER selected : " << SDL_GetCurrentVideoDriver() << '\n';
 
   // Get the desktop area represented by a display, with the primary
   // display located at 0,0 based on viewport allocated on initial position

--- a/TotalCrossVM/src/init/tcsdl.cpp
+++ b/TotalCrossVM/src/init/tcsdl.cpp
@@ -68,15 +68,6 @@ bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen) {
     &SDL_GetDisplayUsableBounds;
 #endif
 
-  SDL_Rect viewport;
-  if(NOT_SUCCESS(TCSDL_GetDisplayBounds(DISPLAY_INDEX, &viewport))) {
-    printf("SDL_GetDisplayBounds failed: %s\n", SDL_GetError());
-    return false;
-  }
-
-  // Adjust height on desktop, it should not affect fullscreen (y should be 0)
-  viewport.h -= viewport.y;
-
   // Create the window
   SDL_Window* window; 
   if(IS_NULL(window = SDL_CreateWindow(
@@ -90,9 +81,6 @@ bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen) {
     printf("SDL_CreateWindow failed: %s\n", SDL_GetError());
     return false;
   }
-
-  // Get the size of the window's client area
-  SDL_GetWindowSize(window, &viewport.w, &viewport.h);
 
   std::cout << "SDL_RENDER_DRIVER available:";
   for( int i = 0; i < SDL_GetNumRenderDrivers(); ++i ) {

--- a/TotalCrossVM/src/init/tcsdl.cpp
+++ b/TotalCrossVM/src/init/tcsdl.cpp
@@ -120,15 +120,6 @@ bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen) {
       return false;
     }
   }
-
-  // Set renderer dimensions
-  if (NOT_SUCCESS(SDL_GetRendererOutputSize(
-                                renderer, 
-                                &viewport.w, 
-                                &viewport.h))) {
-    printf("SDL_GetRendererOutputSize failed: %s\n", SDL_GetError());
-    return false;
-  }
   std::cout << "SDL_RENDER_DRIVER selected : " << rendererInfo.name << '\n';
   
   // Get window pixel format


### PR DESCRIPTION
# Avoid SDL display bounds dependency
The functions of SDL had issues in distros like _Ångström_:
```c++
SDL_GetDisplayBounds();
```
and
```c++
SDL_GetDisplayUsableBounds();
```
and
```c++
SDL_CreateRenderer();
```
they depended on some certain workaround to run correctly on any systems. They were useful to get the size of the screens.

## Solve
We now introduce 3 environment variables for execution. Since we do not have an automatic viewport they need to be set up they are:
|     | TC_WIDTH  | TC_HEIGHT  | TC_FULLSCREEN  |
|---|---|---|---|
| Description  | Size of `width` in pixels  | Size of `height` in pixels  | Is fullscreen or not  | 
| Values  |  int | int  | bool | 

In case the standard resolution is not met, it will be _640x400_. That should change soon.

## Pull request
I think that squash should not be done since each commit is semantically and syntaxically correct.