### PR TITLE
fix(legal): decouple provenance validation from git history

### DIFF
--- a/legal/copyright-provenance/README.md
+++ b/legal/copyright-provenance/README.md
@@ -186,9 +186,12 @@ python3 scripts/validate-copyright-headers.sh \
 For a covered file, validation uses this precedence:
 
 1. Locate the target in approved manifests listed by `active-audits.json`.
-2. Verify its code fingerprint.
-3. Read each historical source from the immutable initial revision.
-4. Build the inherited copyright chain.
+2. Follow each manifest result's `evidence` reference and verify that the
+   immutable evidence identifies the same historical source path and blob.
+3. Build the inherited copyright chain from the source notices recorded in the
+   committed evidence.
+4. In strict snapshot mode, also resolve the historical source revision and
+   verify its original blob, content notices, and audited target fingerprints.
 5. Apply the current Amalgam end year.
 6. Validate or repair the target header.
 
@@ -203,6 +206,15 @@ legal/copyright-provenance/audits/
 ```
 
 is excluded from ordinary header validation. The audit tool, review tool, shared helper, and this README remain normal first-party files and must carry repository headers.
+
+Git history is required while generating, reviewing, and activating an audit.
+`review-audit.py` therefore runs the validator with
+`--require-provenance-snapshots`, which requires the historical source revision
+and verifies the original Git snapshot. Once an approved audit is active,
+ordinary header validation consumes its committed immutable evidence and does
+not depend on the original Git objects remaining available after rebases,
+history cleanup, branch deletion, or garbage collection. Strict snapshot
+validation remains available for activation and integrity checks.
 
 ## Active audit index
 

--- a/legal/copyright-provenance/provenance.py
+++ b/legal/copyright-provenance/provenance.py
@@ -149,6 +149,33 @@ def parse_notices(text: str) -> list[Notice]:
     return notices
 
 
+def parse_recorded_notices(value: object, context: str) -> list[Notice]:
+    """Parse source notices stored in immutable provenance evidence."""
+    if not isinstance(value, list) or not value:
+        raise ProvenanceError(f"missing source copyright notices: {context}")
+    notices: list[Notice] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, dict):
+            raise ProvenanceError(f"invalid source notice {index}: {context}")
+        years = item.get("years")
+        owner = item.get("owner")
+        if not isinstance(years, str) or not isinstance(owner, str):
+            raise ProvenanceError(f"invalid source notice {index}: {context}")
+        normalized_owner = normalize_owner(owner)
+        if not normalized_owner:
+            raise ProvenanceError(f"empty source notice owner at {index}: {context}")
+        try:
+            parsed_years = parse_years(years)
+        except (ProvenanceError, ValueError) as exc:
+            raise ProvenanceError(
+                f"invalid source notice years at {index}: {context}: {years}"
+            ) from exc
+        if not parsed_years:
+            raise ProvenanceError(f"empty source notice years at {index}: {context}")
+        notices.append(Notice(parsed_years, normalized_owner))
+    return notices
+
+
 def merge_years(notices: Iterable[Notice]) -> dict[str, set[int]]:
     merged: dict[str, set[int]] = {}
     for notice in notices:
@@ -286,7 +313,8 @@ def relative_manifest(audit_id: str) -> str:
     return f"audits/{audit_id}/manifest.json"
 
 
-def load_rules(root: Path, audit_filter: set[str] | None = None) -> dict[str, Rule]:
+def load_rules(root: Path, audit_filter: set[str] | None = None,
+               require_source_snapshot: bool = False) -> dict[str, Rule]:
     rules: dict[str, Rule] = {}
     base = (root / PROVENANCE_ROOT).resolve()
     loaded_audits: set[str] = set()
@@ -304,7 +332,10 @@ def load_rules(root: Path, audit_filter: set[str] | None = None) -> dict[str, Ru
             raise ProvenanceError(f"active audit is not approved: {audit_id}")
         if int(manifest.get("schemaVersion", 0)) < 4:
             raise ProvenanceError(f"unsupported active audit schema: {audit_id}")
-        initial = resolve_commit(str(manifest.get("initialRevision", "")))
+        initial_revision = manifest.get("initialRevision")
+        if not isinstance(initial_revision, str) or not initial_revision:
+            raise ProvenanceError(f"active manifest missing initialRevision: {audit_id}")
+        initial = resolve_commit(initial_revision) if require_source_snapshot else None
         loaded_audits.add(audit_id)
         for result in manifest.get("results", []):
             if not isinstance(result, dict):
@@ -313,9 +344,61 @@ def load_rules(root: Path, audit_filter: set[str] | None = None) -> dict[str, Ru
             source_blob = result.get("sourceBlob")
             if not isinstance(source_path, str) or not isinstance(source_blob, str):
                 raise ProvenanceError(f"invalid source in audit {audit_id}")
-            if git_blob(initial, source_path) != source_blob:
-                raise ProvenanceError(f"source blob mismatch: {audit_id}: {source_path}")
-            notices = canonical_inherited(parse_notices(git_text(initial, source_path)))
+            evidence_ref = result.get("evidence")
+            if not isinstance(evidence_ref, str) or not evidence_ref:
+                raise ProvenanceError(f"missing evidence in audit {audit_id}: {source_path}")
+            audit_dir = path.parent.resolve()
+            evidence_path = (audit_dir / evidence_ref).resolve()
+            if audit_dir not in evidence_path.parents or not evidence_path.is_file():
+                raise ProvenanceError(
+                    f"invalid evidence reference in audit {audit_id}: {evidence_ref}"
+                )
+            evidence = read_json(evidence_path)
+            if evidence.get("schemaVersion") != manifest.get("schemaVersion"):
+                raise ProvenanceError(f"evidence schema mismatch: {audit_id}: {evidence_ref}")
+            evidence_source = evidence.get("source")
+            if not isinstance(evidence_source, dict):
+                raise ProvenanceError(f"missing evidence source: {audit_id}: {evidence_ref}")
+            source_fields = (
+                ("commit", initial_revision),
+                ("path", source_path),
+                ("blob", source_blob),
+            )
+            for field, expected in source_fields:
+                if field not in evidence_source:
+                    continue
+                actual = evidence_source[field]
+                if not isinstance(actual, str):
+                    raise ProvenanceError(
+                        f"invalid evidence source {field}: {audit_id}: {evidence_ref}"
+                    )
+                if actual != expected:
+                    raise ProvenanceError(
+                        f"evidence source {field} mismatch: {audit_id}: {source_path}"
+                    )
+            evidence_fingerprint = evidence.get("sourceCodeFingerprint")
+            result_fingerprint = result.get("sourceCodeFingerprint")
+            if evidence_fingerprint is not None and result_fingerprint is not None:
+                if (not isinstance(evidence_fingerprint, str)
+                        or evidence_fingerprint != result_fingerprint):
+                    raise ProvenanceError(
+                        f"evidence source fingerprint mismatch: {audit_id}: {source_path}"
+                    )
+            source_header = evidence.get("sourceHeader")
+            if not isinstance(source_header, dict):
+                raise ProvenanceError(f"missing evidence source header: {audit_id}: {evidence_ref}")
+            recorded_notices = parse_recorded_notices(
+                source_header.get("sourceNotices"), f"{audit_id}: {evidence_ref}"
+            )
+            if initial is not None:
+                if git_blob(initial, source_path) != source_blob:
+                    raise ProvenanceError(f"source blob mismatch: {audit_id}: {source_path}")
+                snapshot_notices = parse_notices(git_text(initial, source_path))
+                if merge_years(snapshot_notices) != merge_years(recorded_notices):
+                    raise ProvenanceError(
+                        f"evidence source notices mismatch: {audit_id}: {source_path}"
+                    )
+            notices = canonical_inherited(recorded_notices)
             for target in result.get("finalTargets", []):
                 if not isinstance(target, dict) or target.get("classification") not in {
                     "inherited", "partial-inherited",

--- a/legal/copyright-provenance/tests/test_provenance_validation.py
+++ b/legal/copyright-provenance/tests/test_provenance_validation.py
@@ -1,0 +1,176 @@
+# Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+#
+# SPDX-License-Identifier: LGPL-2.1-only
+"""Regression tests for immutable provenance evidence validation."""
+from __future__ import annotations
+
+import datetime as dt
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.dont_write_bytecode = True
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+PROVENANCE_DIR = REPOSITORY_ROOT / "legal" / "copyright-provenance"
+VALIDATOR = REPOSITORY_ROOT / "scripts" / "validate-copyright-headers.sh"
+if str(PROVENANCE_DIR) not in sys.path:
+    sys.path.insert(0, str(PROVENANCE_DIR))
+
+from provenance import java_fingerprint  # noqa: E402
+
+AUDIT_ID = "test-missing-history"
+MISSING_REVISION = "4672da9b98ae3196cf49d8b410b14170ef6f1877"
+SOURCE_PATH = "src/Historical.java"
+TARGET_PATH = "src/Target.java"
+SOURCE_NOTICE = {"years": "2026", "owner": "Amalgam Solucoes em TI Ltda"}
+
+
+class ProvenanceValidationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        self.git("init", "-q")
+        self.git("config", "user.name", "Provenance Test")
+        self.git("config", "user.email", "provenance@example.com")
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def git(self, *args: str) -> str:
+        return subprocess.run(
+            ["git", *args], cwd=self.root, check=True,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+        ).stdout.strip()
+
+    def write_json(self, path: Path, value: dict[str, object]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
+    def target_text(self) -> str:
+        current_year = dt.date.today().year
+        years = "2026" if current_year == 2026 else f"2026-{current_year}"
+        return (
+            f"// Copyright (C) {years} Amalgam Solucoes em TI Ltda\n"
+            "//\n"
+            "// SPDX-License-Identifier: LGPL-2.1-only\n"
+            "\n"
+            "final class Target {}\n"
+        )
+
+    def create_audit(self, initial_revision: str = MISSING_REVISION,
+                     source_blob: str = "a" * 40) -> Path:
+        target = self.root / TARGET_PATH
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(self.target_text(), encoding="utf-8")
+        audit_dir = self.root / "legal" / "copyright-provenance" / "audits" / AUDIT_ID
+        evidence_ref = "evidence/source.json"
+        self.write_json(audit_dir / "manifest.json", {
+            "schemaVersion": 4,
+            "auditId": AUDIT_ID,
+            "reviewStatus": "approved",
+            "initialRevision": initial_revision,
+            "results": [{
+                "sourcePath": SOURCE_PATH,
+                "sourceBlob": source_blob,
+                "sourceCodeFingerprint": "b" * 64,
+                "evidence": evidence_ref,
+                "finalTargets": [{
+                    "path": TARGET_PATH,
+                    "codeFingerprint": java_fingerprint(self.target_text()),
+                    "classification": "inherited",
+                }],
+            }],
+        })
+        evidence_path = audit_dir / evidence_ref
+        self.write_json(evidence_path, {
+            "schemaVersion": 4,
+            "source": {
+                "commit": initial_revision,
+                "path": SOURCE_PATH,
+                "blob": source_blob,
+            },
+            "sourceCodeFingerprint": "b" * 64,
+            "sourceHeader": {"sourceNotices": [SOURCE_NOTICE]},
+        })
+        self.write_json(
+            self.root / "legal" / "copyright-provenance" / "active-audits.json",
+            {"schemaVersion": 1, "active": [f"audits/{AUDIT_ID}/manifest.json"]},
+        )
+        return evidence_path
+
+    def validate(self, strict: bool = False) -> subprocess.CompletedProcess[str]:
+        command = [sys.executable, str(VALIDATOR), "--audit-id", AUDIT_ID]
+        if strict:
+            command.append("--require-provenance-snapshots")
+        command.extend(["--files", TARGET_PATH])
+        return subprocess.run(
+            command, cwd=self.root, check=False,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+        )
+
+    def test_ordinary_validation_uses_evidence_when_history_is_missing(self) -> None:
+        self.create_audit()
+
+        result = self.validate()
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("Copyright headers validated: 1 file(s)", result.stdout)
+        self.assertNotIn(MISSING_REVISION, result.stderr)
+
+    def test_strict_validation_requires_missing_historical_commit(self) -> None:
+        self.create_audit()
+
+        result = self.validate(strict=True)
+
+        self.assertEqual(2, result.returncode)
+        self.assertIn(f"cannot resolve commit: {MISSING_REVISION}", result.stderr)
+
+    def test_strict_validation_preserves_resolvable_snapshot_checks(self) -> None:
+        source = self.root / SOURCE_PATH
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_text(
+            "// Copyright (C) 2026 Amalgam Solucoes em TI Ltda\n"
+            "//\n"
+            "// SPDX-License-Identifier: LGPL-2.1-only\n\n"
+            "final class Historical {}\n",
+            encoding="utf-8",
+        )
+        self.git("add", SOURCE_PATH)
+        self.git("commit", "-q", "-m", "test: add historical source")
+        initial_revision = self.git("rev-parse", "HEAD")
+        source_blob = self.git("rev-parse", f"HEAD:{SOURCE_PATH}")
+        self.create_audit(initial_revision, source_blob)
+
+        result = self.validate(strict=True)
+
+        self.assertEqual(0, result.returncode, result.stderr)
+
+    def test_evidence_source_mismatch_is_not_ignored(self) -> None:
+        evidence_path = self.create_audit()
+        evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+        evidence["source"]["path"] = "src/Unrelated.java"
+        self.write_json(evidence_path, evidence)
+
+        result = self.validate()
+
+        self.assertEqual(2, result.returncode)
+        self.assertIn("evidence source path mismatch", result.stderr)
+
+    def test_malformed_recorded_notices_are_rejected(self) -> None:
+        evidence_path = self.create_audit()
+        evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+        evidence["sourceHeader"]["sourceNotices"] = [{"years": "not-a-year", "owner": "Owner"}]
+        self.write_json(evidence_path, evidence)
+
+        result = self.validate()
+
+        self.assertEqual(2, result.returncode)
+        self.assertIn("invalid source notice years", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-copyright-headers.sh
+++ b/scripts/validate-copyright-headers.sh
@@ -212,7 +212,11 @@ def main() -> int:
     try:
         root = repo_root()
         os.chdir(root)
-        rules = load_rules(root, set(args.audit_id) if args.audit_id else None)
+        rules = load_rules(
+            root,
+            set(args.audit_id) if args.audit_id else None,
+            require_source_snapshot=args.require_provenance_snapshots,
+        )
         failures: list[tuple[str, list[str]]] = []
         checked = fixed = 0
         seen: set[str] = set()


### PR DESCRIPTION
## Summary

- load approved active-audit notices from each manifest result's committed immutable evidence
- cross-check evidence schema and historical source metadata, including commit, path, blob, and source fingerprint when recorded
- keep Git-backed source blob/content and target fingerprint verification in strict `--require-provenance-snapshots` mode
- add deterministic temporary-repository regression coverage and document the history-independence contract

## Root cause

Ordinary `load_rules` unconditionally resolved every approved audit's `initialRevision` and reread its historical source from Git. After a legitimate history rewrite or garbage collection, validation could fail even though the reviewed manifest and immutable evidence remained committed:

```
Copyright header configuration error: cannot resolve commit: 4672da9b98ae3196cf49d8b410b14170ef6f1877
```

Ordinary validation now builds rules from the recorded `sourceHeader.sourceNotices` referenced by `results[].evidence`, so approved audits survive loss of the original Git objects. Malformed or unrelated evidence remains a hard configuration error rather than falling back to creation-year rules.

`review-audit.py` still invokes the validator with `--require-provenance-snapshots`. That strict path continues to resolve the historical commit and verify its original blob/content plus audited target fingerprints before activation.

## Validation

- `python3 -m unittest discover -s legal/copyright-provenance/tests -p 'test_*.py'` — 5 tests passed
- `python3 scripts/validate-copyright-headers.sh` — 4 changed files passed
- Git trace of ordinary validation — no attempt to resolve `4672da9b98ae3196cf49d8b410b14170ef6f1877`
- strict validation for both active audits — 2 audited targets passed with resolvable snapshots
- focused header validation for all changed first-party files — passed
- `git diff --check` — passed

Unrelated platform builds were not run because this change is isolated to the provenance/header validator.