### PR TITLE
build: update appdirs to avoid bug on Windows

### DIFF
--- a/TotalCrossSDK/build.gradle
+++ b/TotalCrossSDK/build.gradle
@@ -99,7 +99,7 @@ dependencies {
     compile group: 'org.ow2.asm', name: 'asm-tree', version: '5.2'
 
     // https://mvnrepository.com/artifact/net.harawata/appdirs
-    compile group: 'net.harawata', name: 'appdirs', version: '1.0.0'
+    compile group: 'net.harawata', name: 'appdirs', version: '1.2.0'
 	// https://mvnrepository.com/artifact/net.java.dev.jna/jna-platform
 	runtime group: 'net.java.dev.jna', name: 'jna-platform', version: '4.2.2'
 	


### PR DESCRIPTION
update appdirs library from 1.0.0 to 1.2.0 to avoid the
following bug:

https://github.com/harawata/appdirs/issues/2

```
Exception in thread "Thread-0" java.lang.NoClassDefFoundError: com/sun/jna/platform/win32/Shell32    
        at net.harawata.appdirs.impl.ShellFolderResolver.resolveFolder(ShellFolderResolver.java:38)  
        at net.harawata.appdirs.impl.WindowsAppDirs.getLocalAppData(WindowsAppDirs.java:71)
        at net.harawata.appdirs.impl.WindowsAppDirs.getUserDataDir(WindowsAppDirs.java:33)
        at net.harawata.appdirs.impl.WindowsAppDirs.getUserConfigDir(WindowsAppDirs.java:40)
        at net.harawata.appdirs.AppDirs.getUserConfigDir(AppDirs.java:36)
        at tc.tools.AnonymousUserData.<clinit>(AnonymousUserData.java:43)
        at totalcross.Launcher.lambda$parseArguments$0(Launcher.java:471)
        at totalcross.Launcher$$Lambda$1.run(Launcher.java)
        at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.ClassNotFoundException: com.sun.jna.platform.win32.Shell32
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)   
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
        ... 9 more
```