### PR TITLE
Fix class AnonymousDataUser producing wrong data

### DIFF
--- a/TotalCrossSDK/src/main/java/tc/Deploy.java
+++ b/TotalCrossSDK/src/main/java/tc/Deploy.java
@@ -172,7 +172,13 @@ public class Deploy {
       showException(e, null);
       throw e;
     } finally {
-      AnonymousUserData.instance().deploy(args);
+      new Thread(() -> {
+        try {
+          AnonymousUserData.instance().deploy(args);
+        } catch (Exception e) {
+          //TODO: handle exception in a Log level
+        } 
+      }).start();
     }
   }
 

--- a/TotalCrossSDK/src/main/java/tc/tools/AnonymousUserData.java
+++ b/TotalCrossSDK/src/main/java/tc/tools/AnonymousUserData.java
@@ -36,7 +36,7 @@ public class AnonymousUserData {
 
     private ResponseRequester responseRequester;
 
-    private static File configFile;
+    private File configFile;
 
     private JSONObject config;
 

--- a/TotalCrossSDK/src/main/java/tc/tools/AnonymousUserData.java
+++ b/TotalCrossSDK/src/main/java/tc/tools/AnonymousUserData.java
@@ -38,7 +38,7 @@ public class AnonymousUserData {
 
     private static File configFile;
 
-    private static JSONObject config;
+    private JSONObject config;
 
     private SimpleDateFormat sdf;
 
@@ -68,6 +68,10 @@ public class AnonymousUserData {
 
     /* package */ void setConfigDirPath(String configDirPath) {
         this.configDirPath = configDirPath;
+    }
+
+    /* package */ JSONObject getConfig() {
+        return this.config;
     }
 
     /**
@@ -194,10 +198,6 @@ public class AnonymousUserData {
             }
             throw new Exception("Unexpected Response: user should provide a response.");
         }
-    }
-
-    public JSONObject getConfig() {
-        return config;
     }
 
     private static class HttpJsonConnection {

--- a/TotalCrossSDK/src/main/java/tc/tools/AnonymousUserData.java
+++ b/TotalCrossSDK/src/main/java/tc/tools/AnonymousUserData.java
@@ -107,9 +107,9 @@ public class AnonymousUserData {
         }
     }
 
-    public void launcher(String... args) throws JSONException, IOException, Exception {
+    public void launcher(String... args) throws JSONException, IOException {
         if (!GraphicsEnvironment.isHeadless() && config.isNull("userAcceptedToProvideAnonymousData")) {
-            boolean userAcceptedToContribute = responseRequester.ask();
+            Boolean userAcceptedToContribute = responseRequester.ask();
             config.put("userAcceptedToProvideAnonymousData", userAcceptedToContribute);
             try (PrintWriter writer = new PrintWriter(configFile)) {
                 writer.write(config.toString());
@@ -172,7 +172,7 @@ public class AnonymousUserData {
     }
 
     public interface ResponseRequester {
-        boolean ask() throws Exception;
+        Boolean ask();
     }
 
     private class DefaultResponseRequester implements ResponseRequester {
@@ -186,7 +186,7 @@ public class AnonymousUserData {
             + "anonymous report?";
 
         @Override
-        public boolean ask() throws Exception {
+        public Boolean ask() {
             final String[] options = new String[] { "Yes, send anonymous reports", "Don't send" };
             final ImageIcon icon = new ImageIcon(getClass().getClassLoader().getResource("tc/crossy.png"));
             int dialogResult = JOptionPane.showOptionDialog(null, POPUP_TEXT, "", JOptionPane.YES_NO_OPTION,
@@ -196,7 +196,7 @@ public class AnonymousUserData {
             } else if (dialogResult == JOptionPane.NO_OPTION) {
                 return false;
             }
-            throw new Exception("Unexpected Response: user should provide a response.");
+            return null;
         }
     }
 

--- a/TotalCrossSDK/src/main/java/tc/tools/AnonymousUserData.java
+++ b/TotalCrossSDK/src/main/java/tc/tools/AnonymousUserData.java
@@ -42,7 +42,7 @@ public class AnonymousUserData {
 
     private SimpleDateFormat sdf;
 
-    private static String configDirPath = AppDirsFactory.getInstance().getUserConfigDir("TotalCross", null, null)
+    private String configDirPath = AppDirsFactory.getInstance().getUserConfigDir("TotalCross", null, null)
             .replace("Application Support", "Preferences");
 
     private AnonymousUserData() throws IOException {
@@ -64,6 +64,10 @@ public class AnonymousUserData {
 
     /* package */ void setResponseRequester(ResponseRequester responseRequester) {
         this.responseRequester = responseRequester;
+    }
+
+    /* package */ void setConfigDirPath(String configDirPath) {
+        this.configDirPath = configDirPath;
     }
 
     /**
@@ -190,14 +194,6 @@ public class AnonymousUserData {
             }
             throw new Exception("Unexpected Response: user should provide a response.");
         }
-    }
-
-    public String getConfigDirPath() {
-        return configDirPath;
-    }
-
-    public void setConfigDirPath(String configDirPath) {
-        AnonymousUserData.configDirPath = configDirPath;
     }
 
     public JSONObject getConfig() {

--- a/TotalCrossSDK/src/main/java/tc/tools/AnonymousUserData.java
+++ b/TotalCrossSDK/src/main/java/tc/tools/AnonymousUserData.java
@@ -122,8 +122,18 @@ public class AnonymousUserData {
 
     private void doGetUUID() {
         HttpStream.Options options = new HttpStream.Options();
-        options.socketFactory = new SSLSocketFactory();
         options.openTimeOut = options.readTimeOut = options.writeTimeOut = 60_000;
+        options.httpType = HttpStream.POST;
+        if(BASE_URL.startsWith("https://")) {
+            options.socketFactory = new SSLSocketFactory();
+        }
+        options.postHeaders.put("accept", "application/json");
+        options.postHeaders.put("Content-Type", "application/json");
+        
+        JSONObject dataJson = new JSONObject();
+        dataJson.put("os", System.getProperty("os.name"));
+        dataJson.put("tc_version", Settings.versionStr);
+        options.data = dataJson.toString();
         try (HttpStream hs = new HttpStream(new URI(BASE_URL + GET_UUID), options)) {
             JSONObject ret = readJsonObject(hs);
             config.put("uuid", ret.get("uuid"));
@@ -172,13 +182,14 @@ public class AnonymousUserData {
 
             HttpStream.Options options = new HttpStream.Options();
             options.httpType = HttpStream.POST;
-            options.socketFactory = new SSLSocketFactory();
+            if(BASE_URL.startsWith("https://")) {
+                options.socketFactory = new SSLSocketFactory();
+            }
             options.postHeaders.put("accept", "application/json");
             options.postHeaders.put("Content-Type", "application/json");
             options.openTimeOut = options.readTimeOut = options.writeTimeOut = 60_000;
             
             JSONObject dataJson = new JSONObject();
-            dataJson.put("os", System.getProperty("os.name"));
             dataJson.put("tc_version", Settings.versionStr);
             dataJson.put("date", sdf.format(new Date()));
             dataJson.put("args", String.join(" ", args));

--- a/TotalCrossSDK/src/main/java/tc/tools/AnonymousUserData.java
+++ b/TotalCrossSDK/src/main/java/tc/tools/AnonymousUserData.java
@@ -34,7 +34,7 @@ public class AnonymousUserData {
 
     private static AnonymousUserData instance;
 
-    private static ResponseRequester responseRequester;
+    private ResponseRequester responseRequester;
 
     private static File configFile;
 
@@ -60,6 +60,10 @@ public class AnonymousUserData {
 
     /* package */ void setBaseUrl(String url) {
         this.BASE_URL = url;
+    }
+
+    /* package */ void setResponseRequester(ResponseRequester responseRequester) {
+        this.responseRequester = responseRequester;
     }
 
     /**
@@ -194,14 +198,6 @@ public class AnonymousUserData {
 
     public void setConfigDirPath(String configDirPath) {
         AnonymousUserData.configDirPath = configDirPath;
-    }
-
-    public ResponseRequester getResponseRequester() {
-        return responseRequester;
-    }
-
-    public void setResponseRequester(ResponseRequester responseRequester) {
-        AnonymousUserData.responseRequester = responseRequester;
     }
 
     public JSONObject getConfig() {

--- a/TotalCrossSDK/src/main/java/tc/tools/AnonymousUserData.java
+++ b/TotalCrossSDK/src/main/java/tc/tools/AnonymousUserData.java
@@ -26,7 +26,7 @@ import totalcross.sys.Settings;
 
 public class AnonymousUserData {
 
-    private static String BASE_URL = "https://statistics.totalcross.com/api/v1";
+    private String BASE_URL = "https://statistics.totalcross.com/api/v1";
     private static final String GET_UUID = "/users/get-anonymous-uuid";
     private static final String POST_LAUNCHER = "/launch";
     private static final String POST_DEPLOY = "/deploy";
@@ -58,6 +58,10 @@ public class AnonymousUserData {
         return instance;
     }
 
+    /* package */ void setBaseUrl(String url) {
+        this.BASE_URL = url;
+    }
+
     /**
      * Always returns a valid config object. An empty one is returned if anything
      * fails, not exception is thrown.
@@ -67,7 +71,7 @@ public class AnonymousUserData {
      * 
      * @throws IOException
      */
-    public static void loadConfiguration() throws IOException {
+    public void loadConfiguration() throws IOException {
         config = null;
         File configDir = new File(configDirPath);
         configDir.mkdirs();
@@ -127,7 +131,7 @@ public class AnonymousUserData {
      * @throws IOException
      * @throws JSONException
      */
-    public static boolean checkUUID(String uuid) throws JSONException, IOException {
+    public boolean checkUUID(String uuid) throws JSONException, IOException {
         JSONObject ret = new HttpJsonConnection(BASE_URL + CHECK_UUID + "?uuid=" + uuid).doGet().getResponse();
         boolean isValid = (boolean) ret.get("isValid");
         if (!isValid) {
@@ -160,12 +164,12 @@ public class AnonymousUserData {
     }
 
     private class DefaultResponseRequester implements ResponseRequester {
-        
+
         private static final String POPUP_TEXT = 
             "We'd like to collect anonymous telemetry data to help us prioritize \n"
-            + "improvements. This includes how often you deploy and launches \n"
-            + "(on simulator) your app, which OS you deploy for, your timezone and \n"
-            + "which totalcross version you're using. We do not collect any personal \n"
+                + "improvements. This includes how often you deploy and launches \n"
+                + "(on simulator) your app, which OS you deploy for, your timezone and \n"
+                + "which totalcross version you're using. We do not collect any personal \n"
             + "data or sensitive information. Do you allow TotalCross to send us \n" 
             + "anonymous report?";
 
@@ -182,14 +186,6 @@ public class AnonymousUserData {
             }
             throw new Exception("Unexpected Response: user should provide a response.");
         }
-    }
-
-    public static String getBaseUrl() {
-        return BASE_URL;
-    }
-
-    public static void setBaseUrl(String url) {
-        BASE_URL = url;
     }
 
     public String getConfigDirPath() {

--- a/TotalCrossSDK/src/main/java/tc/tools/AnonymousUserData.java
+++ b/TotalCrossSDK/src/main/java/tc/tools/AnonymousUserData.java
@@ -119,6 +119,7 @@ public class AnonymousUserData {
     private void doGetUUID() {
         HttpStream.Options options = new HttpStream.Options();
         options.socketFactory = new SSLSocketFactory();
+        options.openTimeOut = options.readTimeOut = options.writeTimeOut = 60_000;
         try (HttpStream hs = new HttpStream(new URI(BASE_URL + GET_UUID), options)) {
             JSONObject ret = readJsonObject(hs);
             config.put("userUuid", ret.get("uuid"));
@@ -145,6 +146,7 @@ public class AnonymousUserData {
             options.postHeaders.put("accept", "application/json");
             options.postHeaders.put("Content-Type", "application/json");
 
+            options.openTimeOut = options.readTimeOut = options.writeTimeOut = 60_000;
             JSONObject dataJson = new JSONObject();
             dataJson.put("os", System.getProperty("os.name"));
             dataJson.put("tc_version", Settings.versionStr);

--- a/TotalCrossSDK/src/main/java/tc/tools/AnonymousUserData.java
+++ b/TotalCrossSDK/src/main/java/tc/tools/AnonymousUserData.java
@@ -122,7 +122,7 @@ public class AnonymousUserData {
         options.openTimeOut = options.readTimeOut = options.writeTimeOut = 60_000;
         try (HttpStream hs = new HttpStream(new URI(BASE_URL + GET_UUID), options)) {
             JSONObject ret = readJsonObject(hs);
-            config.put("userUuid", ret.get("uuid"));
+            config.put("uuid", ret.get("uuid"));
 
             try (PrintWriter writer = new PrintWriter(configFile)) {
                 writer.write(config.toString());
@@ -136,7 +136,7 @@ public class AnonymousUserData {
 
     private void doPost(String url, String... args) {
         if (config.optBoolean("userAcceptedToProvideAnonymousData", false)) {
-            if (!config.has("userUuid")) {
+            if (!config.has("uuid")) {
                 doGetUUID();
             }
 
@@ -145,14 +145,14 @@ public class AnonymousUserData {
             options.socketFactory = new SSLSocketFactory();
             options.postHeaders.put("accept", "application/json");
             options.postHeaders.put("Content-Type", "application/json");
-
             options.openTimeOut = options.readTimeOut = options.writeTimeOut = 60_000;
+            
             JSONObject dataJson = new JSONObject();
             dataJson.put("os", System.getProperty("os.name"));
             dataJson.put("tc_version", Settings.versionStr);
             dataJson.put("date", sdf.format(new Date()));
             dataJson.put("args", String.join(" ", args));
-            dataJson.put("userUuid", config.opt("userUuid"));
+            dataJson.put("userUuid", config.opt("uuid"));
             options.data = dataJson.toString();
 
             try (HttpStream hs = new HttpStream(new URI(url), options)) {

--- a/TotalCrossSDK/src/main/java/totalcross/Launcher.java
+++ b/TotalCrossSDK/src/main/java/totalcross/Launcher.java
@@ -465,7 +465,15 @@ final public class Launcher extends java.applet.Applet implements WindowListener
   }
 
   protected void parseArguments(String clazz, String... args) {
-    AnonymousUserData.instance().launcher(args);
+    // Send statistic data if user agreed
+    new Thread(() -> {
+      try {
+        AnonymousUserData.instance().launcher(args);
+      } catch (Exception e) {
+        //TODO: handle exception in a Log level
+      } 
+    }).start();
+
     int n = args.length, i = 0;
     String newDataPath = null;
     try {

--- a/TotalCrossSDK/src/test/java/tc/tools/AnonymousUserDataTest.java
+++ b/TotalCrossSDK/src/test/java/tc/tools/AnonymousUserDataTest.java
@@ -17,8 +17,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Paths;
 
-import tc.tools.AnonymousUserData;
-
 public class AnonymousUserDataTest {
     static AnonymousUserData anonymousUserData;
     static String configDirPath;
@@ -26,8 +24,8 @@ public class AnonymousUserDataTest {
 
     @BeforeEach
     void setup() {
-        AnonymousUserData.setBaseUrl("https://aqueous-plateau-93003.herokuapp.com/api/v1");
         anonymousUserData = AnonymousUserData.instance();
+        anonymousUserData.setBaseUrl("https://aqueous-plateau-93003.herokuapp.com/api/v1");
         configDirPath = Paths.get(System.getProperty("user.home"), "tc-test").toAbsolutePath().toString();
         configPath = Paths.get(configDirPath, "config.json").toAbsolutePath().toString();
         anonymousUserData.setConfigDirPath(configDirPath);

--- a/TotalCrossSDK/src/test/java/tc/tools/AnonymousUserDataTest.java
+++ b/TotalCrossSDK/src/test/java/tc/tools/AnonymousUserDataTest.java
@@ -68,16 +68,7 @@ public class AnonymousUserDataTest {
         // Create config file
         File f = new File(configPath);
         String existingToken = "d61cfa55-cb26-49f3-8468-2a91ed94971f"; // existing on stage server
-        f.createNewFile();
-        try {
-            FileWriter myWriter = new FileWriter(f);
-            myWriter.write("{\"userAcceptedToProvideAnonymousData\":true," +
-                    "\"uuid\": \"" + existingToken + "\"}");
-            myWriter.close();
-          } catch (IOException e) {
-            e.printStackTrace();
-          }
-
+        writeConfigFile(existingToken, true);
         // Use config file
         anonymousUserData.loadConfiguration();
         anonymousUserData.launcher("/src", "200x800");
@@ -91,18 +82,8 @@ public class AnonymousUserDataTest {
     @Test
     void shouldEraseTheExistingInvalidUUIDAndGetANewValidOne() throws IOException {
         // Create config file
-        File f = new File(configPath);
         String existingInvalidUuid = "52f265eb-8d36-4ffe-b2c5-3c4affb278fe"; // existing invalid
-        f.createNewFile();
-        try {
-            FileWriter myWriter = new FileWriter(f);
-            myWriter.write("{\"userAcceptedToProvideAnonymousData\":true," +
-                    "\"uuid\": \"" + existingInvalidUuid + "\"}");
-            myWriter.close();
-          } catch (IOException e) {
-            e.printStackTrace();
-          }
-
+        writeConfigFile(existingInvalidUuid, true);
         // Use config file
         anonymousUserData.loadConfiguration();
         anonymousUserData.launcher("/src", "200x800");
@@ -113,6 +94,19 @@ public class AnonymousUserDataTest {
             "should use not be existing the existing invalid token");
         assertTrue(anonymousUserData.checkUUID(newValidUuid), "new token should be valid");
         
+    }
+
+    private void writeConfigFile(String uuid, boolean userAcceptedToContribute) throws IOException {
+        File f = new File(configPath);
+        f.createNewFile();
+        try {
+            FileWriter myWriter = new FileWriter(f);
+            myWriter.write("{\"userAcceptedToProvideAnonymousData\": " + userAcceptedToContribute + "," +
+                    "\"uuid\": \"" + uuid + "\"}");
+            myWriter.close();
+          } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
  
 }

--- a/TotalCrossSDK/src/test/java/tc/tools/AnonymousUserDataTest.java
+++ b/TotalCrossSDK/src/test/java/tc/tools/AnonymousUserDataTest.java
@@ -60,7 +60,7 @@ public class AnonymousUserDataTest {
         JSONObject object = new JSONObject(str);
 
         assertEquals(true, object.opt("userAcceptedToProvideAnonymousData"), "user accepted should be true");
-        assertNotNull(object.opt("userUuid"), "it should contains an userUuid");
+        assertNotNull(object.opt("uuid"), "it should contains an uuid");
 
     }
 
@@ -73,7 +73,7 @@ public class AnonymousUserDataTest {
         try {
             FileWriter myWriter = new FileWriter(f);
             myWriter.write("{\"userAcceptedToProvideAnonymousData\":true," +
-                    "\"userUuid\": \"" + existingToken + "\"}");
+                    "\"uuid\": \"" + existingToken + "\"}");
             myWriter.close();
           } catch (IOException e) {
             e.printStackTrace();
@@ -85,7 +85,7 @@ public class AnonymousUserDataTest {
         assertEquals(true, 
             anonymousUserData.getConfig().get("userAcceptedToProvideAnonymousData"),
                 "user agreement should come from config file");
-        assertEquals(existingToken, anonymousUserData.getConfig().get("userUuid"),
+        assertEquals(existingToken, anonymousUserData.getConfig().get("uuid"),
             "should use existing token");
     }
  

--- a/TotalCrossSDK/src/test/java/tc/tools/AnonymousUserDataTest.java
+++ b/TotalCrossSDK/src/test/java/tc/tools/AnonymousUserDataTest.java
@@ -1,0 +1,92 @@
+// Copyright (C) 2020 TotalCross Global Mobile Platform Ltda.
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+package tc.tools;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import totalcross.json.JSONObject;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Paths;
+
+import tc.tools.AnonymousUserData;
+
+public class AnonymousUserDataTest {
+    static AnonymousUserData anonymousUserData;
+    static String configDirPath;
+    static String configPath;
+
+    @BeforeEach
+    void setup() {
+        anonymousUserData = AnonymousUserData.instance();
+        configDirPath = Paths.get(System.getProperty("user.home"), "tc-test").toAbsolutePath().toString();
+        configPath = Paths.get(configDirPath, "config.json").toAbsolutePath().toString();
+        anonymousUserData.setConfigDirPath(configDirPath);
+        new File(configDirPath).delete();
+        anonymousUserData.setResponseRequester(() -> {
+            return true;
+        });
+        anonymousUserData.setBaseUrl("https://aqueous-plateau-93003.herokuapp.com/api/v1");
+        anonymousUserData.loadConfiguration();
+    }
+
+    @AfterEach
+    void finish() {
+        new File(configDirPath).delete();
+    }
+
+    @Test
+    void shouldCreateAConfigFile() throws IOException {
+        
+        anonymousUserData.launcher("/src", "200x800");
+        assertEquals(true, new File(configPath).exists(), "file should be created");
+
+        File file = new File(configPath);
+        FileInputStream fis = new FileInputStream(file);
+        byte[] data = new byte[(int) file.length()];
+        fis.read(data);
+        fis.close();
+
+        String str = new String(data, "UTF-8");
+        JSONObject object = new JSONObject(str);
+
+        assertEquals(true, object.opt("userAcceptedToProvideAnonymousData"), "user accepted should be true");
+        assertNotNull(object.opt("userUuid"), "it should contains an userUuid");
+
+    }
+
+    @Test
+    void shouldUseInformationFromExistingConfigFile() throws IOException {
+        // Create config file
+        File f = new File(configPath);
+        String existingToken = "cf871c5e-dd38-4ab8-9796-48b79d076d59"; // existing on stage server
+        f.createNewFile();
+        try {
+            FileWriter myWriter = new FileWriter(f);
+            myWriter.write("{\"userAcceptedToProvideAnonymousData\":true," +
+                    "\"userUuid\": \"" + existingToken + "\"}");
+            myWriter.close();
+          } catch (IOException e) {
+            e.printStackTrace();
+          }
+
+        // Use config file
+        anonymousUserData.loadConfiguration();
+        anonymousUserData.launcher("/src", "200x800");
+        assertEquals(true, 
+            anonymousUserData.getConfig().get("userAcceptedToProvideAnonymousData"),
+                "user agreement should come from config file");
+        assertEquals(existingToken, anonymousUserData.getConfig().get("userUuid"),
+            "should use existing token");
+    }
+ 
+}


### PR DESCRIPTION
## Description:
Class AnonymousDataUser was producing unexpected uuid's and registering deploy and launches without complete data. Some of the reasons are: i) it was storing user uuid as userUuid, differently than the vs code plugin the stores "uuid"; ii) short timeout time causing the token to be generated but not read; iii) #83 and #146 might be related with producing a way more users than the naturally should do, because token were being generated but not stored.

## How Has This Been Tested?
 - Unit tests;
 - integration tests;

## Depends on
- this PR depends on #83 must be draft until #83 is closed.