### PR TITLE
deploy: add Linux ARM 64 to linux_arm platform deploy

### DIFF
--- a/TotalCrossSDK/src/main/java/tc/Deploy.java
+++ b/TotalCrossSDK/src/main/java/tc/Deploy.java
@@ -22,6 +22,7 @@ import tc.tools.deployer.Deployer4Linux;
 import tc.tools.deployer.Deployer4Win32;
 import tc.tools.deployer.Deployer4WinCE;
 import tc.tools.deployer.Deployer4LinuxArm;
+import tc.tools.deployer.Deployer4LinuxArm64;
 import tc.tools.deployer.DeployerException;
 import tc.tools.deployer.Utils;
 import totalcross.util.ElementNotFoundException;
@@ -105,6 +106,7 @@ public class Deploy {
         }
           if ((options & BUILD_LINUX_ARM) != 0) {
               new Deployer4LinuxArm();
+              new Deployer4LinuxArm64();
           }
         if ((options & BUILD_APPLET) != 0) {
           new Deployer4Applet();

--- a/TotalCrossSDK/src/main/java/tc/tools/deployer/Deployer4LinuxArm64.java
+++ b/TotalCrossSDK/src/main/java/tc/tools/deployer/Deployer4LinuxArm64.java
@@ -1,0 +1,94 @@
+// Copyright (C) 2020 TotalCross Global Mobile Platform Ltda.
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+package tc.tools.deployer;
+
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+
+import totalcross.io.File;
+import totalcross.sys.Vm;
+import totalcross.util.Hashtable;
+import totalcross.util.Vector;
+
+public class Deployer4LinuxArm64 {
+  private static byte[] versionBytes = { 52, 0, 36, 0 };
+
+  public Deployer4LinuxArm64() throws Exception {
+    String linuxArguments = DeploySettings.commandLine; // the name of the tcz will be the same as the executable
+    byte[] args = linuxArguments.trim().getBytes();
+    if (args.length > DeploySettings.defaultArgument.length) {
+      throw new IllegalArgumentException("Error: command line for Linux too long. It has " + args.length
+          + ", while the maximum allowed is " + DeploySettings.defaultArgument.length);
+    }
+
+    String targetDir = DeploySettings.targetDir + "linux_arm64/";
+    // create the output folder
+    File f = new File(targetDir);
+    if (!f.exists()) {
+      f.createDir();
+    }
+    // copy the tcz file to there
+    Utils.copyTCZFile(targetDir);
+    // guich@tc123_22: process the pkg file
+    Hashtable ht = new Hashtable(13);
+    Utils.processInstallFile("linux_arm64.pkg", ht);
+    Vector vLocals = (Vector) ht.get("[L]");
+    if (vLocals != null) {
+      Utils.preprocessPKG(vLocals, true);
+      for (int i = vLocals.size(); --i >= 0;) {
+        Utils.copyEntry((String) vLocals.items[i], targetDir);
+      }
+    }
+    Vector vGlobals = (Vector) ht.get("[G]");
+    if (vGlobals != null) {
+      Utils.preprocessPKG(vGlobals, true);
+      for (int i = vGlobals.size(); --i >= 0;) {
+        Utils.copyEntry((String) vGlobals.items[i], targetDir);
+      }
+    }
+
+    if (DeploySettings.mainClassName != null) {
+      // copy the launcher for linux to there
+      byte[] buf = Utils.findAndLoadFile(DeploySettings.etcDir + "launchers/linux_arm64/Launcher", false);
+      if (buf == null) {
+        throw new DeployerException("File linux_arm64/Launcher not found!");
+      }
+
+      // now find the offset of the argument
+      int ofs = Utils.indexOf(buf, DeploySettings.defaultArgument, false);
+      if (ofs < 0) {
+        throw new DeployerException("Can't find offset for command line on linux!");
+      }
+      Vm.arrayCopy(args, 0, buf, ofs, args.length); // no "write taking care" needed
+      buf[ofs + args.length] = 0;
+
+      // find the offset of the version
+      ofs = Utils.indexOf(buf, versionBytes, false);
+      if (ofs > 0) // found version offset?
+      {
+        buf[ofs] = (byte) DeploySettings.getAppVersionHi();
+        buf[ofs + 2] = (byte) DeploySettings.getAppVersionLo();
+      }
+
+      String out = targetDir + DeploySettings.filePrefix;
+      File fout = new File(out, File.CREATE_EMPTY);
+      fout.writeBytes(buf, 0, buf.length);
+      fout.close();
+      // set the executable flag
+      java.io.File ff = new java.io.File(out);
+      ff.setExecutable(true, false);
+        
+        // TCBase & other default tczs
+        List<java.io.File> defaultTczs = DeploySettings.getDefaultTczs();
+        for (java.io.File file : defaultTczs) {
+            FileUtils.copyFileToDirectory(file, new java.io.File(targetDir));
+        }
+        FileUtils.copyFileToDirectory(new java.io.File(DeploySettings.folderTotalCross3DistVM + "/linux_arm64/libtcvm.so"),
+                                      new java.io.File(targetDir));
+
+    }
+    System.out.println("... Files written to folder " + targetDir);
+  }
+}


### PR DESCRIPTION
Adding Linux ARM 64 to linux_arm platform deploy, this will deploy both linux_arm and linux_arm64 when deploying for linux_arm.