### PR TITLE
sdl: sizes and fullscreen update

### DIFF
--- a/TotalCrossVM/src/init/tcsdl.cpp
+++ b/TotalCrossVM/src/init/tcsdl.cpp
@@ -69,7 +69,7 @@ bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen) {
 							 SDL_WINDOWPOS_UNDEFINED,
 							 width,
 							 height,
-							 (getenv("TC_FULLSCREEN") == NULL) ? SDL_WINDOW_SHOWN : SDL_WINDOW_FULLSCREEN
+							 (getenv("TC_FULLSCREEN") == NULL) ?  SDL_WINDOW_FULLSCREEN : SDL_WINDOW_SHOWN
 						 ))) {
 		std::cerr << "SDL_CreateWindow(): " << SDL_GetError() << '\n';
 		return false;

--- a/TotalCrossVM/src/init/tcsdl.cpp
+++ b/TotalCrossVM/src/init/tcsdl.cpp
@@ -28,9 +28,6 @@ static SDL_Texture* texture;
  */
 bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen) {
 
-	int width = (getenv("TC_WIDTH")  == NULL) ? 640 : std::stoi(getenv("TC_WIDTH"));
-	int height = (getenv("TC_HEIGHT") == NULL) ? 400 : std::stoi(getenv("TC_HEIGHT"));
-
 	std::cout << "Testing video drivers..." << '\n';
 	std::vector< bool > drivers(SDL_GetNumVideoDrivers());
 
@@ -61,6 +58,9 @@ bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen) {
 	}
 	std::cout << "SDL_VIDEODRIVER selected : " << SDL_GetCurrentVideoDriver() << '\n';
 
+	int width = (getenv("TC_WIDTH")  == NULL) ? 640 : std::stoi(getenv("TC_WIDTH"));
+	int height = (getenv("TC_HEIGHT") == NULL) ? 400 : std::stoi(getenv("TC_HEIGHT"));
+	
 	// Create the window
 	SDL_Window* window;
 	if (IS_NULL(window = SDL_CreateWindow(

--- a/TotalCrossVM/src/init/tcsdl.cpp
+++ b/TotalCrossVM/src/init/tcsdl.cpp
@@ -58,9 +58,30 @@ bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen) {
 	}
 	std::cout << "SDL_VIDEODRIVER selected : " << SDL_GetCurrentVideoDriver() << '\n';
 
-	int width = (getenv("TC_WIDTH")  == NULL) ? 640 : std::stoi(getenv("TC_WIDTH"));
-	int height = (getenv("TC_HEIGHT") == NULL) ? 400 : std::stoi(getenv("TC_HEIGHT"));
-	
+	SDL_DisplayMode DM;
+	// Get current display mode of all displays.
+  	for(int i = 0; i < SDL_GetNumVideoDisplays(); ++i){
+		int should_be_zero = SDL_GetCurrentDisplayMode(i, &DM);
+
+		if(should_be_zero != 0) {
+			std::cerr << "SDL_GetCurrentDisplayMode() failed for video display #" << i << ": " << SDL_GetError() << '\n';
+		} else {
+			std::cout << "SDL_DisplayMode #" << i << ": current display mode is " << DM.w << "x" << DM.h << "x" << DM.refresh_rate << '\n';
+		}
+	}
+
+	int width = (getenv("TC_WIDTH")  == NULL) ? DM.w : std::stoi(getenv("TC_WIDTH"));
+	int height = (getenv("TC_HEIGHT") == NULL) ? DM.h : std::stoi(getenv("TC_HEIGHT"));
+
+	uint32 flags; 
+	if(getenv("TC_FULLSCREEN") == NULL) {
+		flags = SDL_WINDOW_FULLSCREEN;
+	} else {
+		flags = SDL_WINDOW_SHOWN;
+		width -= width*0.09;
+		height -= height*0.09;
+	}
+
 	// Create the window
 	SDL_Window* window;
 	if (IS_NULL(window = SDL_CreateWindow(


### PR DESCRIPTION
Place a declaration of the size variables closest to its use to resume the implementation of `SDL_DisplayBouns `/ `SDL_WINDOW_RESIZABLE` / Window from GTK