### PR TITLE
sdl: bring back static linking for sdl2 on target armv7

### DIFF
--- a/TotalCrossVM/docker/arm32v7/Dockerfile
+++ b/TotalCrossVM/docker/arm32v7/Dockerfile
@@ -4,23 +4,58 @@ FROM arm32v7/ubuntu:xenial
 MAINTAINER Italo Yeltsin "br.yeltsin@gmail.com"
 
 # TotalCross
-RUN apt-get update
-RUN apt-get install -y cmake ninja-build libfontconfig1-dev
-
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        cmake \
+        ninja-build \
+        build-essential \
+        libfontconfig1-dev \
 # SDL2 
-RUN apt-get install -y build-essential \
-    libtool libasound2-dev libpulse-dev libaudio-dev libx11-dev libxext-dev \
-    libxrandr-dev libxcursor-dev libxi-dev libxinerama-dev libxxf86vm-dev \
-    libxss-dev libgl1-mesa-dev libesd0-dev libdbus-1-dev libudev-dev \
-    libgles2-mesa-dev libegl1-mesa-dev libibus-1.0-dev \
-    fcitx-libs-dev libsamplerate0-dev libsndio-dev
-RUN apt-get install -y libwayland-dev libxkbcommon-dev wayland-protocols
-RUN apt-get install -y libgles1-mesa-dev || apt-get -f install
-RUN apt-get install -y git
-RUN git clone https://github.com/SDL-mirror/SDL.git --branch=release-2.0.10 --single-branch --depth=1 \
-    && cd SDL && mkdir build; cd build \
-    && CFLAGS="-O3 -fPIC" cmake ../ -DSDL_SHARED=0 -DSDL_AUDIO=0 -DVIDEO_VIVANTE=ON -DVIDEO_WAYLAND=ON \ 
-    -DWAYLAND_SHARED=ON; make -j$(($(nproc) + 2)) install 
+        libtool \
+        libasound2-dev \
+        libpulse-dev \
+        libaudio-dev \
+        libx11-dev \
+        libxext-dev \
+        libxrandr-dev \
+        libxcursor-dev \
+        libxi-dev \
+        libxinerama-dev \
+        libxxf86vm-dev \
+        libxss-dev \
+        libgl1-mesa-dev \
+        libesd0-dev \
+        libdbus-1-dev \
+        libudev-dev \
+        libgles2-mesa-dev \
+        libegl1-mesa-dev \
+        libibus-1.0-dev \
+        fcitx-libs-dev \
+        libsamplerate0-dev \
+        libsndio-dev \
+# Wayland
+        libwayland-dev \
+        libxkbcommon-dev \
+        wayland-protocols \
+        git \
+        ca-certificates; \
+    apt-get install -y libgles1-mesa-dev || apt-get -f install; \
+    apt-get clean
+
+RUN git clone https://github.com/SDL-mirror/SDL.git \
+        --branch=release-2.0.10 \
+        --single-branch \
+        --depth=1 \
+    && cd SDL \
+    && mkdir build; cd build \
+    && CFLAGS="-O3 -fPIC" \
+    cmake ../ -G Ninja \
+        -DSDL_SHARED=0 \
+        -DSDL_AUDIO=0 \
+        -DVIDEO_VIVANTE=ON \
+        -DVIDEO_WAYLAND=ON \ 
+        -DWAYLAND_SHARED=ON; \
+    ninja install
 
 # clean up
 RUN rm -r /SDL  

--- a/TotalCrossVM/docker/arm32v7/Dockerfile
+++ b/TotalCrossVM/docker/arm32v7/Dockerfile
@@ -3,8 +3,27 @@ FROM arm32v7/ubuntu:xenial
 
 MAINTAINER Italo Yeltsin "br.yeltsin@gmail.com"
 
+# TotalCross
 RUN apt-get update
-RUN apt-get install -y cmake ninja-build libsdl2-dev libfontconfig1-dev
+RUN apt-get install -y cmake ninja-build libfontconfig1-dev
+
+# SDL2 
+RUN apt-get install -y build-essential \
+    libtool libasound2-dev libpulse-dev libaudio-dev libx11-dev libxext-dev \
+    libxrandr-dev libxcursor-dev libxi-dev libxinerama-dev libxxf86vm-dev \
+    libxss-dev libgl1-mesa-dev libesd0-dev libdbus-1-dev libudev-dev \
+    libgles2-mesa-dev libegl1-mesa-dev libibus-1.0-dev \
+    fcitx-libs-dev libsamplerate0-dev libsndio-dev
+RUN apt-get install -y libwayland-dev libxkbcommon-dev wayland-protocols
+RUN apt-get install -y libgles1-mesa-dev || apt-get -f install
+RUN apt-get install -y git
+RUN git clone https://github.com/SDL-mirror/SDL.git --branch=release-2.0.10 --single-branch --depth=1 \
+    && cd SDL && mkdir build; cd build \
+    && CFLAGS="-O3 -fPIC" cmake ../ -DSDL_SHARED=0 -DSDL_AUDIO=0 -DVIDEO_VIVANTE=ON -DVIDEO_WAYLAND=ON \ 
+    -DWAYLAND_SHARED=ON; make -j$(($(nproc) + 2)) install 
+
+# clean up
+RUN rm -r /SDL  
 
 ENV BUILD_FOLDER /build
 


### PR DESCRIPTION
## Description:

For the reason that many users still use Angstrom to make a first test
of their applications, even though it is deprecated,  these changes
rollback static linking of sdl2 on libtcvm.so for armv7 to make our vm
runnable again without any extra work. 

## Motivation and Context:

For aN easier first try on Angstrom OS. Angstrom doesn't come with sdl2, so this change statically links sdl2 in order to make TotalCross totally functioning on this distribution without any extra work of recompiling this distro with any required dependences. 

## Benefited Devices:
 - Device: Linux arm
 - OS: Angstrom, Raspberry OS

## How Has This Been Tested?
 - It was tested on Angstrom and Raspberry OS by running the TCSample applicaation with the built libtcvm.so

## Tested Devices:
 - Device: Raspberry PI 4 and Toradex Colibri IMX6ULL. 
 - OS: [e.g. Linux Raspbian 10]

## Screenshots or videos: 
![image](https://user-images.githubusercontent.com/4422007/90419325-cbf38980-e08c-11ea-913e-ba1bfe9bf947.png)
