### PR TITLE
scripts: format-source-code: Add script for Unix use

### DIFF
--- a/scripts/format-source-code
+++ b/scripts/format-source-code
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+if ! type astyle > /dev/null; then
+    cat <<EOF
+ERROR: The 'astyle' utility is not available in your machine.
+
+Please install it and run the script again. If you are running on a Debian based
+distribution you can run:
+
+$ apt install astyle
+EOF
+    exit 1
+fi
+
+# We use the script path as a base and allow us to go to the source dir, so we
+# can run the script from there.
+sourcedir=$(dirname $0)/..
+
+cd $sourcedir
+astyle --project=.astylerc --recursive '*.java' '*.c??' '*.h??' '*.c' '*.h'


### PR DESCRIPTION
The script allow for easy run of the script when developing the code. We
can run it from the root source directory or inside the scripts
directory.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>
