### PR TITLE
sdl: use `flags` to adjust window sizes

### DIFF
--- a/TotalCrossVM/src/init/tcsdl.cpp
+++ b/TotalCrossVM/src/init/tcsdl.cpp
@@ -88,7 +88,7 @@ bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen) {
 							 SDL_WINDOWPOS_UNDEFINED,
 							 width,
 							 height,
-							 (getenv("TC_FULLSCREEN") == NULL) ?  SDL_WINDOW_FULLSCREEN : SDL_WINDOW_SHOWN
+							 flags
 						 ))) {
 		std::cerr << "SDL_CreateWindow(): " << SDL_GetError() << '\n';
 		return false;


### PR DESCRIPTION
The previous commits introduce the `flags` variable, but it was unused. This variable is very important to open TC in window mode without window size issues.