### PR TITLE
Shows hint to help if get error in CreateRenderer

### DIFF
--- a/TotalCrossVM/src/init/tcsdl.cpp
+++ b/TotalCrossVM/src/init/tcsdl.cpp
@@ -84,6 +84,7 @@ bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen) {
   // Create a 2D rendering context for a window
   if(IS_NULL(renderer = SDL_CreateRenderer(window, -1, NO_FLAGS))) {
     printf("SDL_CreateRenderer failed: %s\n", SDL_GetError());
+    printf("\nHINT: try to export SDL_RENDER_DRIVER environment variable with an available render driver!\n");
     return false;
   }
 


### PR DESCRIPTION
To improve usability in systems that do not define the `SDL_RENDER_DRIVER` environment variable, it presents a tip on how to solve!

## Comparison
Previous:
```bash
SDL_CreateRenderer failed: Couldn't find matching render driver
```
Next:
```bash
SDL_CreateRenderer failed: Couldn't find matching render driver

HINT: try fill SDL_RENDER_DRIVER environment variable with an available render driver!
```