### PR TITLE
test: add JUnit 5 test engine to TC SDK build

### DIFF
--- a/TotalCrossSDK/build.gradle
+++ b/TotalCrossSDK/build.gradle
@@ -107,9 +107,17 @@ dependencies {
 	compile group: 'net.coobird', name: 'thumbnailator', version: '0.4.8'
 
 	// https://mvnrepository.com/artifact/junit/junit
-	testCompile group: 'junit', name: 'junit', version: '4.12'
+	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
 
     compile(group: 'com.totalcross.annotations', name: 'totalcross-annotations', version: '1.0.0')
+}
+
+test {
+    useJUnitPlatform ()
+    testLogging {
+        exceptionFormat = 'full'
+    }
 }
 
 jar {


### PR DESCRIPTION
## Description:
We can finally run JUnit Tests on our SDK 

## Motivation and Context:
Unit Testing is an essential step on the development process. It provides code quality and avoids bug regression. 

## How Has This Been Tested?
- Intelij;
- command line (`cd TotalCrossSDK; ./gradlew test`);
- VSCode.

I didn't figure out how make it work on VSCode. However, on Intelij and by executing command `./gradlew test` it is working just fine.

Follow the steps bellow to learn how to test and debug on Intelij.

1) open the folder `tc_repository/TotalCrossSDK`;

2 ) Create a Gradle Run/Debug Configuration called test and add `test` to the field `Tasks`:
![image](https://user-images.githubusercontent.com/4422007/94197212-d7a44e00-fe8b-11ea-8bb7-937fa24631e9.png)

3) Click on the play button to run the tests;

4) You can also debug testing by clicking on the bug button near the play button:



