### PR TITLE
Documentation/move build documentation to repository

### DIFF
--- a/TotalCrossVM/android/README.MD
+++ b/TotalCrossVM/android/README.MD
@@ -1,0 +1,51 @@
+# Compiling TotalCross Virtual Machine for Android
+
+First things first, in order to compile a virtual machine for Android, one need to install the following requirements on your machine:
+
+- [Android SDK 28](https://www.androidauthority.com/how-to-install-android-sdk-software-development-kit-21137/) ;
+- [Android NDK 17](https://developer.android.com/ndk/downloads/older_releases) ;
+- [CMake](https://cmake.org/) 3.5.1 or later installed (if you are building from the target platform);
+
+Once you have all requirements installed will be able to build a TotalCross Virtual Machine and test.
+
+## Building step
+
+Basically, to start building TotalCross VM and SDK for Android for testing, one just need two key elements: i) the `dist/` folder which contains our _.apk_; and ii) the `etc/` folder which contains our certificates.
+
+### ANDROID_HOME
+
+You must have the environment variable `ANDROID_HOME` pointed to the path that has the Android SDK folder with the following structure.
+
+```
+.
+├── build-tools  
+├── cmake  
+├── emulator  
+├── licenses  
+├── ndk  
+├── ndk-bundle  
+├── patcher  
+├── platforms  
+├── platform-tools  
+└── sources
+````
+> It's very important that you have the `ndk-bundle/` folder. See more about [NDK](https://developer.android.com/studio/projects/install-ndk).
+
+## Command-line
+You just need to run the following command line inside `TotalCrossVM/android/` folder:
+```bash
+./gradlew assembleDebug copyApk -x test
+```
+The result should be something like:
+```bash
+.
+├── LitebaseSDK/
+│   └── output/
+│       └── debug/
+│           └── TotalCrossSDK/
+├── TotalCrossSDK/
+├── TotalCrossVM/ 
+├── LICENSE
+└── README.md
+```
+Copy the content of this folder must be pasted to the root of a valid SDK.

--- a/TotalCrossVM/docker/README.MD
+++ b/TotalCrossVM/docker/README.MD
@@ -1,0 +1,87 @@
+# Compiling and Testing TotalCross Virtual Machine for Linux/Linux ARM
+
+First things first, in order to compile a virtual machine for Linux or Linux ARM, one need to install the following requirements on your machine:
+
+- [Docker CE](https://docs.docker.com/get-docker/) ;
+- [CMake](https://cmake.org/) 3.5.1 or later installed (if you are building from the target platform);
+
+Once you have all requirements installed will be able to build a TotalCross Virtual Machine and test.
+
+## Building the VM
+
+Basically, to start building TotalCross VM for Linux and Linux ARM for testing, one just need two key elements: i) the `libtcvm.so` which represents our VM; and ii) the executable `Launcher` which loads the VM library and points the main tcz file of your application. 
+
+### Using docker to build
+
+The Dockerfiles and shell scripts required to build TotalCross for Linux take place on `TotalCrossVM/docker`, as you can see bellow:
+
+```
+TotalcrossVM/docker
+├── amd64
+│   ├── Dockerfile
+│   ├── build
+│   ├── build-docker.sh
+│   ├── build.bat
+│   └── cmake.sh
+└── arm32v7
+    ├── Dockerfile
+    ├── build
+    ├── build-docker.sh
+    ├── build.bat
+    └── cmake.sh
+````
+
+So, go the folder of the target architecture (`cd TotalCrossVM/docker/${arch}`) and execute the following steps:
+
+- Build the docker image: `./build-docker.sh`;
+- Execute the build file that uses the image above: `./cmake.sh`;
+
+the build folder will take place at the same folder with the following structure:
+```
+build
+├── CMakeCache.txt
+├── CMakeFiles
+├── Launcher
+├── build.ninja
+├── cmake_install.cmake
+├── libtcvm.so
+└── rules.ninja
+```
+The Launcher
+
+## Testing the VM
+
+To test the TotalCross Linux VM, one need to:
+
+- copy Launcher and `libtcvm.so` to a folder inside your target device, i.e, raspberry pi;
+- choose a TotalCross project to generate and copy `tcz` files to the same folder on your target device;
+- execute Launcher
+
+To do the first step, let's clone our [TCSample repo](https://github.com/TotalCross/tc-sample). Edit it's pom.xml to only generating the TotalCross Zip Files (tcz) by deleting `platforms` tag (lines ~ 59-63).
+```xml
+- <platforms>
+-    <platform>-android</platform>
+-    <platform>-linux</platform>
+-    <platform>-linux_arm</platform>
+- </platforms>
+```
+Run `mvn package` and the tcz files will take place at `target` folder.
+
+```
+target
+└── install
+    ├── linux
+    └── linux_arm
+```
+The final folder on your target device will have the follow structure:
+```
+.
+├── Launcher
+├── libtcvm.so
+├── Material_Icons.tcz
+├── TCBase.tcz
+├── TCFont.tcz
+├── TCSample.tcz
+└── TCUI.tcz
+```
+Execute the following command to test: `./Launcher TCSample`

--- a/TotalCrossVM/xcode/README.MD
+++ b/TotalCrossVM/xcode/README.MD
@@ -1,0 +1,75 @@
+# Compiling and Testing TotalCross Virtual Machine for iOS
+
+First things first, in order to compile a virtual machine for iOS, one need to install the following requirements on your machine:
+
+- Mac OS X;
+- [Xcode](https://apps.apple.com/br/app/xcode/id497799835?mt=12) latest version;
+- [Cmake](https://cmake.org/) 3.5.1 or later installed;
+- [Cocoapods](https://guides.cocoapods.org/using/getting-started.html#getting-started) 1.10.0.beta.1 or later:
+  - Until the moment I was writing this markdown, one could only install the mentioned version by using the following command:
+    - `sudo gem install cocoapods --pre`
+
+Once you have all requirements installed will be able to build a TotalCross Virtual Machine, test and debug it on XCode.
+
+## Building the VM
+
+The ios bundle files are located on `TotalCrossVM/xcode` and has the following struct:
+
+```
+├── Launch\ Screen.storyboard
+├── Podfile
+├── README.md
+├── TotalCross
+├── TotalCross.xcodeproj
+├── TotalCross.xcworkspace
+├── TCVM.xcodeproj (need to be generated)
+└── tcvm
+```
+
+In order to be able to start a change on the iOS VM, we need to generate the xcode project that describes our VM (TCVM.xcodeproj). Then use Cocopods to install the VM depedences (Frameworks, dynamic and static libraries). To do so, execute the following commands on you terminal:
+
+- go to the project folder: `cd TotalCrossVM/xcode`;
+- generate TCVM project: `cmake ../ -GXcode`;
+- install project dependences: `pod install`;
+- open TotalCross workspace on xcode: `open TotalCross.xcworkspace`.
+
+Now we are able to develop new features and fix some bugs and Test on your Xcode.
+
+## Testing the VM
+
+The follow picture shows the project structure open on Xcode:
+
+![TotalCross iOS project structure](https://i.imgur.com/E5r4dMA.png)
+
+To test the TotalCross iOS VM, one need to:
+
+- choose a TotalCross project to generate and copy `tcz` files;
+- plug an iOS Device (iPhone or iPad) on one of your machine's USB ports.
+
+To do the first step, let's clone our [TCSample repo](https://github.com/TotalCross/tc-sample). Edit it's pom.xml to only generating the TotalCross Zip Files (tcz) by deleting `platforms` tag (lines ~ 59-63).
+```xml
+- <platforms>
+-    <platform>-android</platform>
+-    <platform>-linux</platform>
+-    <platform>-linux_arm</platform>
+- </platforms>
+```
+Run `mvn package` and the tcz files will take place at `target` folder.
+
+```
+target
+    ├── Material_Icons.tcz
+    ├── TCBase.tcz
+    ├── TCFont.tcz
+    ├── TCSample.tcz
+    └── TCUI.tcz
+```
+On your Xcode IDE, right click on `TotalCross` and choose `Add Files to "TotalCross"...`. Choose all `.tcz` files at the target folder of your choosen TotalCross project.
+
+Open the TotalCross project at your Xcode Project Nagigator click on the files `TotalCross > AppDelegate.m`. At line ~ 39 replace `#define TCZNAME "TotalCross"` by the name of your TotalCross Application (in this case `TCSample`). So the resulting line will be `#define TCZNAME "TCSample"`.
+
+Plug your device and select it on the TotalCross active scheme (next to the play button). Next, click on the play button and your application will be running on your device.
+
+![Select your device on the active scheme](https://i.imgur.com/P9T6ZCM.png)
+
+> :warning: **if you have not paid for an [Apple Development Certificate](https://developer.apple.com/)**: this [thread](https://stackoverflow.com/questions/4952820/test-ios-app-on-device-without-apple-developer-program-or-jailbreak) on stackoverflow has a little discuss about how to test an application with no cost on XCode. 


### PR DESCRIPTION
## Description:
Move build documentation from GitHub's Wiki to appropriate folder inside the repository.

## Related issue:
Is related but does not close issue #170.

## Motivation and Context:
This change brings the necessary information to build the TotalCross VM on a different platform to the corresponding platform folder inside the repository. Previously it would be necessary to access the Wiki to read the build documentation. This was done for iOS, Android and Linux as it was already done for Windows.

## Benefited Devices:
 - OS: iOS, Android and Linux

## How Has This Been Tested?
 - The documentations was copied as is from the Wiki with no alterations.

