### PR TITLE
cicd: build linux targets in release mode

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Build VM & Launcher
       run: |
-        docker run -v ${PWD}:/sources -t totalcross/${{ matrix.project }}:v1.0.0 bash -c "cmake /sources/TotalCrossVM -G Ninja && ninja"
+        docker run -v ${PWD}:/sources -t totalcross/${{ matrix.project }}:v1.0.0 bash -c "cmake /sources/TotalCrossVM -DCMAKE_BUILD_TYPE=Release -G Ninja && ninja"
           
   build-sdk-and-android:
     name: Build `${{ matrix.project.name }}`

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Build VM & Launcher
       run: |
         mkdir -p build
-        docker run -v ${PWD}/build:/build -v ${PWD}:/sources -t totalcross/${{ matrix.project }}:v1.0.0 bash -c "cmake /sources/TotalCrossVM -G Ninja && ninja"
+        docker run -v ${PWD}/build:/build -v ${PWD}:/sources -t totalcross/${{ matrix.project }}:v1.0.0 bash -c "cmake /sources/TotalCrossVM -DCMAKE_BUILD_TYPE=Release -G Ninja && ninja"
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
cmake builds for debugging by default, we must specify build type as release