### PR TITLE
objects: fix to properly call Objects4D when using jata.util.Objects

### DIFF
--- a/TotalCrossSDK/src/main/java/jdkcompat/util/Objects4D.java
+++ b/TotalCrossSDK/src/main/java/jdkcompat/util/Objects4D.java
@@ -1,12 +1,12 @@
-package totalcross.util;
+package jdkcompat.util;
 
 import java.util.Comparator;
 import java.util.function.Supplier;
 
 import java.util.Arrays;
 
-public final class Objects {
-	private Objects() {}
+public final class Objects4D {
+	private Objects4D() {}
 
 	public static <T> int compare(T a, T b, Comparator<? super T> c) {
 		return a == b? 0: c.compare(a, b);


### PR DESCRIPTION
Changing Objects to Objects4D and change packate to jdkcompat.util instead of totalcross.util to fix on bug when using java.util.Objects. Related to #276 