### PR TITLE
Feature: option to build tcvm without Skia

### DIFF
--- a/TotalCrossVM/CMakeLists.txt
+++ b/TotalCrossVM/CMakeLists.txt
@@ -16,6 +16,11 @@ if(NOT DEFINED BUILD_SHARED_LIBS AND NOT DEFINED TCVM_SHARED)
   endif()
 endif()
 
+# Use skia
+if (NOT DEFINED USE_SKIA)
+  set(USE_SKIA ON)
+endif()
+
 if(TCVM_SHARED)
   add_library(tcvm SHARED)
 else()
@@ -34,10 +39,11 @@ IF (NOT (DEFINED ANDROID_ABI OR MSVC OR CMAKE_GENERATOR STREQUAL Xcode))
 ENDIF (NOT (DEFINED ANDROID_ABI OR MSVC OR CMAKE_GENERATOR STREQUAL Xcode))
 
 # Find Skia
-if(NOT MSVC)
+if(NOT MSVC AND USE_SKIA)
   find_package(Skia REQUIRED)
   include_directories(${SKIA_INCLUDE_DIRS})
-endif(NOT MSVC)
+  add_definitions(-DUSE_SKIA)
+endif(NOT MSVC AND USE_SKIA)
 
 set(TC_SRCDIR "${CMAKE_CURRENT_SOURCE_DIR}/src")
 set(LB_SRCDIR "${CMAKE_CURRENT_SOURCE_DIR}/src/litebase")

--- a/TotalCrossVM/src/nm/ui/GraphicsPrimitives.h
+++ b/TotalCrossVM/src/nm/ui/GraphicsPrimitives.h
@@ -10,7 +10,7 @@
 
 #include "tcclass.h"
 
-#if defined ANDROID || defined darwin || defined HEADLESS
+#if defined USE_SKIA && (defined ANDROID || defined darwin || defined HEADLESS)
 #include "android/skia.h"
 #endif
 

--- a/TotalCrossVM/src/nm/ui/PalmFont_c.h
+++ b/TotalCrossVM/src/nm/ui/PalmFont_c.h
@@ -715,7 +715,7 @@ UserFont loadUserFontFromFontObj(Context currentContext, TCObject fontObj, JChar
    }
 }
 
-#if defined ANDROID || defined darwin || defined HEADLESS
+#if defined USE_SKIA && (defined ANDROID || defined darwin || defined HEADLESS)
 #include "android/skia.h"
 
 int32 getJCharWidth(Context currentContext, TCObject fontObj, JChar ch) {

--- a/TotalCrossVM/src/nm/ui/font_Font.c
+++ b/TotalCrossVM/src/nm/ui/font_Font.c
@@ -7,7 +7,7 @@
 
 #include "tcvm.h"
 #include "PalmFont_c.h"
-#if defined ANDROID || defined darwin || defined HEADLESS
+#if defined USE_SKIA && (defined ANDROID || defined darwin || defined HEADLESS)
 #include "android/skia.h"
 #endif
 
@@ -37,6 +37,7 @@ TC_API void tufF_fontCreate(NMParams p) // totalcross/ui/font/Font native void f
    if(!(nameTTF[len-4] == '.' && nameTTF[len-3] == 't' && nameTTF[len-2] == 't' && nameTTF[len-1] == 'f')) {
       xstrcat(nameTTF, ".ttf");
    }
+
    int32 fontIdx = skia_getTypefaceIndex(nameTTF);
    if (fontIdx == -1) {
        if ((file = tczGetFile(nameTTF, false)) != null) {

--- a/TotalCrossVM/src/nm/ui/gfx_Graphics.c
+++ b/TotalCrossVM/src/nm/ui/gfx_Graphics.c
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "tcvm.h"
-#if defined ANDROID || defined darwin || defined HEADLESS
+#if defined USE_SKIA && (defined ANDROID || defined darwin || defined HEADLESS)
 #define Graphics_forePixel(o) (Graphics_foreColor(o) | 0xFF000000)
 #define Graphics_backPixel(o) (Graphics_backColor(o) | 0xFF000000)
 #else

--- a/TotalCrossVM/src/nm/ui/image_Image.c
+++ b/TotalCrossVM/src/nm/ui/image_Image.c
@@ -145,7 +145,7 @@ TC_API void tuiI_setTransparentColor_i(NMParams p) // totalcross/ui/image/Image 
    p->retO = thisObj;
 }
 
-#if defined ANDROID || defined darwin || defined HEADLESS
+#if defined USE_SKIA && (defined ANDROID || defined darwin || defined HEADLESS)
 #include "android/skia.h"
 #endif
 //////////////////////////////////////////////////////////////////////////

--- a/TotalCrossVM/src/nm/ui/linux/gfx_Graphics_c.h
+++ b/TotalCrossVM/src/nm/ui/linux/gfx_Graphics_c.h
@@ -12,7 +12,9 @@ void privateScreenChange(int32 w, int32 h)
 }
 
 #include "../../init/tcsdl.h"
+#ifdef USE_SKIA
 #include "../android/skia.h"
+#endif
 
 
 bool graphicsStartup(ScreenSurface screen, int16 appTczAttr)
@@ -63,7 +65,8 @@ bool graphicsStartup(ScreenSurface screen, int16 appTczAttr)
 
    screen->screenW = w;
    screen->screenH = h;
-
+#else
+   TCSDL_Init(screen, exeName, *(tcSettings.isFullScreenPtr));
 #endif
    return true;
 }
@@ -87,6 +90,8 @@ void graphicsUpdateScreen(Context currentContext, ScreenSurface screen) // scree
    bounds.x2 = currentContext->dirtyX2;
    bounds.y2 = currentContext->dirtyY2;
    SCREEN_EX(screen)->primary->Flip(SCREEN_EX(screen)->primary, &bounds, DSFLIP_ONSYNC);
+#else
+   TCSDL_UpdateTexture(screen->screenW, screen->screenH, screen->pitch, screen->pixels);
 #endif
 }
 


### PR DESCRIPTION
## Description:
New feature to build TCVM without Skia. 
It's possible to generate a very little final libtcvm (~3MB on Linux). 
It's also now possible to test the VM on OpenBSD.

## Motivation and Context:
Able to use TCVM on OpenBSD.

## Benefited Devices:
 - OS: OpenBSD 6.8

## Tested Devices:
 - OS: Linux Debian 10