### PR TITLE
Memoization

### DIFF
--- a/TotalCrossVM/src/tcvm/tcvm.c
+++ b/TotalCrossVM/src/tcvm/tcvm.c
@@ -642,6 +642,25 @@ noMoreParams:
                cp = class_->cp;
                method = newMethod;
                code = method->code;
+
+               if (xstrcmp(newMethod->name, "fibR") == 0) {
+                  int a = 0;
+                  a++;
+
+                  // if argument in hash, set reg64 & XSELECT
+
+                  switch (reg64[-(int32)method->v64Count]) {
+                     case 0:reg64[code->reg.reg] = 1; XSELECT(address,RETURN_reg64); 
+                     case 1:reg64[code->reg.reg] = 1; XSELECT(address,RETURN_reg64); 
+                     case 2:reg64[code->reg.reg] = 2; XSELECT(address,RETURN_reg64); 
+                     case 3:reg64[code->reg.reg] = 3; XSELECT(address,RETURN_reg64); 
+                     case 4:reg64[code->reg.reg] = 5; XSELECT(address,RETURN_reg64); 
+                     case 5:reg64[code->reg.reg] = 8; XSELECT(address,RETURN_reg64); 
+                     case 6:reg64[code->reg.reg] = 13; XSELECT(address,RETURN_reg64); 
+                     case 7:reg64[code->reg.reg] = 21; XSELECT(address,RETURN_reg64); 
+                     case 8:reg64[code->reg.reg] = 34; XSELECT(address,RETURN_reg64); 
+                  }
+               }
                NEXT_OP0
             }
             // no else here!
@@ -865,6 +884,10 @@ returnVoid:
          if (((int32)(context->callStack-context->callStackStart)) >= callStackMethodEnd)
          {
 resumePreviousMethod:
+            // if (fibR) {
+            //    // save argument -> result in hashmap
+            // }
+
             code = ((Code)context->callStack[-1]) + method->paramSkip; // now that retReg was used, its safe to skip over the parameters
             // pop the current method's stack frame
             context->regI  -= method->iCount;

--- a/TotalCrossVM/src/tcvm/tcvm.c
+++ b/TotalCrossVM/src/tcvm/tcvm.c
@@ -181,6 +181,8 @@ TC_API TValue executeMethod(Context context, Method method, ...)
    int32 hashName,hashParams;
    ThreadHandle thread;
 
+   printf("m: %s, %s\n", method->class_->name, method->name);
+
 #ifdef DIRECT_JUMP // use a direct jump if supported
    uint32 **address;
    uint32 **addrMtdParam;
@@ -502,6 +504,10 @@ mainLoop:
          {
             newMethod = mac->m;
 contCall:
+            if (xstrcmp(newMethod->name, "fibR") == 0) {
+               int a = 0;
+               a++;
+            }
             regI  = context->regI; // same of regI += method->iCount
             regO  = context->regO;
             reg64 = context->reg64;
@@ -586,6 +592,10 @@ cont:
                   if (--nparam == 0) // if no more parameters, continue. putting this here avoids another "if (nparam > 0)" after this block ends.
                      goto noMoreParams;
                }
+            if (xstrcmp(newMethod->name, "fibR") == 0) {
+               int a = 0;
+               a++;
+            }
                // The method's parameters are passed in the registers, in sequence.
                params = (uint8*)(code+1);
                for (; nparam-- > 0; params++, regs++)
@@ -622,6 +632,9 @@ cont:
                }
             }
 noMoreParams:
+
+                  // OPCODE(RETURN_reg64) context->callStack -= 2; /*newMethod = (Method)context->callStack[0]; if (newMethod->flags.isSynchronized) unlockMutex(newMethod->flags.isStatic? (size_t)newMethod->class_ : (size_t)regO[-method->oCount]); */ if (((int32)(context->callStack-context->callStackStart)) >= callStackMethodEnd) {reg64      [((Code)context->callStack[-1])->mtd.retOr1stParam - ((Method)context->callStack[-2])->v64Count] = reg64[code->reg.reg];      goto resumePreviousMethod;} else {returnedValue.asInt64  = reg64[code->reg.reg];     goto finishMethod;}
+
             if (!newMethod->flags.isNative)
             {
                // replace current variables by the new ones
@@ -748,6 +761,11 @@ notYetLinked:
             hashName = cp->hashNames[code->mtd.sym];
             hashParams = cp->hashParams[code->mtd.sym];
             methodName = cp->mtdfld[sym[1]];
+            printf("m2: %s, %s\n", className, methodName);
+            if (xstrcmp(methodName, "fibR") == 0) {
+               int a = 10;
+               a++;
+            }
             if (code->op.op == CALL_virtual)
             {
                c = OBJ_CLASS(regO[code->mtd.this_]); // search for the method starting on the class pointed by "this"

--- a/TotalCrossVM/src/util/posix/debug_c.h
+++ b/TotalCrossVM/src/util/posix/debug_c.h
@@ -54,6 +54,8 @@ static bool privateDebug(char* str)
          fflush(fdebug);
          fsync(fileno(fdebug));
       }
+   } else {
+      printf("%s\n", str);
    }
     return err;
 }


### PR DESCRIPTION
> In computing, memoization or memoisation is an optimization technique used primarily to speed up computer programs by storing the results of expensive function calls and returning the cached result when the same inputs occur again.
> **Wikipedia**

- [x] Hard coded results for fibR inside executeMethod
- [ ] Replace the hard coded results with an actual cache for the method fibR (the method being optimized is still hard coded and we'll only be supporting a single 64-bit argument)
- [ ] Expand implementation to handle methods used in more "real life" examples and perform tests to evaluate the performance we get in more realistic scenarios. One suggestion is for using Math trigonometry methods like sin, cos, tan, asin, acos, atan and atan2, and perform tests drawing circles and stuff.
- [ ] Expand cache to handle a method that returns a 32 bit value (like int)
- [ ] Find out how to detect the return value and use the appropriate detour with XSELECT
- [ ] Add support for arguments with a 32 bit value (like int)
- [ ] Create a new annotation for methods that may be memoized by the VM, which would just set a flag, nothing fancy
- [ ] Change the VM to look for methods flagged for memoization instead of using hard coded method names (please notice we are only actually optimising methods which accept a single argument and both the argument and the return value must be either 32 or 64 bit values)
- [ ] Expand support for methods with N arguments
- [ ] Replace the annotation with automatic detection of memoizable methods