### PR TITLE
Fix arrow operator end EOL

### DIFF
--- a/TotalCrossVM/modules/skia/include/private/SkTemplates.h
+++ b/TotalCrossVM/modules/skia/include/private/SkTemplates.h
@@ -480,13 +480,11 @@ private:
 using SkAutoFree = std::unique_ptr<void, SkFunctionWrapper<void, void, sk_free>>;
 
 template<typename C, std::size_t... Is>
-constexpr auto SkMakeArrayFromIndexSequence(C c, skstd::index_sequence<Is...>)
-- > std::array<skstd::result_of_t<C(std::size_t)>, sizeof...(Is)> {
+constexpr auto SkMakeArrayFromIndexSequence(C c, skstd::index_sequence<Is...>) -> std::array<skstd::result_of_t<C(std::size_t)>, sizeof...(Is)> {
 	return {{ c(Is)... }};
 }
 
-template<size_t N, typename C> constexpr auto SkMakeArray(C c)
-- > std::array<skstd::result_of_t<C(std::size_t)>, N> {
+template<size_t N, typename C> constexpr auto SkMakeArray(C c) -> std::array<skstd::result_of_t<C(std::size_t)>, N> {
 	return SkMakeArrayFromIndexSequence(c, skstd::make_index_sequence<N> {});
 }
 


### PR DESCRIPTION
The following error was identified in the build:

```bash
[ 97%] Building C object CMakeFiles/tcvm.dir/src/litebase/parser/SQLInsertStatement.c.o
[ 98%] Building C object CMakeFiles/tcvm.dir/src/litebase/parser/SQLSelectStatement.c.o
[ 98%] Building C object CMakeFiles/tcvm.dir/src/litebase/parser/SQLUpdateStatement.c.o
[ 99%] Building CXX object CMakeFiles/tcvm.dir/src/nm/ui/android/skia.cpp.o
In file included from /home/allan/TotalCross/sdk-public/TotalCrossVM/src/nm/ui/android/skia.cpp:37:
In file included from /home/allan/TotalCross/sdk-public/TotalCrossVM/modules/skia/include/core/SkPathEffect.h:12:
In file included from /home/allan/TotalCross/sdk-public/TotalCrossVM/modules/skia/include/core/SkPath.h:22:
In file included from /home/allan/TotalCross/sdk-public/TotalCrossVM/modules/skia/include/core/../private/SkPathRef.h:19:
/home/allan/TotalCross/sdk-public/TotalCrossVM/modules/skia/include/private/SkTemplates.h:483:79: error: expected ';' at
      end of declaration
constexpr auto SkMakeArrayFromIndexSequence(C c, skstd::index_sequence<Is...>)
```
The include files were played by the code formatter and `SkTemplates` was breaking.