### PR TITLE
Topic/build android with docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ build/
 TotalCrossVM/android/src/main/libs/armeabi/
 TotalCrossVM/android/.idea
 TotalCrossVM/android/app/src/main/assets/tcfiles\.zip
+TotalCrossVM/android/app/.cxx

--- a/TotalCrossVM/android/app/build.gradle
+++ b/TotalCrossVM/android/app/build.gradle
@@ -15,6 +15,7 @@ def buildType // stores build type, debug or release
 
 android {
     compileSdkVersion 28
+    ndkVersion "21.0.6113669"
     compileOptions {
     	// compile with Java 8 to allow using try-with-resources without raising the API level to 19
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/TotalCrossVM/docker/android/cmake.sh
+++ b/TotalCrossVM/docker/android/cmake.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+BASEDIR=$(dirname $0)
+WORKDIR=$(pwd)
+
+mkdir -p ${WORKDIR}/.gradle
+
+# execute docker run
+docker run 
+    -v ${WORKDIR}/../../:/vm                                \
+    -v ${WORKDIR}/.gradle:/root/.gradlew                    \
+    -it fabernovel/android:api-28-gcloud-ndk-v1.2.0         \
+    bash -c "cd /vm/android && ./gradlew assembleDebug"

--- a/totalcross.code-workspace
+++ b/totalcross.code-workspace
@@ -1,0 +1,14 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {
+		"cmake.sourceDirectory": "${workspaceFolder}/TotalCrossVM",
+		"java.configuration.updateBuildConfiguration": "interactive",
+		"files.watcherExclude": {
+			"**/.gradle/**": true
+		}
+	}
+}


### PR DESCRIPTION
## Description:
NDK version required for building is now 21.0.6113669.
Adds a script for building android using a container.

## Motivation and Context:
Provides a common environment for building for android.