### PR TITLE
sdl: fixes segfault during SDL initialization

### DIFF
--- a/TotalCrossVM/src/init/tcsdl.cpp
+++ b/TotalCrossVM/src/init/tcsdl.cpp
@@ -34,20 +34,8 @@ bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen) {
 	std::cout << "Testing video drivers..." << '\n';
 	std::vector< bool > drivers(SDL_GetNumVideoDrivers());
 
-	for (int i = 0; i < drivers.size(); ++i) {
-		drivers[i] = (0 == SDL_VideoInit(SDL_GetVideoDriver(i)));
-		SDL_VideoQuit();
-	}
-
 	std::cout << "SDL_VIDEODRIVER available:";
 	for (int i = 0; i < drivers.size(); ++i) {
-		std::cout << " " << SDL_GetVideoDriver(i);
-	}
-	std::cout << '\n';
-
-	std::cout << "SDL_VIDEODRIVER usable   :";
-	for (int i = 0; i < drivers.size(); ++i) {
-      if( !drivers[ i ] ) continue;
 		std::cout << " " << SDL_GetVideoDriver(i);
 	}
 	std::cout << '\n';


### PR DESCRIPTION
Using SDL_VideoInit and SDL_VideoQuit just to test the available video
drivers causes a segfault during SDL_Init on some systems.

fixes #263 and possibly #265 as well