### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,3 +202,9 @@ Before submitting a pull request, please make sure the following is done:
 After your pull request has been submitted, TotalCross code maintainers will acknowledge it as soon as possible. We aim to do it in three days tops.
 
 TotalCross code maintainers hold backlog grooming meetings most Fridays. Your pull request will likely be discussed then and you should get a position on where it stands on TotalCross backlog the following Monday.
+
+| Action | Action deadline |
+|---|---|
+| Pull request committed | -  |
+| First reply | 3 days  | 
+| Backlog prioritisation feedback | 7 days  | 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,8 +182,7 @@ Resolves: #123
 
 We try to enforce these rules for the following reasons:
 
-- Communicate in a better way the nature of changes;
-- Work better with review tools;
+- Communicate in a better way the nature of changes;ly
 - Automatically determining a semantic version bump (based on the types of commits);
 - Make it easier for people to contribute, by allowing them to explore a more structured commit history.
 
@@ -197,3 +196,9 @@ Before submitting a pull request, please make sure the following is done:
 - Build your changes;
 - If you’ve fixed a bug or added code that should be tested, **add tests**;
 - Ensure your commit is validated;
+
+### What happens next?
+
+After your pull request has been submitted, TotalCross code maintainers will acknowledge it as soon as possible. We aim to do it in three days tops.
+
+TotalCross code maintainers hold backlog grooming meetings most Fridays. Your pull request will likely be discussed then and you should get a position on where it stands on TotalCross backlog the following Monday.


### PR DESCRIPTION
docs: add a session to "Submitting a pull request" describing what the contributor can expect from the code maintainers after submitting a pull request.

## Description:
TotalCross code maintainers commit to reply to open pull requests no later than 3 days and to discuss it during the next weekly backlog grooming meeting.

## Motivation and Context:
Added paragraphs provide a guideline for code maintainers to reply to pull requests, both for first interaction and when backlog discussions will take place.
It also aligns code contributors expectations for come maintainers replies.
