### PR TITLE
cicd: allow manual trigger for package workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,6 +1,7 @@
 name: Packages `totalcross`
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 1 * * 1"
 


### PR DESCRIPTION
Sometimes, we need to build everything without having to merge commits. Just add button to start workflow manually.