### PR TITLE
check commit on pull request as well

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -1,5 +1,5 @@
 name: 'Commit Message Check'
-on: [push]
+on: [push, pull_request]
 
 jobs:
   check-commit-message:
@@ -12,38 +12,63 @@ jobs:
         with:
           pattern: '^[a-z0-9,\s]+: .+(?:\n(?:\n.+)+)?(?:\n\n.+)?$'
           error: 'Your message must have the correct format "<scope>: <subject>" with an optional body and footer separated by blank lines.'
-
+          excludeDescription: true 
+          excludeTitle: true
+          checkAllCommitMessages: true 
+          accessToken: ${{ secrets.GITHUB_TOKEN }}
+          
       - name: Check Title Capitalize
         uses: gsactions/commit-message-checker@v1
         with:
           pattern: '^[^A-Z]'
           flags: ''
           error: 'Your title should not capitalize first word.'
-
+          excludeDescription: true 
+          excludeTitle: true
+          checkAllCommitMessages: true 
+          accessToken: ${{ secrets.GITHUB_TOKEN }}
+          
       - name: Check Title Length
         uses: gsactions/commit-message-checker@v1
         with:
           pattern: '^[^\s]+([ \t]+[^\s]+){2,}[ \t]*(\n.*)?$'
           flags: 's'
           error: 'A meaningful title should contain at least 3 words.'
-
+          excludeDescription: true 
+          excludeTitle: true
+          checkAllCommitMessages: true 
+          accessToken: ${{ secrets.GITHUB_TOKEN }}
+          
       - name: Check Title Line Length
         uses: gsactions/commit-message-checker@v1
         with:
           pattern: '^([^\n]{1,80}|Merge pull request.*)(\n.*)?$'
           flags: 's'
           error: 'The maximum title line length of 80 characters is exceeded.'
-
+          excludeDescription: true 
+          excludeTitle: true
+          checkAllCommitMessages: true 
+          accessToken: ${{ secrets.GITHUB_TOKEN }}
+          
       - name: Check Title Line Separator
         uses: gsactions/commit-message-checker@v1
         with:
           pattern: '^[^\n]+(\n\n.+)?$'
           flags: 's'
           error: 'Should leave an empty line after title.'
-
+          excludeDescription: true 
+          excludeTitle: true
+          checkAllCommitMessages: true 
+          accessToken: ${{ secrets.GITHUB_TOKEN }}
+          
       - name: Check Line Length
         uses: gsactions/commit-message-checker@v1
         with:
           pattern: '^[^\n]+(\n[^\n]{0,80})*$'
           flags: 's'
           error: 'The maximum line length of 80 characters is exceeded.'
+          excludeDescription: true 
+          excludeTitle: true
+          checkAllCommitMessages: true 
+          accessToken: ${{ secrets.GITHUB_TOKEN }}
+          


### PR DESCRIPTION
## Description:
Commit checker are not checking commit from external contributors. Also, if we squash commit with the github pull request tool, the final commit is not being checked as well.