### PR TITLE
image: using lockChanges now correctly prevents texture recreation

### DIFF
--- a/TotalCrossVM/src/nm/ui/GraphicsPrimitives_c.h
+++ b/TotalCrossVM/src/nm/ui/GraphicsPrimitives_c.h
@@ -407,16 +407,15 @@ end:
 static void drawSurface(Context currentContext, TCObject dstSurf, TCObject srcSurf, int32 srcX, int32 srcY, int32 w, int32 h,
                         int32 dstX, int32 dstY, int32 doClip)
 {
-    if (Surface_isImage(srcSurf))
-    {
-        TCObject pixelsObj = Image_pixels(srcSurf);
-        Pixel *pixels = (Pixel *)ARRAYOBJ_START(pixelsObj);
-        int32 width = Image_width(srcSurf);
-        int32 height = Image_height(srcSurf);
+    if (Surface_isImage(srcSurf)) {
         int32 id = Image_textureId(srcSurf);
-
-        Image_textureId(srcSurf) = skia_makeBitmap(id, pixels, width, height);
-
+        if (Image_changed(srcSurf) || id == -1) {
+            TCObject pixelsObj = Image_pixels(srcSurf);
+            Pixel *pixels = (Pixel *)ARRAYOBJ_START(pixelsObj);
+            int32 width = Image_width(srcSurf);
+            int32 height = Image_height(srcSurf);
+            Image_textureId(srcSurf) = skia_makeBitmap(id, pixels, width, height);
+        }
         dstX += Graphics_transX(dstSurf);
         dstY += Graphics_transY(dstSurf);
         skia_setClip(Get_Clip(dstSurf));

--- a/TotalCrossVM/src/nm/ui/image_Image.c
+++ b/TotalCrossVM/src/nm/ui/image_Image.c
@@ -157,16 +157,19 @@ TC_API void tuiI_applyChanges(NMParams p) // totalcross/ui/image/Image native pu
    applyChanges(p->currentContext,thisObj);
 #endif 
 #else
-      TCObject img = p->obj[0];
-
-      int32 frameCount = Image_frameCount(img);
-      TCObject pixelsObj = frameCount == 1 ? Image_pixels(img) : Image_pixelsOfAllFrames(img);
-      Pixel *pixels = (Pixel *)ARRAYOBJ_START(pixelsObj);
-      int32 width = (Image_frameCount(img) > 1) ? Image_widthOfAllFrames(img) : Image_width(img);
+   TCObject img = p->obj[0];
+   int32 frameCount = Image_frameCount(img);
+   TCObject pixelsObj = frameCount == 1 ? Image_pixels(img) : Image_pixelsOfAllFrames(img);
+   
+   if (pixelsObj != NULL) {
+      int32 width = (frameCount > 1) ? Image_widthOfAllFrames(img) : Image_width(img);
       int32 height = Image_height(img);
       int32 id = Image_textureId(img);
+      Pixel *pixels = (Pixel *)ARRAYOBJ_START(pixelsObj);
 
       Image_textureId(img) = skia_makeBitmap(id, pixels, width, height);
+   }
+   Image_changed(img) = false;
 #endif
 }
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description:
fixes lockChanges, by changing applyChanges and drawSurface to use
the changed field to avoid texture recreation

### Related Issue:
#182

## Benefited Devices:
Platforms that use Skia

## How Has This Been Tested?
Tested on Linux devices - should have no side effects.
