### PR TITLE
build: fix glibc build error

### DIFF
--- a/TotalCrossVM/CMakeLists.txt
+++ b/TotalCrossVM/CMakeLists.txt
@@ -611,7 +611,9 @@ else()
   target_link_libraries(tcvm ${SKIA_LIBRARIES} pthread stdc++)
   if(NOT APPLE AND UNIX)
     target_link_libraries(tcvm fontconfig)
-    target_link_libraries(tcvm -Wl,--wrap=log2f,--wrap=powf,--wrap=expf,--wrap=exp2f) # Avoid glibc dependencies
+    if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
+      target_link_libraries(tcvm -Wl,--wrap=log2f,--wrap=powf,--wrap=expf,--wrap=exp2f) # Avoid glibc dependencies
+    endif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
   endif(NOT APPLE AND UNIX)
 endif(DEFINED ANDROID_ABI)
 

--- a/TotalCrossVM/src/nm/io/device/gpiod/posix/gpiodLib.c
+++ b/TotalCrossVM/src/nm/io/device/gpiod/posix/gpiodLib.c
@@ -10,7 +10,7 @@
 #include <dlfcn.h>
 #include <glob.h>
 
-#if !defined APPLE && !defined ANDROID && defined linux
+#if !defined APPLE && !defined ANDROID && defined linux && defined __arm__ && !defined __aarch64__
 // Avoid dependency on glibc 2.27
 __asm__(".symver glob,glob@GLIBC_2.4");
 #endif

--- a/TotalCrossVM/src/nm/ui/android/skia.cpp
+++ b/TotalCrossVM/src/nm/ui/android/skia.cpp
@@ -68,7 +68,7 @@
 
 
 extern "C" {
-#if !defined APPLE && !defined ANDROID && defined linux
+#if !defined APPLE && !defined ANDROID && defined linux && defined __arm__ && !defined __aarch64__
 // Avoid dependency on glibc 2.27
 // These functions are used by Skia .a file, so we have to define a wrapper.
 // https://stackoverflow.com/questions/8823267/linking-against-older-symbol-version-in-a-so-file


### PR DESCRIPTION
Solve error that occurs after new skia version

```log
libtcvm.so: 
  No symbol version section for versioned symbol `expf@GLIBC_2.4'
```