### PR TITLE
cicd: change last artifacts workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Download last artifact
         uses: dawidd6/action-download-artifact@v2
         with:
-          workflow: main.yml
+          workflow: package.yml
           workflow_conclusion: success
           name: TotalCross
           path: ../TotalCross


### PR DESCRIPTION
The release workflow would generate errors because the workflow file is wrong.