### PR TITLE
feature: bette support jetbrain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,10 +57,12 @@ build/
 # Git
 *.orig
 
+# JetBrain's IDEs
+TotalCrossVM/android/.idea
+TotalCrossSDK/.idea
 
 #Android
 .externalNativeBuild
 TotalCrossVM/android/src/main/libs/armeabi/
-TotalCrossVM/android/.idea
 TotalCrossVM/android/app/src/main/assets/tcfiles\.zip
 TotalCrossVM/android/app/.cxx


### PR DESCRIPTION
## Description:
Better support JetBrain families of IDEs

## Motivation and Context:
TotalCrossSDK under JetBrain's IDEs left some garbage which needs to be ignored

