### PR TITLE
build: make libtcvm compatible with glibc 2.16+ (previously 2.27+)

### DIFF
--- a/TotalCrossVM/CMakeLists.txt
+++ b/TotalCrossVM/CMakeLists.txt
@@ -611,6 +611,7 @@ else()
   target_link_libraries(tcvm ${SKIA_LIBRARIES} pthread stdc++)
   if(NOT APPLE AND UNIX)
     target_link_libraries(tcvm fontconfig)
+    target_link_libraries(tcvm -Wl,--wrap=log2f,--wrap=powf,--wrap=expf,--wrap=exp2f) # Avoid glibc dependencies
   endif(NOT APPLE AND UNIX)
 endif(DEFINED ANDROID_ABI)
 

--- a/TotalCrossVM/src/nm/io/device/gpiod/posix/gpiodLib.c
+++ b/TotalCrossVM/src/nm/io/device/gpiod/posix/gpiodLib.c
@@ -10,6 +10,11 @@
 #include <dlfcn.h>
 #include <glob.h>
 
+#if !defined APPLE && !defined ANDROID && defined linux
+// Avoid dependency on glibc 2.27
+__asm__(".symver glob,glob@GLIBC_2.4");
+#endif
+
 static void* gpiodLib = NULL;
 
 _gpiod_chip_open_by_numberProc _gpiod_chip_open_by_number;

--- a/TotalCrossVM/src/nm/ui/android/skia.cpp
+++ b/TotalCrossVM/src/nm/ui/android/skia.cpp
@@ -66,6 +66,34 @@
 #include <map>
 
 
+extern "C" {
+#if !defined APPLE && !defined ANDROID && defined linux
+// Avoid dependency on glibc 2.27
+// These functions are used by Skia .a file, so we have to define a wrapper.
+// https://stackoverflow.com/questions/8823267/linking-against-older-symbol-version-in-a-so-file
+__asm__(".symver log2f,log2f@GLIBC_2.4");
+float __wrap_log2f(float x) {
+  return log2f(x);
+}
+
+__asm__(".symver powf,powf@GLIBC_2.4");
+float __wrap_powf(float x, float y) {
+  return powf(x, y);
+}
+
+__asm__(".symver expf,expf@GLIBC_2.4");
+float __wrap_expf(float x) {
+  return expf(x);
+}
+
+__asm__(".symver exp2f,exp2f@GLIBC_2.4");
+float __wrap_exp2f(float x) {
+  return exp2f(x);
+}
+#endif
+}
+
+
 #define SKIA_DEBUG
 // #define SKIA_TRACE
 


### PR DESCRIPTION
Many build tools and toolchains use newer versions of GLIBC. This was causing problems on some systems including the Raspberry Pi.