### PR TITLE
sdl: fixes screen not updating after the window size is changed

### DIFF
--- a/TotalCrossVM/src/event/linux/event_c.h
+++ b/TotalCrossVM/src/event/linux/event_c.h
@@ -187,10 +187,11 @@ void privatePumpEvent(Context currentContext)
    if(SDL_PollEvent(&event)) {
       if(event.type == SDL_WINDOWEVENT) {
          if(event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED) {
-            int width, height;
-            TCSDL_GetWindowSize(&screen, &width, &height);
-            // screenChange(mainContext, width, height,0,0,false);
-            printf("Exe log: size changed!\n");
+            int width = event.window.data1;
+            int height = event.window.data2;
+            // SDL_Surface must be refreshed after a SDL_WINDOWEVENT_SIZE_CHANGED event
+            TCSDL_WindowSizeChanged(&screen, width, height);
+            // screenChange(mainContext, width, height, 0, 0, false);
          }
          TCSDL_Present();
       }

--- a/TotalCrossVM/src/init/tcsdl.cpp
+++ b/TotalCrossVM/src/init/tcsdl.cpp
@@ -284,3 +284,9 @@ void TCSDL_Destroy(ScreenSurface screen) {
 void TCSDL_GetWindowSize(ScreenSurface screen, int32* width, int32* height) {
 	SDL_GetWindowSize(SCREEN_EX(screen)->window, width, height);
 }
+
+void TCSDL_WindowSizeChanged(ScreenSurface screen, int32 width, int32 height) {
+	SCREEN_EX(screen)->surface = surface = SDL_GetWindowSurface(SCREEN_EX(screen)->window);
+	screen->screenW = width;
+	screen->screenH = height;
+}

--- a/TotalCrossVM/src/init/tcsdl.h
+++ b/TotalCrossVM/src/init/tcsdl.h
@@ -23,6 +23,7 @@ extern "C" {
     void TCSDL_Present();
     void TCSDL_Destroy(ScreenSurface screen);
     void TCSDL_GetWindowSize(ScreenSurface screen, int32* width, int32* height);
+    void TCSDL_WindowSizeChanged(ScreenSurface screen, int32 width, int32 height);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The SDL_Surface structure may be invalidated after a window
size changed event. On most devices the surface is still valid
after this event if the actual width and height values aren't changed.
(I have no idea why this event is raised if the actual values are the
same, but this seems to happen at least once after the initialization).

It's important to notice that the actual pointer to the screen pixels
referenced by surface->pixels DOES NOT change when the surface
is refreshed. So it's safe for us to keep using it directly with Skia.

To make sure it works for any device, SDL_GetWindowSurface
must be executed after this event to make sure the internal surface
structure kept by window is refreshed, even if we don't actually
use the new surface anywhere after. ¯\_(ツ)_/¯