### PR TITLE
arm64: adds support for building to arm64 using docker

### DIFF
--- a/TotalCrossVM/docker/arm64/Dockerfile
+++ b/TotalCrossVM/docker/arm64/Dockerfile
@@ -1,0 +1,67 @@
+FROM arm64v8/ubuntu:xenial
+# 
+
+MAINTAINER Italo Yeltsin "br.yeltsin@gmail.com"
+
+# TotalCross
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        cmake \
+        ninja-build \
+        build-essential \
+        libfontconfig1-dev \
+# SDL2 
+        libtool \
+        libasound2-dev \
+        libpulse-dev \
+        libaudio-dev \
+        libx11-dev \
+        libxext-dev \
+        libxrandr-dev \
+        libxcursor-dev \
+        libxi-dev \
+        libxinerama-dev \
+        libxxf86vm-dev \
+        libxss-dev \
+        libgl1-mesa-dev \
+        libesd0-dev \
+        libdbus-1-dev \
+        libudev-dev \
+        libgles2-mesa-dev \
+        libegl1-mesa-dev \
+        libibus-1.0-dev \
+        fcitx-libs-dev \
+        libsamplerate0-dev \
+        libsndio-dev \
+# Wayland
+        libwayland-dev \
+        libxkbcommon-dev \
+        wayland-protocols \
+        git \
+        ca-certificates; \
+    apt-get install -y libgles1-mesa-dev || apt-get -f install; \
+    apt-get clean
+
+RUN git clone https://github.com/SDL-mirror/SDL.git \
+        --branch=release-2.0.10 \
+        --single-branch \
+        --depth=1 \
+    && cd SDL \
+    && mkdir build; cd build \
+    && CFLAGS="-O3 -fPIC" \
+    cmake ../ -G Ninja \
+        -DSDL_SHARED=0 \
+        -DSDL_AUDIO=0 \
+        -DVIDEO_VIVANTE=ON \
+        -DVIDEO_WAYLAND=ON \ 
+        -DWAYLAND_SHARED=ON; \
+    ninja install
+
+# clean up
+RUN rm -r /SDL  
+
+ENV BUILD_FOLDER /build
+
+WORKDIR ${BUILD_FOLDER}
+CMD ["/bin/bash", "-c", "make", "-j$(($(nproc) + 2))", "-f", "${BUILD_FOLDER}/Makefile"]
+# CMD ["make", "clean"]

--- a/TotalCrossVM/docker/arm64/build-docker.sh
+++ b/TotalCrossVM/docker/arm64/build-docker.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+export DOCKER_CLI_EXPERIMENTAL=enabled
+export DOCKER_BUILDKIT=1
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+docker buildx create --use --name armbuilder
+docker buildx inspect --bootstrap
+docker buildx build --platform linux/arm64 --load -t totalcross/linux-arm64-build .

--- a/TotalCrossVM/docker/arm64/cmake.sh
+++ b/TotalCrossVM/docker/arm64/cmake.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+BASEDIR=$(dirname $0)
+WORKDIR=$(cd $BASEDIR; pwd)
+
+sudo rm -Rf bin
+mkdir build
+
+# execute docker run
+sudo docker run -v ${WORKDIR}/../arm64/build:/build \
+                -v ${WORKDIR}/../../:/sources \
+                -t totalcross/linux-arm64-build \
+                bash -c "cmake /sources -DPNG_ARM_NEON_OPT=0 -G Ninja && ninja"
+
+# PNG_ARM_NEON_OPT must be disabled when building for arm64, 
+# because NEON instructions are not supported by qemu yet


### PR DESCRIPTION
## Description:
- adds Dockerfile and script to create the container for building the libtcvm
- adds precompiled static library libskia.a for archtecture arm64 (aarch64)
- adds script cmake.sh that builds the libtcvm.

⚠️  **Please notice** that PNG_ARM_NEON_OPT must be disabled when building for arm64, because NEON instructions are not supported by qemu yet. This is done by passing the argument PNG_ARM_NEON_OPT=0 when executing cmake.

### Related Issue:
#137 

## Motivation and Context:
Building also for linux-arm64 is required to support iMX8 modules.

## Benefited Devices:
 - Any device with arm64 architecture running Linux


## Tested Devices:
 - Toradex iMX8 using yocto image built in house

## Screenshots or videos: 
TODO
