### PR TITLE
Topic/use sdlsurface on cpu

### DIFF
--- a/TotalCrossVM/src/init/tcsdl.cpp
+++ b/TotalCrossVM/src/init/tcsdl.cpp
@@ -181,6 +181,7 @@ bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen) {
 	SCREEN_EX(screen)->window = window;
 	SCREEN_EX(screen)->renderer = renderer;
 	SCREEN_EX(screen)->texture = texture;
+	SCREEN_EX(screen)->surface = surface;
 
 	SDL_FreeFormat(pixelformat);
 

--- a/TotalCrossVM/src/init/tcsdl.cpp
+++ b/TotalCrossVM/src/init/tcsdl.cpp
@@ -13,10 +13,10 @@
 #include <iostream>
 #include <vector>
 
-static SDL_Renderer* renderer;
-static SDL_Texture* texture;
-static SDL_Window *window; 
-static SDL_Surface *surface;
+static SDL_Renderer* renderer = NULL;
+static SDL_Texture* texture = NULL;
+static SDL_Window *window = NULL; 
+static SDL_Surface *surface = NULL;
 static bool usesTexture;
 
 /*

--- a/TotalCrossVM/src/init/tcsdl.cpp
+++ b/TotalCrossVM/src/init/tcsdl.cpp
@@ -225,14 +225,23 @@ void TCSDL_Present() {
  * Destroy all SDL allocated variables
  */
 void TCSDL_Destroy(ScreenSurface screen) {
-	if (screen->pixels != NULL) {
+	if (usesTexture && screen->pixels != NULL) {
 		free(screen->pixels);
 	}
 
 	if (SCREEN_EX(screen) != NULL) {
-		SDL_DestroyTexture(SCREEN_EX(screen)->texture);
-		SDL_DestroyRenderer(SCREEN_EX(screen)->renderer);
-		SDL_DestroyWindow(SCREEN_EX(screen)->window);
+		if (SCREEN_EX(screen)->surface != NULL) {
+			SDL_FreeSurface(SCREEN_EX(screen)->surface);
+		}
+		if (SCREEN_EX(screen)->texture != NULL) {
+			SDL_DestroyTexture(SCREEN_EX(screen)->texture);
+		}
+		if (SCREEN_EX(screen)->renderer != NULL) {
+			SDL_DestroyRenderer(SCREEN_EX(screen)->renderer);
+		}
+		if (SCREEN_EX(screen)->window != NULL) {
+			SDL_DestroyWindow(SCREEN_EX(screen)->window);
+		}
 		free(SCREEN_EX(screen));
 	}
 	SDL_Quit();

--- a/TotalCrossVM/src/nm/ui/linux/gfx_ex.h
+++ b/TotalCrossVM/src/nm/ui/linux/gfx_ex.h
@@ -27,6 +27,7 @@ typedef struct TScreenSurfaceEx
    SDL_Window *window;
    SDL_Renderer *renderer;
    SDL_Texture *texture;
+   SDL_Surface* surface;
 #else
    IDirectFB *dfb;
    IDirectFBSurface *primary;


### PR DESCRIPTION
## Description:
use SDL_Surface instead of SDL_Renderer when hardware accelerated graphics is not available

### Related Issue:
#63 

## Motivation and Context:
Improves performance on devices without hardware acceleration

## Benefited Devices:
 - Linux systems

## How Has This Been Tested?
Tested using SDL_GetTicks to measure the performance with both implementations:
texture and software renderer x surface

## Tested Devices:
 - iMX6ULL
 - RaspberryPi