### PR TITLE
cicd: copy *.jar files because we need them to release versions

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -108,6 +108,7 @@ jobs:
       working-directory: TotalCrossSDK
       run: |
         ./gradlew dist -x test --stacktrace
+        cp build/libs/totalcross-sdk-* dist
     
     - name: Build Android
       working-directory: TotalCrossVM/android


### PR DESCRIPTION
Some files still had to be obtained, and that didn't make any sense. Closes #235.