### PR TITLE
sdl: event: linux: removes redundant code

### DIFF
--- a/TotalCrossVM/src/event/linux/event_c.h
+++ b/TotalCrossVM/src/event/linux/event_c.h
@@ -123,9 +123,6 @@ void handleTextInputEvent(SDL_Event event) {
 
 void privatePumpEvent(Context currentContext)
 {
-   if (!privateIsEventAvailable())
-      return;
-
 #ifndef HEADLESS
    DFBInputEvent evt;
    int x, y;


### PR DESCRIPTION
## Description:
isEventAvailable is executed before pumpEvent, there's no need for calling it twice

## Motivation and Context:
I was looking for ways to improve graphical performance and noticed this redundant call.

## Benefited Devices:
- Linux systems

## Tested Devices:
- iMX6ULL