### PR TITLE
cicd: fix cyclical dependency for PRs (commit checker)

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -1,5 +1,5 @@
 name: 'Commit Message Check'
-on: [push]
+on: [pull_request]
 
 jobs:
   check-commit-message:


### PR DESCRIPTION
Fix the issue described in #238. Workflow overlooked in previous commit. Now commits will only be analyzed on pull requests (it makes more sense).