### PR TITLE
fix(vm): render image graphics into image pixels

### DIFF
--- a/TotalCrossVM/src/nm/ui/GraphicsPrimitives_c.h
+++ b/TotalCrossVM/src/nm/ui/GraphicsPrimitives_c.h
@@ -1,5 +1,6 @@
 // Copyright (C) 2000-2013 SuperWaba Ltda.
-// Copyright (C) 2014-2020 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -469,6 +470,57 @@ static void drawSurface(Context currentContext, TCObject dstSurf, TCObject srcSu
          if (w <= 0 || h <= 0) {
             return;
          }
+      }
+
+      if (Graphics_isImageSurface(dstSurf)) {
+         TCObject pixelsObj = frameCount > 1 ? Image_pixelsOfAllFrames(srcSurf) : Image_pixels(srcSurf);
+         Pixel *srcPixels = (Pixel*)ARRAYOBJ_START(pixelsObj);
+         Pixel *dstPixels = getSurfacePixels(dstSurf);
+         int32 srcPitch = frameCount > 1 ? Image_widthOfAllFrames(srcSurf) : Image_width(srcSurf);
+         int32 dstPitch = Graphics_pitch(dstSurf);
+         int32 dstRow, row, col;
+         int32 alphaMask = Image_alphaMask(srcSurf);
+
+         if (frameCount > 1) {
+            frame = Image_currentFrame(srcSurf);
+            if (frame < 0) {
+               frame = 0;
+            }
+            else if (frame >= frameCount) {
+               frame = frameCount - 1;
+            }
+         }
+
+         srcPixels += frame * Image_width(srcSurf);
+         dstPixels += dstY * dstPitch + dstX;
+         dstRow = dstPitch - w;
+
+         for (row = 0; row < h; row++, dstPixels += dstRow) {
+            int32 sourceY = (int32)((srcY + row) / scaleH);
+            PixelConv *srcRow = (PixelConv*)(srcPixels + sourceY * srcPitch);
+            for (col = 0; col < w; col++, dstPixels++) {
+               int32 sourceX = (int32)((srcX + col) / scaleW);
+               PixelConv *ps = srcRow + sourceX;
+               PixelConv *pt = (PixelConv*)dstPixels;
+               int32 a = ps->a * alphaMask;
+               a = (a + 1 + (a >> 8)) >> 8; // alphaMask * a / 255
+               if (a == 0xFF) {
+                  pt->pixel = ps->pixel;
+               }
+               else if (a != 0) {
+                  int32 ma = 0xFF - a;
+                  int32 r = (a * ps->r + ma * pt->r);
+                  int32 g = (a * ps->g + ma * pt->g);
+                  int32 b = (a * ps->b + ma * pt->b);
+                  pt->r = (r + 1 + (r >> 8)) >> 8;
+                  pt->g = (g + 1 + (g >> 8)) >> 8;
+                  pt->b = (b + 1 + (b >> 8)) >> 8;
+               }
+            }
+         }
+
+         markDirty(currentContext, dstSurf, dstX, dstY, w, h);
+         return;
       }
 
       int32 id = Image_textureId(srcSurf);

--- a/TotalCrossVM/src/nm/ui/ImagePrimitives_c.h
+++ b/TotalCrossVM/src/nm/ui/ImagePrimitives_c.h
@@ -1,5 +1,6 @@
 // Copyright (C) 2000-2013 SuperWaba Ltda.
-// Copyright (C) 2014-2020 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -55,6 +56,7 @@ static void applyColor(TCObject obj, Pixel color) // guich@tc112_24
       Image_currentFrame(obj) = 2;
       setCurrentFrame(obj, 0);
    }
+   Image_changed(obj) = true;
 }
 
 #define BIAS_BITS 16
@@ -312,6 +314,7 @@ static void changeColors(TCObject obj, Pixel from, Pixel to)
       Image_currentFrame(obj) = 2;
       setCurrentFrame(obj, 0);
    }
+   Image_changed(obj) = true;
 }
 
 static void getScaledInstance(TCObject thisObj, TCObject newObj)
@@ -656,6 +659,7 @@ static void applyColor2(TCObject obj, Pixel color)
       Image_currentFrame(obj) = 2;
       setCurrentFrame(obj, 0);
    }
+   Image_changed(obj) = true;
 }
 
 void setTransparentColor(TCObject obj, Pixel color);
@@ -679,6 +683,7 @@ void setTransparentColor(TCObject obj, Pixel color)
       Image_currentFrame(obj) = 2;
       setCurrentFrame(obj, 0);
    }
+   Image_changed(obj) = true;
 }
 
 static int timestampOldLimit;


### PR DESCRIPTION
Ensure image-to-image operations are drawn into the destination image pixel buffer instead of the global canvas, so changes made through Image.getGraphics() are preserved when the image texture is recreated.

Also mark direct image pixel mutations as changed so existing textures are invalidated before repainting.

Closes #393 