### PR TITLE
bugfix: fixing issue #184

### DIFF
--- a/TotalCrossSDK/src/main/java/totalcross/ui/dialog/keyboard/AlphabetKeyboard.java
+++ b/TotalCrossSDK/src/main/java/totalcross/ui/dialog/keyboard/AlphabetKeyboard.java
@@ -190,7 +190,8 @@ public class AlphabetKeyboard extends Container {
     button.setForeColor(FORE_COLOR);
     button.setFont(font);
     button.setBackColor(Color.getRGB(233, 233, 235));
-    button.effect = null;
+    // find a better way to disable effects, this method produces double pen_up events
+    // button.effect = null;
   }
 
   public void changeCase(boolean toUpperCase) {


### PR DESCRIPTION
## Description:
Fix the double PEN_UP issue on keyboard. The problem was with the ripple effect; when the effect was  forcibly removed, the keyboard produced double events.
Reintroduction of the ripple effect solves the issue but we might need to find a way to safely disable it, if on low end devices this is a problem

### Related Issue:
Issue #184 

## Benefited Devices:
 - Any device that has onscreen keyboard

## How Has This Been Tested?
 - On the emulator