### PR TITLE
bugfix #124: no upscaling of font, fixing memory consumption

### DIFF
--- a/TotalCrossSDK/src/main/java/totalcross/ui/FloatingLabel.java
+++ b/TotalCrossSDK/src/main/java/totalcross/ui/FloatingLabel.java
@@ -226,8 +226,16 @@ public class FloatingLabel<T extends Control & HasValue<?>> {
 	}
 
 	private void fullStep() {
-		// Label Font size Animation
-		fcap = fcap.adjustedBy(isExpanded ? captionFontSmall.size - target.getFont().size : target.getFont().size - captionFontSmall.size);
+        // Label Font size Animation
+        if (fcap.size != captionAnimationFontTarget.size) {
+            int delta = isExpanded ? captionFontSmall.size - target.getFont().size : target.getFont().size - captionFontSmall.size;
+            int newSize = delta + fcap.size;
+            if ( (!isExpanded && newSize > captionAnimationFontTarget.size) || (isExpanded && newSize < captionAnimationFontTarget.size)) {
+                delta = captionAnimationFontTarget.size - fcap.size;
+            }
+            fcap = fcap.adjustedBy(delta);
+        }
+
 		// Label Position Animation
 		if (target instanceof OutlinedEdit) {
 			xcap = !isExpanded ? xcap0 : topX;


### PR DESCRIPTION
## Description:

There was a memory aggression, when using FloatingLabel. A runaway argument preventing proper animation, which lead to the font to grow forever. This patch bounds the size of the font used and prevents from this memory leak.

### Related Issue:
Fix issue #124 

## Benefited Devices:
 - All devices

## How Has This Been Tested?
- Used the DashBoard sample and the simulator
- applied on master version

## Tested Devices:
 - Device: Mac
 - OS: macOS 10.15.5