### PR TITLE
bugfix: fixes permission for writing on storage for android-29

### DIFF
--- a/TotalCrossVM/android/app/src/main/AndroidManifest.xml
+++ b/TotalCrossVM/android/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
          android:resizeableActivity="true"
          android:allowBackup="true"
          android:backupInForeground="false"
+         android:requestLegacyExternalStorage="true"
          tools:replace="android:label, android:icon, android:theme"
          >
         <meta-data android:name="isFullScreen" android:value="fullscreen:0" />


### PR DESCRIPTION
starting from target-sdk 29 application should use scoped storage
https://developer.android.com/training/data-storage#scoped-storage