### PR TITLE
Solves #101

### DIFF
--- a/TotalCrossSDK/src/main/java/totalcross/net/ssl/SSLSocketFactory.java
+++ b/TotalCrossSDK/src/main/java/totalcross/net/ssl/SSLSocketFactory.java
@@ -24,6 +24,11 @@ public class SSLSocketFactory extends SocketFactory {
 	}
 
 	@Override
+	public Socket createSocket(String host, int port) throws UnknownHostException, IOException {
+		return createSocket(host, port, Socket.DEFAULT_OPEN_TIMEOUT);
+	}
+
+	@Override
 	public Socket createSocket(String host, int port, int timeout) throws UnknownHostException,
 		IOException {
 		return new SSLSocket(host, port, timeout);


### PR DESCRIPTION
## Description:
Should always yields a `SSLSocket` when in `SSLSocketFactory`. As
`SSLSocketFactory` extends `SocketFactory` and does not override the
`createSocket(String, int)` method, and calls from super classe. As
`SocketFactory` yields plain sockets...

This fix just delegates to `createSocket(String, int, int)` passing the default
`Socket.DEFAULT_OPEN_TIMEOUT` as the open timeout argument. Maybe it should be
better to call `new SSLSocket(String, int)`, but this constructor does not
exists yet.

### Related Issue:
 - Solves #101

## Motivation and Context:
Creates a SSLSocket from a SSLSocketFactory implying the default open timeout.

## Benefited Devices:
TC-SDK as a whole, also Java

## How Has This Been Tested?
 - By writing a merge request to https://gitlab.com/geosales-open-source/tc-http-conn/develop to let it be able to deal with HTTPS.
   - this MR indeed https://gitlab.com/geosales-open-source/tc-http-conn/-/merge_requests/19
- Used TC 4.3.8, but as this is pure Java should apply to any version

## Tested Devices:
 - JVM 8