### PR TITLE
Feat/migrate windows to sdl2 skia raster

### DIFF
--- a/.agent/plans/migrate-windows-to-sdl2-skia-raster.md
+++ b/.agent/plans/migrate-windows-to-sdl2-skia-raster.md
@@ -1,0 +1,238 @@
+<!--
+Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+
+SPDX-License-Identifier: LGPL-2.1-only
+-->
+
+# Migrate Windows desktop to SDL2 windowing and Skia raster rendering
+
+This ExecPlan follows `AGENTS.md` and `.agent/PLANS.md`. It defines the
+architecture and acceptance criteria for replacing the experimental Windows
+desktop migration history with a concise, reviewable implementation history.
+
+## Purpose / Big Picture
+
+Windows desktop currently couples Win32 window creation, event delivery,
+software presentation, and platform services. The migration makes those
+responsibilities explicit so Windows can use SDL2 for windowing and events,
+Skia for raster drawing, and the existing CPU framebuffer for presentation,
+while retaining the native Win32 implementation as a supported fallback.
+
+The observable result is a Windows default of SDL2 + Skia + Software with
+physical-pixel presentation and logical TotalCross coordinates. A developer
+can still configure Native + Legacy + Software, and WinCE remains on its
+existing native path. The implementation must not add a TotalCross GPU
+backend or make host/system SDL a prerequisite for supported builds.
+
+## Working Set and Resume Protocol
+
+The implementation worktree is the temporary rebuild branch created from the
+requested base commit. The original branch is protected by a backup branch;
+the backup is never modified. The two tracked artifacts for this migration
+are this plan and the final editorial report at
+`.agent/reports/windows-sdl-skia-raster-editorial.md`.
+
+No migration state, evidence, archive, or helper script is part of the
+rebuilt history. Validation logs and the old/new revision manifest live in
+the developer worktree or temporary artifact directories and are not source
+deliverables. If interrupted, inspect the current branch, its last commit,
+the scoped diff, and the backup branch before continuing.
+
+## Progress
+
+- [ ] Record the final old/new revision comparison and production-tree audit.
+- [ ] Rebuild the functional history in architectural order.
+- [ ] Pass focused tests, header checks, source limits, macOS SDL + Skia
+  Release validation, SDK validation, and exact-HEAD enabled CI.
+- [ ] Add the final factual report only after functional CI succeeds.
+- [ ] Update the original branch with `git push --force-with-lease`, leaving
+  the backup branch intact.
+
+## Current Architecture and Scope
+
+### Supported configuration matrix
+
+The selectors in `TotalCrossVM/cmake/TCGraphics.cmake` expose three
+independent choices:
+
+    Windowing       Renderer       Graphics       Contract
+    Native          Legacy         Software       Windows fallback
+    SDL             Legacy         Software       diagnostic path
+    SDL             Skia           Software       Windows default
+    Native          Skia           any            rejected on Windows
+    any             any            GLES            outside this migration
+
+WinCE is fixed to Native + Legacy + Software. Android and iOS retain their
+existing platform-specific defaults. SDL2 comes from the pinned
+`TotalCrossVM/deps/totalcross-depot-tools` checkout and is linked through the
+repository's imported dependency target.
+
+### Windowing and event ownership
+
+`TotalCrossVM/src/event/Event.c` selects event delivery by windowing backend.
+The SDL event implementation belongs under `src/event/sdl`, while DirectFB
+and Native Windows implementations remain in their platform-specific paths.
+SDL owns SDL event polling, text input, modifier capture, special-key
+translation, mouse unions, lifecycle events, and supported Windows hotkey
+bridging. The native Windows event path remains available for Native
+windowing.
+
+`TotalCrossVM/src/nm/ui/sdl` owns SDL window state and the renderer-facing
+surface contract. `Window.c` separates backend operations from platform
+services. Windows SDL may obtain an `HWND` through SDL SysWM only for native
+services; it must not reintroduce a second Win32 event pump.
+
+### Raster and lifecycle ownership
+
+The software graphics path owns a CPU framebuffer. SDL presents that memory
+through a fixed ARGB8888 streaming texture, and Skia uses the corresponding
+BGRA raster interpretation deterministically. Window-owned SDL surfaces are
+not borrowed or freed. SDL window/renderer lifetime is separate from
+backbuffer and Skia binding lifetime so screen recreation can tear down and
+rebind the correct resources.
+
+SDL logical and physical display metrics drive content scale, resize, and
+display-change handling. Resize ownership belongs to the selected windowing
+backend. Rotation confirmation and F9 behavior must not apply stale or
+malformed pending requests.
+
+### Startup and command-line contracts
+
+Desktop startup uses a shared resolver in `WindowStartup.c/.h`. It owns
+environment loading, `/scr` presence and values, TCZ dimensions, default
+window sizing, position, fullscreen, maximized, and resizable state. The
+precedence is explicit `/scr`, valid environment dimensions, TCZ attributes,
+then half-display defaults; an explicit `-1` remains an explicit source and
+resolves its missing dimension to a default. SDL and Native Windows translate
+one resolved configuration into their native APIs, while WinCE keeps its
+existing path.
+
+The launcher parses the full composite command line, including options after
+`/cmd`, removes reserved VM options, preserves near matches and unrelated
+arguments, and passes `MainWindow.getCommandLine()` only the compacted
+application payload. The historical non-desktop command-separator behavior is
+preserved.
+
+## Plan of Work
+
+1. Write this plan as the first post-base commit.
+2. Consolidate Windows SDL dependency preparation, static-runtime settings,
+   workflow fallback coverage, and the final depot-tools reference.
+3. Make graphics, renderer, and windowing selectors explicit and enforce the
+   supported matrix.
+4. Extract shared SDL window state, route software graphics by backend, and
+   route events by windowing selection.
+5. Add the Windows SDL adapter, SysWM platform-service bridge, software
+   framebuffer, Skia raster binding, deterministic pixel format, and Skia
+   ownership rules.
+6. Separate backend operations from platform services, centralize SIP values,
+   and move resize ownership to the backend.
+7. Consolidate SDL text input, keyboard shortcuts, modifiers, special keys,
+   native hotkeys, and their permanent contract coverage.
+8. Consolidate desktop command-line filtering and preserve legacy separator
+   semantics.
+9. Consolidate F9, rotation, resize confirmation, pending-request handling,
+   and display-change behavior.
+10. Add the final shared `WindowStartup` resolver and its CMake wiring,
+    followed by permanent native and source-level tests.
+11. After functional validation and exact-HEAD CI, write the final report as
+    the last commit and perform the leased branch update.
+
+Each implementation commit will contain one architectural purpose, preserve
+the final behavior directly, and omit superseded fixes, reversions, and
+execution artifacts. Commit titles and bodies will pass the repository
+validator and cached whitespace checks before acceptance.
+
+## Decision Log
+
+- Decision: keep Native + Legacy + Software as an explicit Windows fallback.
+  Rationale: the migration must not make SDL runtime or renderer behavior the
+  only recovery path.
+
+- Decision: use SDL for shared windowing and events, but use SysWM only for
+  Windows platform services. Rationale: this prevents duplicate event pumps
+  and keeps platform integrations available without coupling rendering to
+  Win32 window creation.
+
+- Decision: use a CPU framebuffer with a fixed SDL texture and Skia raster
+  surface. Rationale: the target is software rendering; SDL surface format
+  discovery and window-owned surface lifetime are not stable contracts for
+  this architecture.
+
+- Decision: centralize startup policy in `WindowStartup` and keep backend
+  translations local. Rationale: repeated fixes to `/scr`, environment, TCZ,
+  fullscreen, and sizing must resolve once and behave consistently across
+  SDL and Native Windows.
+
+- Decision: keep `TotalCrossVM/src/jni/Android.mk` identical to the base.
+  Rationale: it is legacy Android wiring outside this migration and must have
+  no branch history in the rebuilt result.
+
+## Validation and Acceptance
+
+Validation is a release-gate change because the rewrite crosses CMake
+selectors, native source dispatch, event/input behavior, startup ABI, and
+Windows platform integration.
+
+Required focused validation includes:
+
+- commit-title/body validation and `git diff --check --cached` before every
+  reconstructed commit;
+- focused copyright/header validation for every changed first-party source,
+  test, script, Markdown, and workflow file;
+- permanent SDL desktop contracts, command-line resolver tests, and the
+  retained native startup resolver test;
+- source-size and source-growth checks required by the repository;
+- `git diff --check $BASE..HEAD`, where `$BASE` denotes the branch base;
+- macOS Release SDL + Skia + Software `tcvm`/`Launcher` build and the SDK
+  validation normally required by this migration;
+- selector checks for default, fallback, diagnostic, and rejected matrix
+  configurations;
+- exact-HEAD Merge Flow with every enabled job, including Windows SDL and
+  Windows Native + Legacy. Policy-disabled jobs may remain skipped.
+
+The functional HEAD must pass CI before the final report commit is created.
+The report commit is documentation-only and does not trigger a second CI
+requirement. Windows interactive behavior can be reported as deferred only if
+the enabled Windows CI jobs pass and no local Windows runtime is available.
+
+Acceptance also requires that the production tree matches the old branch's
+final implementation except for the intentional Android.mk restoration and
+removal of migration execution artifacts. Exactly the plan and report remain
+as tracked migration artifacts.
+
+## Risks and Open Questions
+
+- The macOS host may not provide Windows compilers, runtime smoke, or staged
+  Windows native artifacts; those claims require the exact-HEAD Windows CI
+  jobs.
+- SDL logical versus physical metrics can diverge across HiDPI monitors and
+  display changes; both the resolver and renderer binding must preserve the
+  logical/physical contract.
+- SDL text input and keydown ownership can duplicate printable characters or
+  lose modifiers if translation occurs in more than one layer.
+- Static MSVC runtime and dependency pins must remain consistent between
+  local CMake configuration and Windows workflow fallback builds.
+- The rewritten history must not accidentally drop a final fix merely because
+  its original commit was labeled as a temporary repair; the old/new
+  production diff is the final audit.
+
+## Idempotence and Recovery
+
+The backup branch is the authoritative recovery point for the original
+history. Re-running reconstruction must use the temporary branch and compare
+its tree to the backup; never mutate or delete the backup. The original
+worktree's untracked files remain outside the rewrite and are not cleaned.
+
+Before the final update, verify the rebuilt functional HEAD, the exact
+Android.mk comparison, tracked artifact inventory, scoped production diff,
+and CI result. If any check fails, leave the original branch and backup
+untouched, correct the temporary branch, and rerun only the necessary focused
+validation.
+
+## Outcomes & Retrospective
+
+This section is completed in the final report commit after the functional
+history, validation evidence, production-tree audit, and branch update are
+complete. It will distinguish delivered behavior from deferred runtime proof
+and document any compatibility limitation that remains.

--- a/.agent/reports/windows-sdl-skia-raster-editorial.md
+++ b/.agent/reports/windows-sdl-skia-raster-editorial.md
@@ -1,0 +1,102 @@
+<!--
+Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+
+SPDX-License-Identifier: LGPL-2.1-only
+-->
+
+# Windows SDL2 + Skia raster migration — editorial handoff
+
+## Outcome
+
+The migration history was rebuilt from the branch base into focused logical
+commits. The protected pre-rebuild backup remains unchanged. The final
+production tree matches the backup except for the intentional removal of the
+two plan-execution helper scripts and the required Android.mk invariant.
+
+The standalone SDL lifecycle fix was removed. Its SDL event polling and Apple
+touch behavior now belong to the SDL event/input commit, while startup
+`appTczAttr` propagation belongs to the desktop startup integration commit.
+
+## Logical commit list
+
+- docs(plan): plan Windows SDL2 Skia migration
+- build(windows): prepare SDL2 dependency toolchain
+- build(cmake): define desktop backend matrix
+- refactor(windowing): extract shared SDL surface state
+- refactor(graphics): route software backend by windowing
+- refactor(event): select dispatch by windowing backend
+- refactor(windowing,windows): bridge SDL window services
+- feat(renderer): integrate software Skia presentation
+- refactor(window): separate backend platform services
+- feat(event): consolidate SDL desktop input ownership
+- fix(windowing): harden display and screen lifecycle
+- fix(runtime): filter desktop command line options
+- fix(windowing): finalize SDL rotation ownership
+- refactor(windowing): centralize desktop startup policy
+- test(windowing): retain desktop contract coverage
+- docs(report): report Windows SDL2 Skia migration
+
+The two Python desktop-contract helpers are not in this history. They are
+plan-execution tools and are restored only in the worktree after this report.
+
+## Final architecture
+
+Windows defaults to SDL + Skia + Software. Native + Legacy + Software remains
+available as a fallback, SDL + Legacy + Software remains useful for
+diagnostics, Windows Native + Skia is rejected, and WinCE remains Native +
+Legacy + Software.
+
+SDL owns the desktop window and event path. SysWM is limited to platform
+services and does not create a second Win32 event pump. The SDL event/input
+commit owns SDL polling, text input, modifiers, special keys, mouse events,
+touch handling, lifecycle events, and the supported Windows hotkey bridge.
+
+The software path presents a CPU framebuffer through a fixed ARGB8888
+streaming texture. Skia uses the matching BGRA raster interpretation and
+deterministic channel mapping. Window, renderer, backbuffer, and Skia resource
+lifetimes remain explicit across resize and screen recreation.
+
+Desktop startup policy is centralized in `WindowStartup.c/.h`. It resolves
+TCZ attributes, environment dimensions, `/scr`, position, fullscreen,
+maximized, and resizable state once, then lets SDL and Native Windows apply
+their platform-specific outer-window behavior.
+
+## Provenance decision
+
+The provenance-audit stage was explicitly waived for this rerun. No provenance
+classifications were activated and no provenance-driven header repairs were
+applied. Ordinary repository header validation passed for the rebuilt
+functional tree.
+
+## Validation
+
+- Passed: ordinary copyright-header validation for the rebuilt functional
+  range.
+- Passed: final whitespace validation from the branch base.
+- Passed: `TotalCrossVM/src/jni/Android.mk` comparison against the branch base.
+- Passed: production-tree comparison against the protected backup after
+  excluding migration documents, legal audit artifacts, Android.mk, and the
+  intentional helper removal; no unexplained production difference remains.
+- Passed: all newly created source files stayed below 20 KiB and 600 lines.
+- Assessed: no active repository source-size validator exists. A separate
+  untracked draft reports two changed legacy files crossing its draft limit;
+  no production code was changed to satisfy that non-active policy.
+- Passed: native `window_startup_native_test` executable.
+- Passed: macOS Release SDL + Skia + Software builds for `tcvm` and `Launcher`.
+- Passed: SDK distribution build with `TotalCrossSDK/gradlew-agent dist -x test`.
+- Passed: `ctest`; no tests are registered in the native build directory.
+
+## Merge Flow
+
+The new exact-HEAD Merge Flow passed: [run 33574454125](https://github.com/TotalCross/totalcross/actions/runs/33574454125).
+Checkout, Windows SDL, Windows Native + Legacy, macOS, Linux amd64, Linux
+arm64, Linux arm32v7, Android, iOS, and SDK jobs passed. The policy-disabled
+Linux arm32v7 cross job was skipped.
+
+## Deferred runtime coverage
+
+The developer host has no Windows compiler/runtime or interactive Windows
+desktop. Windows runtime smoke, mixed-DPI monitor movement, manual text and
+modifier interaction, native hotkeys, and visual comparison remain for a
+Windows-capable environment. The enabled Windows CI jobs provide build
+coverage, not interactive desktop smoke.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -393,6 +393,8 @@ jobs:
         mkdir TotalCrossVM\vc2022
         pushd TotalCrossVM\vc2022
         cmake ..\ -G"Visual Studio 17 2022" -A Win32
+        findstr /C:"<RuntimeLibrary>MultiThreaded</RuntimeLibrary>" tcvm.vcxproj >NUL || exit /b 1
+        findstr /C:"<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>" tcvm.vcxproj >NUL || exit /b 1
         cmake --build . --config Release
         popd
 
@@ -403,6 +405,55 @@ jobs:
         path: |
           TotalCrossVM/vc2022/Release/*.dll
           TotalCrossVM/vc2022/Release/*.exe
+
+  build-windows-native-legacy:
+    name: Build `windows-native-legacy`
+    needs: checkout-source
+    runs-on: windows-2022
+
+    steps:
+    - name: Download source code
+      uses: actions/download-artifact@v7
+      with:
+        name: source-code
+
+    - name: Extract source code
+      shell: bash
+      run: tar -xzf source-code.tar.gz
+
+    - name: Download prepared native dependencies
+      uses: actions/download-artifact@v7
+      with:
+        name: prepared-native-dependencies
+
+    - name: Extract prepared native dependencies
+      shell: bash
+      run: tar -xzf depot-tools-native-dependencies.tar.gz
+
+    - name: Export SQLite SEE override
+      shell: bash
+      env:
+        SQLITE3_RELEASE_TAG_OVERRIDE: ${{ secrets.SQLITE3_RELEASE_TAG }}
+        SQLITE3_GITHUB_REPO_OVERRIDE: ${{ secrets.SQLITE3_GITHUB_REPO }}
+      run: |
+        if [ -n "${SQLITE3_RELEASE_TAG_OVERRIDE:-}" ]; then
+          printf 'SQLITE3_RELEASE_TAG=%s\n' "$SQLITE3_RELEASE_TAG_OVERRIDE" >> "$GITHUB_ENV"
+        fi
+        if [ -n "${SQLITE3_GITHUB_REPO_OVERRIDE:-}" ]; then
+          printf 'SQLITE3_GITHUB_REPO=%s\n' "$SQLITE3_GITHUB_REPO_OVERRIDE" >> "$GITHUB_ENV"
+        fi
+
+    - name: Build VM with Native and Legacy renderer
+      shell: cmd
+      run: |
+        mkdir TotalCrossVM\vc2022-native-legacy-runtime-fix
+        pushd TotalCrossVM\vc2022-native-legacy-runtime-fix
+        cmake ..\ -G"Visual Studio 17 2022" -A Win32 -DTC_WINDOWING_NATIVE=ON -DTC_WINDOWING_SDL=OFF -DTC_RENDERER_LEGACY=ON -DTC_RENDERER_SKIA=OFF -DTC_GRAPHICS_SOFTWARE=ON
+        findstr /C:"<RuntimeLibrary>MultiThreaded</RuntimeLibrary>" tcvm.vcxproj >NUL || exit /b 1
+        findstr /C:"<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>" tcvm.vcxproj >NUL || exit /b 1
+        cmake --build . --config Release
+        if not exist Release\tcvm.dll exit /b 1
+        popd
 
   build-macos-arm64:
     name: Build `macos-arm64`

--- a/TotalCrossVM/CMakeLists.txt
+++ b/TotalCrossVM/CMakeLists.txt
@@ -661,6 +661,7 @@ set(SOURCES
     ${TC_SRCDIR}/nm/ui/media_Camera.c
     ${TC_SRCDIR}/nm/ui/YoutubePlayer.c
     ${TC_SRCDIR}/nm/ui/Window.c
+    ${TC_SRCDIR}/nm/ui/WindowStartup.c
     ${TC_SRCDIR}/nm/ui/dialog_FilePicker.c
 
     ${TC_SRCDIR}/nm/util/concurrent_Lock.c

--- a/TotalCrossVM/CMakeLists.txt
+++ b/TotalCrossVM/CMakeLists.txt
@@ -5,10 +5,39 @@
 
 cmake_minimum_required(VERSION 3.11)
 
+set(TC_MSVC_RUNTIME_POLICY_AVAILABLE FALSE)
+
+if(POLICY CMP0091)
+  cmake_policy(SET CMP0091 NEW)
+  set(CMAKE_MSVC_RUNTIME_LIBRARY
+    "MultiThreaded$<$<CONFIG:Debug>:Debug>"
+  )
+  set(TC_MSVC_RUNTIME_POLICY_AVAILABLE TRUE)
+endif()
+
 include(FetchContent)
 
 # set the project name
 project(tcvm VERSION 7.2.2)
+
+if(MSVC AND NOT TC_MSVC_RUNTIME_POLICY_AVAILABLE)
+  foreach(flag_var
+      CMAKE_C_FLAGS
+      CMAKE_C_FLAGS_DEBUG
+      CMAKE_C_FLAGS_RELEASE
+      CMAKE_C_FLAGS_MINSIZEREL
+      CMAKE_C_FLAGS_RELWITHDEBINFO
+      CMAKE_CXX_FLAGS
+      CMAKE_CXX_FLAGS_DEBUG
+      CMAKE_CXX_FLAGS_RELEASE
+      CMAKE_CXX_FLAGS_MINSIZEREL
+      CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+    if(DEFINED ${flag_var})
+      string(REGEX REPLACE "/MD" "/MT"
+        ${flag_var} "${${flag_var}}")
+    endif()
+  endforeach()
+endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/TotalCrossVM/CMakeLists.txt
+++ b/TotalCrossVM/CMakeLists.txt
@@ -47,6 +47,7 @@ include(cmake/TCGraphics.cmake)
 tc_generate_platform_config()
 
 option(TC_BUILD_IR_TESTS "Build focused TCIR contract tests" OFF)
+option(TC_BUILD_NATIVE_STARTUP_TEST "Build the native desktop startup test" OFF)
 option(TC_BUILD_IR_BENCHMARKS "Build optional TCIR performance benchmarks" OFF)
 option(TC_ENABLE_C_AOT "Build the experimental portable-C TCIR backend" OFF)
 option(TC_ENABLE_SLJIT_JIT "Build the experimental SLJIT TCIR backend" OFF)
@@ -855,6 +856,28 @@ link_directories(${PROJECT_SOURCE_DIR})
 # add the library
 set(LIBRARY_ARGS ${SOURCES} ${TC_WCE_SOURCES} ${TC_MSVC_SOURCES} ${TC_NOT_MSVC_SOURCES} ${TC_SKIA_SOURCES} ${TC_SDL_SOURCES} ${TC_ANDROID_SOURCES} ${TCVM_iOS_FILES})
 target_sources(tcvm PUBLIC ${LIBRARY_ARGS})
+
+if(TC_BUILD_NATIVE_STARTUP_TEST)
+  add_executable(window_startup_native_test
+    ${TC_SRCDIR}/tests/window_startup_native_test.c
+    ${TC_SRCDIR}/nm/ui/WindowStartup.c
+  )
+  target_include_directories(window_startup_native_test PRIVATE
+    "${TC_PLATFORM_GENERATED_INCLUDE_DIR}"
+    "${TC_SRCDIR}"
+    "${TC_SRCDIR}/tcvm"
+  )
+  target_compile_definitions(window_startup_native_test PRIVATE
+    TC_PLATFORM_CONFIGURED=1
+  )
+  target_link_libraries(window_startup_native_test PRIVATE
+    SDL2::SDL2
+    Skia::Skia
+  )
+  target_compile_options(window_startup_native_test PRIVATE
+    $<$<OR:$<C_COMPILER_ID:GNU>,$<C_COMPILER_ID:Clang>,$<C_COMPILER_ID:AppleClang>>:-Wall;-Wextra>
+  )
+endif()
 
 if(TC_ENABLE_COMPILED_DISPATCH)
   add_library(tcir_runtime STATIC

--- a/TotalCrossVM/cmake/TCGraphics.cmake
+++ b/TotalCrossVM/cmake/TCGraphics.cmake
@@ -4,55 +4,106 @@
 
 include_guard(GLOBAL)
 
-#
-# Graphics API used to access the destination surface.
-#
-set(TC_GRAPHICS_GLES OFF)
-set(TC_GRAPHICS_SOFTWARE OFF)
-
-#
-# Renderer responsible for drawing TotalCross primitives.
-#
-set(TC_RENDERER_SKIA OFF)
-set(TC_RENDERER_LEGACY OFF)
-
-#
-# Window and native surface integration.
-#
-set(TC_WINDOWING_SDL OFF)
-set(TC_WINDOWING_NATIVE OFF)
-
-# ---------------------------------------------------------------------------
-# Graphics
-# ---------------------------------------------------------------------------
-
+# The first option in each pair is the user-facing selector.  The inverse is
+# derived below so a command-line/cache choice is not overwritten by the
+# platform defaults and contradictory pairs cannot be selected accidentally.
 if(TC_TARGET_ANDROID OR TC_TARGET_IOS)
-  set(TC_GRAPHICS_GLES ON)
+  set(TC_GRAPHICS_SOFTWARE_DEFAULT OFF)
 else()
-  set(TC_GRAPHICS_SOFTWARE ON)
+  set(TC_GRAPHICS_SOFTWARE_DEFAULT ON)
 endif()
-
-# ---------------------------------------------------------------------------
-# Renderer
-# ---------------------------------------------------------------------------
 
 if(TC_TARGET_ANDROID
    OR TC_TARGET_IOS
    OR TC_TARGET_LINUX
-   OR TC_TARGET_MACOS)
-  set(TC_RENDERER_SKIA ON)
+   OR TC_TARGET_MACOS
+   OR TC_TARGET_WINDOWS)
+  set(TC_RENDERER_SKIA_DEFAULT ON)
 else()
-  set(TC_RENDERER_LEGACY ON)
+  set(TC_RENDERER_SKIA_DEFAULT OFF)
 endif()
 
-# ---------------------------------------------------------------------------
-# Windowing
-# ---------------------------------------------------------------------------
-
-if(TC_TARGET_LINUX OR TC_TARGET_MACOS)
-  set(TC_WINDOWING_SDL ON)
+if(TC_TARGET_LINUX OR TC_TARGET_MACOS OR TC_TARGET_WINDOWS)
+  set(TC_WINDOWING_SDL_DEFAULT ON)
 else()
-  set(TC_WINDOWING_NATIVE ON)
+  set(TC_WINDOWING_SDL_DEFAULT OFF)
+endif()
+
+# Accept the inverse names as compatibility inputs when the canonical option
+# was not supplied, then publish both names for the C/C++ preprocessor.  Use
+# explicit cache assignments instead of option(): old CMake policies allow
+# option() to discard a normal variable set from an inverse compatibility flag.
+set(_tc_graphics_software_choice ${TC_GRAPHICS_SOFTWARE_DEFAULT})
+if(DEFINED TC_GRAPHICS_SOFTWARE)
+  set(_tc_graphics_software_choice ${TC_GRAPHICS_SOFTWARE})
+elseif(DEFINED TC_GRAPHICS_GLES)
+  if(TC_GRAPHICS_GLES)
+    set(_tc_graphics_software_choice OFF)
+  else()
+    set(_tc_graphics_software_choice ON)
+  endif()
+endif()
+set(TC_GRAPHICS_SOFTWARE ${_tc_graphics_software_choice} CACHE BOOL
+  "Use the CPU/software graphics surface" FORCE)
+
+set(_tc_renderer_skia_choice ${TC_RENDERER_SKIA_DEFAULT})
+if(DEFINED TC_RENDERER_SKIA)
+  set(_tc_renderer_skia_choice ${TC_RENDERER_SKIA})
+elseif(DEFINED TC_RENDERER_LEGACY)
+  if(TC_RENDERER_LEGACY)
+    set(_tc_renderer_skia_choice OFF)
+  else()
+    set(_tc_renderer_skia_choice ON)
+  endif()
+endif()
+set(TC_RENDERER_SKIA ${_tc_renderer_skia_choice} CACHE BOOL
+  "Use the Skia primitive renderer" FORCE)
+
+set(_tc_windowing_sdl_choice ${TC_WINDOWING_SDL_DEFAULT})
+if(DEFINED TC_WINDOWING_SDL)
+  set(_tc_windowing_sdl_choice ${TC_WINDOWING_SDL})
+elseif(DEFINED TC_WINDOWING_NATIVE)
+  if(TC_WINDOWING_NATIVE)
+    set(_tc_windowing_sdl_choice OFF)
+  else()
+    set(_tc_windowing_sdl_choice ON)
+  endif()
+endif()
+set(TC_WINDOWING_SDL ${_tc_windowing_sdl_choice} CACHE BOOL
+  "Use SDL for window creation and events" FORCE)
+
+if(TC_GRAPHICS_SOFTWARE)
+  set(TC_GRAPHICS_GLES OFF CACHE BOOL "Use the GLES graphics surface" FORCE)
+else()
+  set(TC_GRAPHICS_GLES ON CACHE BOOL "Use the GLES graphics surface" FORCE)
+endif()
+
+if(TC_RENDERER_SKIA)
+  set(TC_RENDERER_LEGACY OFF CACHE BOOL "Use the legacy primitive renderer" FORCE)
+else()
+  set(TC_RENDERER_LEGACY ON CACHE BOOL "Use the legacy primitive renderer" FORCE)
+endif()
+
+if(TC_WINDOWING_SDL)
+  set(TC_WINDOWING_NATIVE OFF CACHE BOOL "Use native platform windowing" FORCE)
+else()
+  set(TC_WINDOWING_NATIVE ON CACHE BOOL "Use native platform windowing" FORCE)
+endif()
+
+if(TC_TARGET_WINCE)
+  if(TC_WINDOWING_SDL OR TC_RENDERER_SKIA OR TC_GRAPHICS_GLES)
+    message(FATAL_ERROR "WinCE supports only Native + Legacy + Software")
+  endif()
+  set(TC_GRAPHICS_SOFTWARE ON CACHE BOOL "Use the CPU/software graphics surface" FORCE)
+  set(TC_GRAPHICS_GLES OFF CACHE BOOL "Use the GLES graphics surface" FORCE)
+  set(TC_RENDERER_SKIA OFF CACHE BOOL "Use the Skia primitive renderer" FORCE)
+  set(TC_RENDERER_LEGACY ON CACHE BOOL "Use the legacy primitive renderer" FORCE)
+  set(TC_WINDOWING_SDL OFF CACHE BOOL "Use SDL for window creation and events" FORCE)
+  set(TC_WINDOWING_NATIVE ON CACHE BOOL "Use native platform windowing" FORCE)
+endif()
+
+if(TC_TARGET_WINDOWS AND TC_WINDOWING_NATIVE AND TC_RENDERER_SKIA)
+  message(FATAL_ERROR "Windows Native windowing supports only the Legacy renderer")
 endif()
 
 # ---------------------------------------------------------------------------

--- a/TotalCrossVM/deps/totalcross-depot-tools.ref
+++ b/TotalCrossVM/deps/totalcross-depot-tools.ref
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 
-118ff8925b165c79de87cd2d69f562b570b1ebd5
+0ebff1d7202fab6e61758344219f60fa757fe6ce

--- a/TotalCrossVM/src/event/Event.c
+++ b/TotalCrossVM/src/event/Event.c
@@ -1,5 +1,6 @@
 // Copyright (C) 2000-2013 SuperWaba Ltda.
-// Copyright (C) 2014-2020 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -11,7 +12,9 @@ void updateScreen(Context currentContext);
 void vmSetAutoOff(bool enable); // vm_c.h
 
 // Platform-specific code
-#if defined(WINCE) || defined(WIN32)
+#if TC_WINDOWING_SDL
+ #include "sdl/event_c.h"
+#elif defined(WINCE) || defined(WIN32)
  #include "win/event_c.h"
 #elif defined(darwin)
  #include "darwin/event_c.h"

--- a/TotalCrossVM/src/event/Event.c
+++ b/TotalCrossVM/src/event/Event.c
@@ -15,14 +15,20 @@ void vmSetAutoOff(bool enable); // vm_c.h
 // Platform-specific code
 #if TC_WINDOWING_SDL
  #include "sdl/event_c.h"
-#elif defined(WINCE) || defined(WIN32)
- #include "win/event_c.h"
-#elif defined(darwin)
- #include "darwin/event_c.h"
-#elif defined(ANDROID)                                                             
- #include "android/event_c.h"
+#elif TC_WINDOWING_NATIVE
+ #if TC_OS_WINDOWS || TC_OS_WINCE
+  #include "win/event_c.h"
+ #elif TC_OS_ANDROID
+  #include "android/event_c.h"
+ #elif TC_OS_IOS
+  #include "darwin/event_c.h"
+ #elif TC_OS_LINUX
+  #include "linux/event_c.h"
+ #else
+  #error Unsupported native event backend
+ #endif
 #else
- #include "linux/event_c.h"
+ #error No event backend selected
 #endif
 //
 
@@ -63,7 +69,7 @@ static bool pumpEvent(Context currentContext)
       privatePumpEvent(currentContext);
    checkTimer(currentContext);
 sleep:
-#ifndef darwin   
+#if !TC_OS_IOS
    Sleep(1); // avoid 100% cpu - important on Android!
 #endif   
    return ok;
@@ -101,7 +107,7 @@ void mainEventLoop(Context currentContext)
    onMinimize = getMethod(OBJ_CLASS(mainClass), true, "_onMinimize", 0);
    onRestore = getMethod(OBJ_CLASS(mainClass), true, "_onRestore", 0);
 
-#ifdef darwin
+#if TC_OS_IOS
     graphicsSetupIOS(); // start the opengl context in the same thread of the events
 #endif
    if (_onTimerTick == null || _postEvent == null || onMinimize == null || onRestore == null) // unlikely to occur...

--- a/TotalCrossVM/src/event/Event.c
+++ b/TotalCrossVM/src/event/Event.c
@@ -9,6 +9,7 @@
 #include "tcvm.h"
 
 void updateScreen(Context currentContext);
+void markWholeScreenDirty(Context currentContext);
 void vmSetAutoOff(bool enable); // vm_c.h
 
 // Platform-specific code

--- a/TotalCrossVM/src/event/linux/event_c.h
+++ b/TotalCrossVM/src/event/linux/event_c.h
@@ -4,379 +4,95 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
-#if TC_WINDOWING_SDL
- #if __APPLE__
-  #include "SDL.h"
- #else
-  #include "SDL2/SDL.h"
- #endif
- #include "../../init/tcsdl.h"
-#else
- #include <directfb.h>
-#endif
-
-#define MAX_SCALE_FINGERS 2
-
-typedef struct
-{
-   SDL_FingerID id;
-   float x;
-   float y;
-   bool active;
-} ScaleFinger;
-
-static ScaleFinger scaleFingers[MAX_SCALE_FINGERS];
-static int32 scaleFingerCount;
-static bool scaleGestureActive;
-static double lastScaleDistance;
-
-static void postScaleEvent(double scale) {
-   union
-   {
-      double d;
-      uint64 l;
-   } bits;
-
-   bits.d = scale;
-   postEvent(mainContext, MULTITOUCHEVENT_SCALE, 0, (int32)(bits.l >> 32), (int32)bits.l, -1);
-}
-
-static int32 findScaleFinger(SDL_FingerID id) {
-   int32 i;
-   for (i = 0; i < MAX_SCALE_FINGERS; i++) {
-      if (scaleFingers[i].active && scaleFingers[i].id == id) {
-         return i;
-      }
-   }
-   return -1;
-}
-
-static double scaleSqrt(double value) {
-   int32 i;
-   double result;
-
-   if (value <= 0) {
-      return 0;
-   }
-
-   result = value >= 1 ? value : 1;
-   for (i = 0; i < 12; i++) {
-      result = (result + value / result) / 2;
-   }
-   return result;
-}
-
-static double getScaleDistance() {
-   double dx = (double)scaleFingers[0].x - (double)scaleFingers[1].x;
-   double dy = (double)scaleFingers[0].y - (double)scaleFingers[1].y;
-   return scaleSqrt(dx * dx + dy * dy);
-}
-
-static void beginScaleGesture() {
-   if (!scaleGestureActive && scaleFingerCount >= MAX_SCALE_FINGERS) {
-      scaleGestureActive = true;
-      lastScaleDistance = getScaleDistance();
-#if !__APPLE__
-      if (isDragging) {
-         isDragging = false;
-         postEvent(mainContext, PENEVENT_PEN_UP, 0, 10000, 10000, -1);
-      }
-#endif
-      postEvent(mainContext, MULTITOUCHEVENT_SCALE, 1, 0, 0, -1);
-   }
-}
-
-static void endScaleGesture() {
-   if (scaleGestureActive) {
-      scaleGestureActive = false;
-      lastScaleDistance = 0;
-      postEvent(mainContext, MULTITOUCHEVENT_SCALE, 2, 0, 0, -1);
-   }
-}
+#include <directfb.h>
 
 bool privateIsEventAvailable()
 {
-#if TC_WINDOWING_SDL
-   return SDL_PollEvent(NULL) != 0;
-#else
-	return (DEVICE_CTX->events->HasEvent(DEVICE_CTX->events) == DFB_OK);
-#endif
-}
-
-void handleFingerTouchEvent(SDL_Event event) {
-   int width = 0, height = 0;
-   TCSDL_GetWindowSize(&screen, &width, &height);
-   int32 x = event.tfinger.x * width, y = event.tfinger.y * height;
-   switch (event.type) {
-      case SDL_FINGERDOWN: {
-         int32 i = findScaleFinger(event.tfinger.fingerId);
-         if (i < 0 && scaleFingerCount < MAX_SCALE_FINGERS) {
-            for (i = 0; i < MAX_SCALE_FINGERS; i++) {
-               if (!scaleFingers[i].active) {
-                  scaleFingers[i].id = event.tfinger.fingerId;
-                  scaleFingers[i].x = event.tfinger.x;
-                  scaleFingers[i].y = event.tfinger.y;
-                  scaleFingers[i].active = true;
-                  scaleFingerCount++;
-                  break;
-               }
-            }
-         }
-         if (scaleFingerCount >= MAX_SCALE_FINGERS) {
-            beginScaleGesture();
-         }
-#if !__APPLE__
-         else {
-            isDragging = true;
-            postEvent(mainContext, PENEVENT_PEN_DOWN, 0, x, y, -1);
-         }
-#endif
-         break;
-      }
-      case SDL_FINGERUP:
-      {
-         int32 i = findScaleFinger(event.tfinger.fingerId);
-         if (i >= 0) {
-            scaleFingers[i].active = false;
-            scaleFingerCount--;
-            if (scaleGestureActive) {
-               endScaleGesture();
-               break;
-            }
-         }
-#if !__APPLE__
-         if (!scaleGestureActive) {
-            isDragging = false;
-            postEvent(mainContext, PENEVENT_PEN_UP, 0, x, y, -1);
-         }
-#endif
-         break;
-      }
-      case SDL_FINGERMOTION: {
-         int32 i = findScaleFinger(event.tfinger.fingerId);
-         if (i >= 0) {
-            scaleFingers[i].x = event.tfinger.x;
-            scaleFingers[i].y = event.tfinger.y;
-         }
-         if (scaleGestureActive) {
-            if (i >= 0) {
-               double distance = getScaleDistance();
-               if (lastScaleDistance > 0 && distance > 0) {
-                  postScaleEvent(distance / lastScaleDistance);
-               }
-               lastScaleDistance = distance;
-            }
-         } else {
-            postEvent(mainContext, MOUSEEVENT_MOUSE_MOVE, 0, x, y, -1);
-         }
-         break;
-      }
-   }
-}
-
-void handleMouseEvent(SDL_Event event) {
-   int32 timestamp = getTimeStamp();
-   if(event.button.button == SDL_BUTTON_LEFT) {
-      switch (event.type) {
-         case SDL_MOUSEBUTTONDOWN:
-            isDragging = true;
-            postEvent(mainContext, PENEVENT_PEN_DOWN, 0, event.button.x, event.button.y, timestamp);
-            break;
-         case SDL_MOUSEBUTTONUP:
-            isDragging = false;
-            postEvent(mainContext, PENEVENT_PEN_UP, 0, event.button.x, event.button.y, timestamp);
-            break;
-         case SDL_MOUSEMOTION:
-            if(event.motion.state == SDL_PRESSED) { // start dragging
-               postEvent(mainContext, PENEVENT_PEN_DRAG, 0, event.motion.x, event.motion.y, timestamp);
-            }
-            else {
-               postEvent(mainContext, MOUSEEVENT_MOUSE_MOVE, 0, event.motion.x, event.motion.y, timestamp);
-            }
-      }
-   }
-}
-
-void handleKeyboardEvent(SDL_Event event) {
-   int key, modifier;
-   if(event.type == SDL_KEYDOWN) {
-      key = keyDevice2Portable(event.key.keysym.sym);
-      modifier = (int)keyGetPortableModifiers(event.key.keysym.mod);
-      if (showKeyCodes) // debug keys?
-      {
-            // printf("Key code: %d\nModifier: %X\n",(int)key, modifier);
-            printf("Event keysym: %d\n", event.key.keysym.sym);
-      }
-      if (key == SK_SCREEN_CHANGE)
-      {
-         // if (*tcSettings.screenWidthPtr != *tcSettings.screenHeightPtr)
-         //    screenChange(mainContext, *tcSettings.screenHeightPtr,*tcSettings.screenWidthPtr,0,0,false);
-      }
-      else if (key != event.key.keysym.sym) {
-         postEvent(mainContext, KEYEVENT_SPECIALKEY_PRESS, key, 0, 0, modifier);
-      }
-      // else if (key < 255)
-      //    postEvent(mainContext, KEYEVENT_KEY_PRESS, event.key.keysym.unicode, 0, 0, modifier);
-   }
-}
-
-void handleWheelEvent(SDL_Event event) {
-   int x, y;
-   SDL_GetMouseState(&x, &y);
-   if(event.wheel.y > 0) // scroll up
-   {
-      postEvent(mainContext, MOUSEEVENT_MOUSE_WHEEL, WHEEL_UP, x, max32(y,0),-1);       
-   }
-   else if(event.wheel.y < 0) // scroll down
-   {
-      postEvent(mainContext, MOUSEEVENT_MOUSE_WHEEL, WHEEL_DOWN, x, max32(y,0),-1);  
-   }
-   if(event.wheel.x > 0) // scroll right
-   {
-      postEvent(mainContext, MOUSEEVENT_MOUSE_WHEEL, WHEEL_RIGHT, x, max32(y,0),-1);  
-   }
-   else if(event.wheel.x < 0) // scroll left
-   {
-      postEvent(mainContext, MOUSEEVENT_MOUSE_WHEEL, WHEEL_LEFT, x, max32(y,0),-1);  
-   }
-}
-
-void handleTextInputEvent(SDL_Event event) {
-   char text[32];
-   text[0] = '\0';
-   int i = 0;
-   strcpy(text, event.text.text);
-   for (; text[i] != '\0'; i++) {
-      int modifier = (int)keyGetPortableModifiers(SDL_GetModState());
-      postEvent(mainContext, KEYEVENT_KEY_PRESS, text[i], 0, 0, modifier);
-   }
+   return DEVICE_CTX->events->HasEvent(DEVICE_CTX->events) == DFB_OK;
 }
 
 void privatePumpEvent(Context currentContext)
 {
-#if TC_WINDOWING_SDL
-   SDL_Event event;
-   if(SDL_PollEvent(&event)) {
-      if(event.type == SDL_WINDOWEVENT) {
-         if(event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED) {
-            int width = event.window.data1;
-            int height = event.window.data2;
-            // SDL_Surface must be refreshed after a SDL_WINDOWEVENT_SIZE_CHANGED event
-            TCSDL_WindowSizeChanged(&screen, width, height);
-            // screenChange(mainContext, width, height, 0, 0, false);
-         }
-         TCSDL_Present();
-      }
-      if(event.type >= SDL_FINGERDOWN && event.type <= SDL_FINGERMOTION) { // Finger Touch Events
-         handleFingerTouchEvent(event);
-      }
-      else if(event.type >= SDL_MOUSEMOTION && event.type <= SDL_MOUSEWHEEL) { //Mouse events
-         handleMouseEvent(event);
-      }
-      if(event.type >= SDL_KEYDOWN) { // KeyBoard events
-        handleKeyboardEvent(event);
-      }
-      if(event.type == SDL_TEXTINPUT) { // Text Input Events
-         handleTextInputEvent(event);
-      }
-      if(event.type == SDL_MOUSEWHEEL) { // Wheel Events
-         handleWheelEvent(event);
-      }
-      if(event.type == SDL_QUIT) {
-         keepRunning = false;
-      }
-   }
-#else
    DFBInputEvent evt;
    int x, y;
    int key;
+   UNUSED(currentContext)
 
    if (DEVICE_CTX->events->GetEvent(DEVICE_CTX->events, DFB_EVENT(&evt)) == DFB_OK)
    {
-      if (handleEvent(&evt)) // let the attached native libs handle this event
+      if (handleEvent(&evt))
          return;
 
       switch (evt.type)
       {
-//      case DIET_KEYRELEASE:
-//         if (evt.key_symbol == DIKS_ESCAPE)
-//            keepRunning = false;
-//         break;
-      case DIET_KEYPRESS:
-      //case DIET_KEYRELEASE:
-         key = keyDevice2Portable(evt.key_symbol);
-         if (showKeyCodes) // debug keys?
-         {
-            alert("Key code: %d\nModifier: %X\n",(int)key, (int)keyGetPortableModifiers(evt.modifiers));
-            return;
-         }
+         case DIET_KEYPRESS:
+            key = keyDevice2Portable(evt.key_symbol);
+            if (showKeyCodes)
+            {
+               alert("Key code: %d\nModifier: %X", (int)key,
+                  (int)keyGetPortableModifiers(evt.modifiers));
+               return;
+            }
+            if (key == SK_SCREEN_CHANGE)
+            {
+               if (*tcSettings.screenWidthPtr != *tcSettings.screenHeightPtr)
+                  screenChange(mainContext, *tcSettings.screenHeightPtr,
+                     *tcSettings.screenWidthPtr, 0, 0, false);
+            }
+            else if (key != evt.key_symbol)
+               postEvent(mainContext, KEYEVENT_SPECIALKEY_PRESS, key, 0, 0, evt.modifiers);
+            else if (key < 255)
+               postEvent(mainContext, KEYEVENT_KEY_PRESS, key, 0, 0, evt.modifiers);
+            break;
 
-         if (key == SK_SCREEN_CHANGE)
-         {
-            if (*tcSettings.screenWidthPtr != *tcSettings.screenHeightPtr)
-               screenChange(mainContext, *tcSettings.screenHeightPtr,*tcSettings.screenWidthPtr,0,0,false);
-         }
-         else
-         if (key != evt.key_symbol)
-            postEvent(mainContext, KEYEVENT_SPECIALKEY_PRESS, key, 0, 0, evt.modifiers);
-         else
-         if (key < 255)
-            postEvent(mainContext, KEYEVENT_KEY_PRESS, key, 0, 0, evt.modifiers);
-         break;
+         case DIET_BUTTONPRESS:
+            isDragging = true;
+            DEVICE_CTX->layer->GetCursorPosition(DEVICE_CTX->layer, &x, &y);
+            postEvent(mainContext, PENEVENT_PEN_DOWN, 0, x, y, -1);
+            break;
 
-      case DIET_BUTTONPRESS:
-         isDragging = true;
-         DEVICE_CTX->layer->GetCursorPosition(DEVICE_CTX->layer, &x, &y);
-         postEvent(mainContext, PENEVENT_PEN_DOWN, 0, x, y, -1);
-         break;
+         case DIET_BUTTONRELEASE:
+            isDragging = false;
+            DEVICE_CTX->layer->GetCursorPosition(DEVICE_CTX->layer, &x, &y);
+            postEvent(mainContext, PENEVENT_PEN_UP, 0, x, y, -1);
+            break;
 
-      case DIET_BUTTONRELEASE:
-         isDragging = false;
-         DEVICE_CTX->layer->GetCursorPosition(DEVICE_CTX->layer, &x, &y);
-         postEvent(mainContext, PENEVENT_PEN_UP, 0, x, y, -1);
-         break;
+         case DIET_AXISMOTION:
+            DEVICE_CTX->layer->GetCursorPosition(DEVICE_CTX->layer, &x, &y);
+            postEvent(mainContext,
+               isDragging ? PENEVENT_PEN_DRAG : MOUSEEVENT_MOUSE_MOVE,
+               0, x, y, -1);
+            break;
 
-      case DIET_AXISMOTION:
-         DEVICE_CTX->layer->GetCursorPosition(DEVICE_CTX->layer, &x, &y);
-         postEvent(mainContext, isDragging ? PENEVENT_PEN_DRAG : MOUSEEVENT_MOUSE_MOVE, 0, x, y, -1);
-         break;
-
-      default:
-         break;
+         default:
+            break;
       }
    }
-#endif
 }
 
 bool privateInitEvent()
 {
-#if TC_WINDOWING_SDL
-   return true;
-#else
    DFBResult err;
-
    deviceCtx = (TScreenSurfaceEx*)xmalloc(sizeof(TScreenSurfaceEx));
 
    err = DirectFBInit(0, NULL);
-   if (err != DFB_OK) return false;
+   if (err != DFB_OK)
+      return false;
    err = DirectFBCreate(&DEVICE_CTX->dfb);
-   if (err != DFB_OK || !DEVICE_CTX->dfb) return false;
+   if (err != DFB_OK || !DEVICE_CTX->dfb)
+      return false;
 
-   DFBResult res = DEVICE_CTX->dfb->CreateInputEventBuffer(DEVICE_CTX->dfb, DICAPS_ALL, DFB_TRUE, &DEVICE_CTX->events);
-   return (res == DFB_OK && DEVICE_CTX->events);
-#endif
+   return DEVICE_CTX->dfb->CreateInputEventBuffer(
+      DEVICE_CTX->dfb, DICAPS_ALL, DFB_TRUE, &DEVICE_CTX->events) == DFB_OK
+      && DEVICE_CTX->events;
 }
 
 void privateDestroyEvent()
 {
-#if TC_WINDOWING_SDL
-   SDL_FlushEvents(SDL_FIRSTEVENT, SDL_LASTEVENT);
-#else
    if (DEVICE_CTX->dfb)
    {
       DEVICE_CTX->dfb->Release(DEVICE_CTX->dfb);
       DEVICE_CTX->dfb = NULL;
    }
-   //xfree(deviceCtx); todo@ crashes since another access is done yet
-#endif
+   // xfree(deviceCtx) is intentionally deferred; another access occurs later.
 }

--- a/TotalCrossVM/src/event/linux/specialkeys_c.h
+++ b/TotalCrossVM/src/event/linux/specialkeys_c.h
@@ -4,41 +4,10 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
-#if TC_WINDOWING_SDL
- #if __APPLE__
-  #include "SDL.h"
- #else
-  #include "SDL2/SDL.h"
- #endif
- #include "../../init/tcsdl.h"
-#else
- #include <directfb.h>
-#endif
+#include <directfb.h>
 
 int32 privateKeyPortable2Device(PortableSpecialKeys key)
 {
-#if TC_WINDOWING_SDL
-   switch (key)
-   {
-      case SK_PAGE_UP        : return SDLK_PAGEUP   ;
-      case SK_PAGE_DOWN      : return SDLK_PAGEDOWN ;
-      case SK_HOME           : return SDLK_HOME     ;
-      case SK_END            : return SDLK_END      ;
-      case SK_UP             : return SDLK_UP       ;
-      case SK_DOWN           : return SDLK_DOWN     ;
-      case SK_LEFT           : return SDLK_LEFT     ;
-      case SK_RIGHT          : return SDLK_RIGHT    ;
-      case SK_INSERT         : return SDLK_INSERT   ;
-      case SK_ENTER          : return SDLK_RETURN   ;
-      case SK_TAB            : return SDLK_TAB      ;
-      case SK_BACKSPACE      : return SDLK_BACKSPACE;
-      case SK_ESCAPE         : return SDLK_ESCAPE   ;
-      case SK_DELETE         : return SDLK_DELETE   ;
-      case SK_SCREEN_CHANGE  : return SDLK_F9       ;
-      default: // avoid warning "enumeration value 'XXX' not handled in switch"
-         break;
-   }
-#else
    switch (key)
    {
       case SK_PAGE_UP        : return DIKS_PAGE_UP;
@@ -59,30 +28,11 @@ int32 privateKeyPortable2Device(PortableSpecialKeys key)
       default: // avoid warning "enumeration value 'XXX' not handled in switch"
          break;
    }
-#endif
    return key;
 }
 
 PortableSpecialKeys privateKeyDevice2Portable(int32 key)
 {
-#if TC_WINDOWING_SDL
-   switch (key) {
-      case SDLK_PAGEUP: return SK_PAGE_UP;
-      case SDLK_PAGEDOWN: return SK_PAGE_DOWN;
-      case SDLK_HOME: return SK_HOME;
-      case SDLK_END: return SK_END;
-      case SDLK_UP: return SK_UP;
-      case SDLK_DOWN: return SK_DOWN;
-      case SDLK_LEFT: return SK_LEFT;
-      case SDLK_RIGHT: return SK_RIGHT;
-      case SDLK_INSERT: return SK_INSERT;
-      case SDLK_RETURN: return SK_ENTER;
-      case SDLK_TAB: return SK_TAB;
-      case SDLK_BACKSPACE: return SK_BACKSPACE;
-      case SDLK_DELETE: return SK_DELETE;
-      case SDLK_F9: return SK_SCREEN_CHANGE;
-   }
-#else
    switch (key)
    {
       case DIKS_PAGE_UP       : return SK_PAGE_UP;
@@ -101,22 +51,14 @@ PortableSpecialKeys privateKeyDevice2Portable(int32 key)
       case DIKS_DELETE        : return SK_DELETE;
       case DIKS_F9            : return SK_SCREEN_CHANGE;
    }
-#endif
    return key;
 }
 
 PortableModifiers privateKeyGetPortableModifiers(int32 mods)
 {
-#if TC_WINDOWING_SDL
-   if(mods & KMOD_NONE)  return PM_NONE;
-   return (((mods & KMOD_LSHIFT) || (mods & KMOD_RSHIFT)) ? PM_SHIFT   : PM_NONE) |
-          (((mods & KMOD_LCTRL) || (mods & KMOD_RCTRL)) ? PM_CONTROL : PM_NONE) |
-          (((mods & KMOD_LALT) || (mods & KMOD_RALT)) ? PM_ALT     : PM_NONE) ;
-#else
    if (mods == -1)
       return PM_NONE;
    return ((mods & (1 << DIMKI_SHIFT))   ? PM_SHIFT   : PM_NONE) |
           ((mods & (1 << DIMKI_CONTROL)) ? PM_CONTROL : PM_NONE) |
           ((mods & (1 << DIMKI_ALT))     ? PM_ALT     : PM_NONE) ;
-#endif
 }

--- a/TotalCrossVM/src/event/sdl/event_c.h
+++ b/TotalCrossVM/src/event/sdl/event_c.h
@@ -24,20 +24,46 @@ static ScaleFinger scaleFingers[MAX_SCALE_FINGERS];
 static int32 scaleFingerCount;
 static bool scaleGestureActive;
 static double lastScaleDistance;
+static int32 pendingScreenRotationOrientation;
+
+static int32 screenOrientation(int32 width, int32 height)
+{
+   return width > height ? 1 : width < height ? -1 : 0;
+}
+
+static void resolvePendingScreenRotation(const TScreenConfiguration *configuration)
+{
+   int32 resultingOrientation;
+
+   if (pendingScreenRotationOrientation == 0 || configuration == NULL)
+      return;
+
+   resultingOrientation = screenOrientation(
+      configuration->width, configuration->height);
+   if (resultingOrientation != 0
+      && resultingOrientation != pendingScreenRotationOrientation)
+   {
+      int32 minimum = screen.minScreenW;
+      screen.minScreenW = screen.minScreenH;
+      screen.minScreenH = minimum;
+   }
+   pendingScreenRotationOrientation = 0;
+}
 
 static void dispatchPortableSpecialKey(PortableSpecialKeys key, int32 modifiers)
 {
    if (key == SK_SCREEN_CHANGE)
    {
-      if (*tcSettings.screenWidthPtr != *tcSettings.screenHeightPtr)
-      {
-         int32 minimum = screen.minScreenW;
-         screen.minScreenW = screen.minScreenH;
-         screen.minScreenH = minimum;
-         screenChange(mainContext, *tcSettings.screenHeightPtr,
-            *tcSettings.screenWidthPtr, *tcSettings.screenHeightInDPIPtr,
-            *tcSettings.screenWidthInDPIPtr, false);
-      }
+      int32 width;
+      int32 height;
+      if (pendingScreenRotationOrientation != 0)
+         return;
+      TCSDL_GetWindowSize(&screen, &width, &height);
+      if (width <= 0 || height <= 0 || width == height)
+         return;
+      pendingScreenRotationOrientation = screenOrientation(width, height);
+      if (!TCSDL_SetWindowSize(height, width))
+         pendingScreenRotationOrientation = 0;
    }
    else
       postEvent(mainContext, KEYEVENT_SPECIALKEY_PRESS, key, 0, 0, modifiers);
@@ -420,11 +446,15 @@ void privatePumpEvent(Context currentContext)
                TScreenConfiguration configuration;
                if (TCSDL_QueryWindowMetrics(&screen, &configuration))
                {
+                  if (event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED)
+                     resolvePendingScreenRotation(&configuration);
                   ScreenChangeFlags changes = screenApplyConfiguration(
                      &screen, &configuration);
                   screenConsumePendingChanges(&screen);
                   screenChangeCommitted(mainContext, changes);
                }
+               else if (event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED)
+                  pendingScreenRotationOrientation = 0;
                break;
             }
             case SDL_WINDOWEVENT_MINIMIZED:

--- a/TotalCrossVM/src/event/sdl/event_c.h
+++ b/TotalCrossVM/src/event/sdl/event_c.h
@@ -8,6 +8,7 @@
 #include "SDL2/SDL.h"
 #endif
 #include "../../init/tcsdl.h"
+#include "event_sdl.h"
 
 #define MAX_SCALE_FINGERS 2
 
@@ -23,6 +24,71 @@ static ScaleFinger scaleFingers[MAX_SCALE_FINGERS];
 static int32 scaleFingerCount;
 static bool scaleGestureActive;
 static double lastScaleDistance;
+
+static void dispatchPortableSpecialKey(PortableSpecialKeys key, int32 modifiers)
+{
+   if (key == SK_SCREEN_CHANGE)
+   {
+      if (*tcSettings.screenWidthPtr != *tcSettings.screenHeightPtr)
+      {
+         int32 minimum = screen.minScreenW;
+         screen.minScreenW = screen.minScreenH;
+         screen.minScreenH = minimum;
+         screenChange(mainContext, *tcSettings.screenHeightPtr,
+            *tcSettings.screenWidthPtr, *tcSettings.screenHeightInDPIPtr,
+            *tcSettings.screenWidthInDPIPtr, false);
+      }
+   }
+   else
+      postEvent(mainContext, KEYEVENT_SPECIALKEY_PRESS, key, 0, 0, modifiers);
+}
+
+#if defined(WIN32) && !defined(WINCE)
+static bool windowsMessageHookInstalled;
+
+PortableSpecialKeys vmWin32KeyToPortable(int32 key);
+
+static void SDLCALL sdlWindowsMessageHook(void *userdata, void *hWnd,
+   unsigned int message, Uint64 wParam, Sint64 lParam)
+{
+   int32 key;
+   Int32Array keys;
+   int32 len;
+
+   UNUSED(userdata);
+   UNUSED(lParam);
+   if (message != WM_HOTKEY || hWnd != (void*)mainHWnd
+      || interceptedSpecialKeys == null)
+      return;
+
+   key = (int32)wParam;
+   keys = interceptedSpecialKeys;
+   len = ARRAYLEN(keys);
+   while (len-- > 0)
+   {
+      if (*keys++ == key)
+      {
+         dispatchPortableSpecialKey(vmWin32KeyToPortable(key), -1);
+         return;
+      }
+   }
+}
+
+void sdlInstallWindowsMessageHook()
+{
+   SDL_SetWindowsMessageHook(sdlWindowsMessageHook, null);
+   windowsMessageHookInstalled = true;
+}
+
+void sdlRemoveWindowsMessageHook()
+{
+   if (windowsMessageHookInstalled)
+   {
+      SDL_SetWindowsMessageHook(null, null);
+      windowsMessageHookInstalled = false;
+   }
+}
+#endif
 
 static void postScaleEvent(double scale)
 {
@@ -72,11 +138,13 @@ static void beginScaleGesture()
    {
       scaleGestureActive = true;
       lastScaleDistance = getScaleDistance();
+#if !__APPLE__
       if (isDragging)
       {
          isDragging = false;
          postEvent(mainContext, PENEVENT_PEN_UP, 0, 10000, 10000, -1);
       }
+#endif
       postEvent(mainContext, MULTITOUCHEVENT_SCALE, 1, 0, 0, -1);
    }
 }
@@ -93,9 +161,8 @@ static void endScaleGesture()
 
 bool privateIsEventAvailable()
 {
-   SDL_Event event;
-   return SDL_PeepEvents(&event, 1, SDL_PEEKEVENT,
-      SDL_FIRSTEVENT, SDL_LASTEVENT) > 0;
+   // Pump native events while checking availability without consuming them.
+   return SDL_PollEvent(NULL);
 }
 
 static void handleFingerTouchEvent(SDL_Event event)
@@ -127,11 +194,13 @@ static void handleFingerTouchEvent(SDL_Event event)
          }
          if (scaleFingerCount >= MAX_SCALE_FINGERS)
             beginScaleGesture();
+#if !__APPLE__
          else
          {
             isDragging = true;
             postEvent(mainContext, PENEVENT_PEN_DOWN, 0, x, y, -1);
          }
+#endif
          break;
       }
       case SDL_FINGERUP:
@@ -147,11 +216,13 @@ static void handleFingerTouchEvent(SDL_Event event)
                break;
             }
          }
+#if !__APPLE__
          if (!scaleGestureActive)
          {
             isDragging = false;
             postEvent(mainContext, PENEVENT_PEN_UP, 0, x, y, -1);
          }
+#endif
          break;
       }
       case SDL_FINGERMOTION:
@@ -178,7 +249,6 @@ static void handleFingerTouchEvent(SDL_Event event)
 
 static void handleMouseEvent(SDL_Event event)
 {
-   int32 timestamp = getTimeStamp();
    switch (event.type)
    {
       case SDL_MOUSEBUTTONDOWN:
@@ -186,7 +256,7 @@ static void handleMouseEvent(SDL_Event event)
          {
             isDragging = true;
             postEvent(mainContext, PENEVENT_PEN_DOWN, 0,
-               event.button.x, event.button.y, timestamp);
+               event.button.x, event.button.y, -1);
          }
          break;
       case SDL_MOUSEBUTTONUP:
@@ -194,31 +264,51 @@ static void handleMouseEvent(SDL_Event event)
          {
             isDragging = false;
             postEvent(mainContext, PENEVENT_PEN_UP, 0,
-               event.button.x, event.button.y, timestamp);
+               event.button.x, event.button.y, -1);
          }
          break;
       case SDL_MOUSEMOTION:
          if (event.motion.state & SDL_BUTTON_LMASK)
             postEvent(mainContext, PENEVENT_PEN_DRAG, 0,
-               event.motion.x, event.motion.y, timestamp);
+               event.motion.x, event.motion.y, -1);
          else
             postEvent(mainContext, MOUSEEVENT_MOUSE_MOVE, 0,
-               event.motion.x, event.motion.y, timestamp);
+               event.motion.x, event.motion.y, -1);
          break;
+   }
+}
+
+static bool isControlShortcut(int32 key, int32 modifiers)
+{
+   if ((modifiers & KMOD_CTRL) == 0)
+      return false;
+   switch (key)
+   {
+      case SDLK_a:
+      case SDLK_c:
+      case SDLK_p:
+      case SDLK_v:
+      case SDLK_x:
+      case SDLK_SPACE:
+         return true;
+      default:
+         return false;
    }
 }
 
 static void handleKeyboardEvent(SDL_Event event)
 {
-   int key, modifier;
+   int key;
    if (event.type == SDL_KEYDOWN)
    {
       key = keyDevice2Portable(event.key.keysym.sym);
-      modifier = (int)keyGetPortableModifiers(event.key.keysym.mod);
       if (showKeyCodes)
          printf("Event keysym: %d\n", event.key.keysym.sym);
       if (key != event.key.keysym.sym)
-         postEvent(mainContext, KEYEVENT_SPECIALKEY_PRESS, key, 0, 0, modifier);
+         dispatchPortableSpecialKey(key, event.key.keysym.mod);
+      else if (isControlShortcut(event.key.keysym.sym, event.key.keysym.mod))
+         postEvent(mainContext, KEYEVENT_KEY_PRESS, event.key.keysym.sym,
+            0, 0, event.key.keysym.mod);
    }
 }
 
@@ -253,7 +343,7 @@ static void postTextCodePoint(uint32 codePoint, int32 modifier)
 static void handleTextInputEvent(SDL_Event event)
 {
    const uint8 *text = (const uint8*)event.text.text;
-   int32 modifier = (int32)keyGetPortableModifiers(SDL_GetModState());
+   int32 modifier = SDL_GetModState();
    while (*text != '\0')
    {
       uint32 codePoint;
@@ -382,6 +472,16 @@ void privatePumpEvent(Context currentContext)
 bool privateInitEvent()
 {
    return true;
+}
+
+void sdlEventWindowCreated(void)
+{
+   SDL_StartTextInput();
+}
+
+void sdlEventWindowDestroying(void)
+{
+   SDL_StopTextInput();
 }
 
 void privateDestroyEvent()

--- a/TotalCrossVM/src/event/sdl/event_c.h
+++ b/TotalCrossVM/src/event/sdl/event_c.h
@@ -1,0 +1,292 @@
+// Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#if __APPLE__
+#include "SDL.h"
+#else
+#include "SDL2/SDL.h"
+#endif
+#include "../../init/tcsdl.h"
+
+#define MAX_SCALE_FINGERS 2
+
+typedef struct
+{
+   SDL_FingerID id;
+   float x;
+   float y;
+   bool active;
+} ScaleFinger;
+
+static ScaleFinger scaleFingers[MAX_SCALE_FINGERS];
+static int32 scaleFingerCount;
+static bool scaleGestureActive;
+static double lastScaleDistance;
+
+static void postScaleEvent(double scale)
+{
+   union
+   {
+      double d;
+      uint64 l;
+   } bits;
+
+   bits.d = scale;
+   postEvent(mainContext, MULTITOUCHEVENT_SCALE, 0,
+      (int32)(bits.l >> 32), (int32)bits.l, -1);
+}
+
+static int32 findScaleFinger(SDL_FingerID id)
+{
+   int32 i;
+   for (i = 0; i < MAX_SCALE_FINGERS; i++)
+      if (scaleFingers[i].active && scaleFingers[i].id == id)
+         return i;
+   return -1;
+}
+
+static double scaleSqrt(double value)
+{
+   int32 i;
+   double result;
+
+   if (value <= 0)
+      return 0;
+   result = value >= 1 ? value : 1;
+   for (i = 0; i < 12; i++)
+      result = (result + value / result) / 2;
+   return result;
+}
+
+static double getScaleDistance()
+{
+   double dx = (double)scaleFingers[0].x - (double)scaleFingers[1].x;
+   double dy = (double)scaleFingers[0].y - (double)scaleFingers[1].y;
+   return scaleSqrt(dx * dx + dy * dy);
+}
+
+static void beginScaleGesture()
+{
+   if (!scaleGestureActive && scaleFingerCount >= MAX_SCALE_FINGERS)
+   {
+      scaleGestureActive = true;
+      lastScaleDistance = getScaleDistance();
+      if (isDragging)
+      {
+         isDragging = false;
+         postEvent(mainContext, PENEVENT_PEN_UP, 0, 10000, 10000, -1);
+      }
+      postEvent(mainContext, MULTITOUCHEVENT_SCALE, 1, 0, 0, -1);
+   }
+}
+
+static void endScaleGesture()
+{
+   if (scaleGestureActive)
+   {
+      scaleGestureActive = false;
+      lastScaleDistance = 0;
+      postEvent(mainContext, MULTITOUCHEVENT_SCALE, 2, 0, 0, -1);
+   }
+}
+
+bool privateIsEventAvailable()
+{
+   SDL_Event event;
+   return SDL_PeepEvents(&event, 1, SDL_PEEKEVENT,
+      SDL_FIRSTEVENT, SDL_LASTEVENT) > 0;
+}
+
+static void handleFingerTouchEvent(SDL_Event event)
+{
+   int width = 0, height = 0;
+   TCSDL_GetWindowSize(&screen, &width, &height);
+   int32 x = event.tfinger.x * width;
+   int32 y = event.tfinger.y * height;
+
+   switch (event.type)
+   {
+      case SDL_FINGERDOWN:
+      {
+         int32 i = findScaleFinger(event.tfinger.fingerId);
+         if (i < 0 && scaleFingerCount < MAX_SCALE_FINGERS)
+         {
+            for (i = 0; i < MAX_SCALE_FINGERS; i++)
+            {
+               if (!scaleFingers[i].active)
+               {
+                  scaleFingers[i].id = event.tfinger.fingerId;
+                  scaleFingers[i].x = event.tfinger.x;
+                  scaleFingers[i].y = event.tfinger.y;
+                  scaleFingers[i].active = true;
+                  scaleFingerCount++;
+                  break;
+               }
+            }
+         }
+         if (scaleFingerCount >= MAX_SCALE_FINGERS)
+            beginScaleGesture();
+         else
+         {
+            isDragging = true;
+            postEvent(mainContext, PENEVENT_PEN_DOWN, 0, x, y, -1);
+         }
+         break;
+      }
+      case SDL_FINGERUP:
+      {
+         int32 i = findScaleFinger(event.tfinger.fingerId);
+         if (i >= 0)
+         {
+            scaleFingers[i].active = false;
+            scaleFingerCount--;
+            if (scaleGestureActive)
+            {
+               endScaleGesture();
+               break;
+            }
+         }
+         if (!scaleGestureActive)
+         {
+            isDragging = false;
+            postEvent(mainContext, PENEVENT_PEN_UP, 0, x, y, -1);
+         }
+         break;
+      }
+      case SDL_FINGERMOTION:
+      {
+         int32 i = findScaleFinger(event.tfinger.fingerId);
+         if (i >= 0)
+         {
+            scaleFingers[i].x = event.tfinger.x;
+            scaleFingers[i].y = event.tfinger.y;
+         }
+         if (scaleGestureActive && i >= 0)
+         {
+            double distance = getScaleDistance();
+            if (lastScaleDistance > 0 && distance > 0)
+               postScaleEvent(distance / lastScaleDistance);
+            lastScaleDistance = distance;
+         }
+         else
+            postEvent(mainContext, MOUSEEVENT_MOUSE_MOVE, 0, x, y, -1);
+         break;
+      }
+   }
+}
+
+static void handleMouseEvent(SDL_Event event)
+{
+   int32 timestamp = getTimeStamp();
+   if (event.button.button == SDL_BUTTON_LEFT)
+   {
+      switch (event.type)
+      {
+         case SDL_MOUSEBUTTONDOWN:
+            isDragging = true;
+            postEvent(mainContext, PENEVENT_PEN_DOWN, 0,
+               event.button.x, event.button.y, timestamp);
+            break;
+         case SDL_MOUSEBUTTONUP:
+            isDragging = false;
+            postEvent(mainContext, PENEVENT_PEN_UP, 0,
+               event.button.x, event.button.y, timestamp);
+            break;
+         case SDL_MOUSEMOTION:
+            if (event.motion.state == SDL_PRESSED)
+               postEvent(mainContext, PENEVENT_PEN_DRAG, 0,
+                  event.motion.x, event.motion.y, timestamp);
+            else
+               postEvent(mainContext, MOUSEEVENT_MOUSE_MOVE, 0,
+                  event.motion.x, event.motion.y, timestamp);
+            break;
+      }
+   }
+}
+
+static void handleKeyboardEvent(SDL_Event event)
+{
+   int key, modifier;
+   if (event.type == SDL_KEYDOWN)
+   {
+      key = keyDevice2Portable(event.key.keysym.sym);
+      modifier = (int)keyGetPortableModifiers(event.key.keysym.mod);
+      if (showKeyCodes)
+         printf("Event keysym: %d\n", event.key.keysym.sym);
+      if (key != event.key.keysym.sym)
+         postEvent(mainContext, KEYEVENT_SPECIALKEY_PRESS, key, 0, 0, modifier);
+   }
+}
+
+static void handleWheelEvent(SDL_Event event)
+{
+   int x, y;
+   SDL_GetMouseState(&x, &y);
+   if (event.wheel.y > 0)
+      postEvent(mainContext, MOUSEEVENT_MOUSE_WHEEL, WHEEL_UP, x, max32(y, 0), -1);
+   else if (event.wheel.y < 0)
+      postEvent(mainContext, MOUSEEVENT_MOUSE_WHEEL, WHEEL_DOWN, x, max32(y, 0), -1);
+   if (event.wheel.x > 0)
+      postEvent(mainContext, MOUSEEVENT_MOUSE_WHEEL, WHEEL_RIGHT, x, max32(y, 0), -1);
+   else if (event.wheel.x < 0)
+      postEvent(mainContext, MOUSEEVENT_MOUSE_WHEEL, WHEEL_LEFT, x, max32(y, 0), -1);
+}
+
+static void handleTextInputEvent(SDL_Event event)
+{
+   int i;
+   int modifier = (int)keyGetPortableModifiers(SDL_GetModState());
+   for (i = 0; event.text.text[i] != '\0'; i++)
+      postEvent(mainContext, KEYEVENT_KEY_PRESS, event.text.text[i], 0, 0, modifier);
+}
+
+void privatePumpEvent(Context currentContext)
+{
+   SDL_Event event;
+   UNUSED(currentContext)
+
+   if (!SDL_PollEvent(&event))
+      return;
+
+   switch (event.type)
+   {
+      case SDL_WINDOWEVENT:
+         if (event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED)
+            TCSDL_WindowSizeChanged(&screen, event.window.data1, event.window.data2);
+         TCSDL_Present();
+         break;
+      case SDL_FINGERDOWN:
+      case SDL_FINGERUP:
+      case SDL_FINGERMOTION:
+         handleFingerTouchEvent(event);
+         break;
+      case SDL_MOUSEMOTION:
+      case SDL_MOUSEBUTTONDOWN:
+      case SDL_MOUSEBUTTONUP:
+         handleMouseEvent(event);
+         break;
+      case SDL_KEYDOWN:
+         handleKeyboardEvent(event);
+         break;
+      case SDL_TEXTINPUT:
+         handleTextInputEvent(event);
+         break;
+      case SDL_MOUSEWHEEL:
+         handleWheelEvent(event);
+         break;
+      case SDL_QUIT:
+         keepRunning = false;
+         break;
+   }
+}
+
+bool privateInitEvent()
+{
+   return true;
+}
+
+void privateDestroyEvent()
+{
+   SDL_FlushEvents(SDL_FIRSTEVENT, SDL_LASTEVENT);
+}

--- a/TotalCrossVM/src/event/sdl/event_c.h
+++ b/TotalCrossVM/src/event/sdl/event_c.h
@@ -179,29 +179,32 @@ static void handleFingerTouchEvent(SDL_Event event)
 static void handleMouseEvent(SDL_Event event)
 {
    int32 timestamp = getTimeStamp();
-   if (event.button.button == SDL_BUTTON_LEFT)
+   switch (event.type)
    {
-      switch (event.type)
-      {
-         case SDL_MOUSEBUTTONDOWN:
+      case SDL_MOUSEBUTTONDOWN:
+         if (event.button.button == SDL_BUTTON_LEFT)
+         {
             isDragging = true;
             postEvent(mainContext, PENEVENT_PEN_DOWN, 0,
                event.button.x, event.button.y, timestamp);
-            break;
-         case SDL_MOUSEBUTTONUP:
+         }
+         break;
+      case SDL_MOUSEBUTTONUP:
+         if (event.button.button == SDL_BUTTON_LEFT)
+         {
             isDragging = false;
             postEvent(mainContext, PENEVENT_PEN_UP, 0,
                event.button.x, event.button.y, timestamp);
-            break;
-         case SDL_MOUSEMOTION:
-            if (event.motion.state == SDL_PRESSED)
-               postEvent(mainContext, PENEVENT_PEN_DRAG, 0,
-                  event.motion.x, event.motion.y, timestamp);
-            else
-               postEvent(mainContext, MOUSEEVENT_MOUSE_MOVE, 0,
-                  event.motion.x, event.motion.y, timestamp);
-            break;
-      }
+         }
+         break;
+      case SDL_MOUSEMOTION:
+         if (event.motion.state & SDL_BUTTON_LMASK)
+            postEvent(mainContext, PENEVENT_PEN_DRAG, 0,
+               event.motion.x, event.motion.y, timestamp);
+         else
+            postEvent(mainContext, MOUSEEVENT_MOUSE_MOVE, 0,
+               event.motion.x, event.motion.y, timestamp);
+         break;
    }
 }
 
@@ -233,12 +236,78 @@ static void handleWheelEvent(SDL_Event event)
       postEvent(mainContext, MOUSEEVENT_MOUSE_WHEEL, WHEEL_LEFT, x, max32(y, 0), -1);
 }
 
+static void postTextCodePoint(uint32 codePoint, int32 modifier)
+{
+   if (codePoint <= 0xFFFF)
+      postEvent(mainContext, KEYEVENT_KEY_PRESS, (int32)codePoint, 0, 0, modifier);
+   else
+   {
+      codePoint -= 0x10000;
+      postEvent(mainContext, KEYEVENT_KEY_PRESS,
+         (int32)(0xD800 + (codePoint >> 10)), 0, 0, modifier);
+      postEvent(mainContext, KEYEVENT_KEY_PRESS,
+         (int32)(0xDC00 + (codePoint & 0x3FF)), 0, 0, modifier);
+   }
+}
+
 static void handleTextInputEvent(SDL_Event event)
 {
-   int i;
-   int modifier = (int)keyGetPortableModifiers(SDL_GetModState());
-   for (i = 0; event.text.text[i] != '\0'; i++)
-      postEvent(mainContext, KEYEVENT_KEY_PRESS, event.text.text[i], 0, 0, modifier);
+   const uint8 *text = (const uint8*)event.text.text;
+   int32 modifier = (int32)keyGetPortableModifiers(SDL_GetModState());
+   while (*text != '\0')
+   {
+      uint32 codePoint;
+      int32 length;
+      uint8 first = *text++;
+
+      if (first < 0x80)
+      {
+         codePoint = first;
+         length = 0;
+      }
+      else if (first >= 0xC2 && first <= 0xDF)
+      {
+         codePoint = first & 0x1F;
+         length = 1;
+      }
+      else if (first >= 0xE0 && first <= 0xEF)
+      {
+         codePoint = first & 0x0F;
+         length = 2;
+      }
+      else if (first >= 0xF0 && first <= 0xF4)
+      {
+         codePoint = first & 0x07;
+         length = 3;
+      }
+      else
+      {
+         postTextCodePoint(0xFFFD, modifier);
+         continue;
+      }
+
+      const uint8 *continuation = text;
+      bool valid = true;
+      for (int32 i = 0; i < length; i++)
+      {
+         if ((continuation[i] & 0xC0) != 0x80)
+         {
+            valid = false;
+            break;
+         }
+         codePoint = (codePoint << 6) | (continuation[i] & 0x3F);
+      }
+      if (!valid || (length == 2 && codePoint < 0x800)
+         || (length == 3 && codePoint < 0x10000)
+         || codePoint > 0x10FFFF
+         || (codePoint >= 0xD800 && codePoint <= 0xDFFF))
+      {
+         postTextCodePoint(0xFFFD, modifier);
+         continue;
+      }
+      text += length;
+      postTextCodePoint(codePoint, modifier);
+   }
 }
 
 void privatePumpEvent(Context currentContext)
@@ -252,8 +321,35 @@ void privatePumpEvent(Context currentContext)
    switch (event.type)
    {
       case SDL_WINDOWEVENT:
-         if (event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED)
-            TCSDL_WindowSizeChanged(&screen, event.window.data1, event.window.data2);
+         switch (event.window.event)
+         {
+            case SDL_WINDOWEVENT_SIZE_CHANGED:
+            case SDL_WINDOWEVENT_DISPLAY_CHANGED:
+            case SDL_WINDOWEVENT_MOVED:
+            {
+               TScreenConfiguration configuration;
+               if (TCSDL_QueryWindowMetrics(&screen, &configuration))
+               {
+                  ScreenChangeFlags changes = screenApplyConfiguration(
+                     &screen, &configuration);
+                  screenConsumePendingChanges(&screen);
+                  screenChangeCommitted(mainContext, changes);
+               }
+               break;
+            }
+            case SDL_WINDOWEVENT_MINIMIZED:
+               postOnMinimizeOrRestore(true);
+               break;
+            case SDL_WINDOWEVENT_RESTORED:
+               postOnMinimizeOrRestore(false);
+               break;
+            case SDL_WINDOWEVENT_EXPOSED:
+               markWholeScreenDirty(mainContext);
+               break;
+            case SDL_WINDOWEVENT_CLOSE:
+               keepRunning = false;
+               break;
+         }
          TCSDL_Present();
          break;
       case SDL_FINGERDOWN:
@@ -271,6 +367,8 @@ void privatePumpEvent(Context currentContext)
          break;
       case SDL_TEXTINPUT:
          handleTextInputEvent(event);
+         break;
+      case SDL_TEXTEDITING:
          break;
       case SDL_MOUSEWHEEL:
          handleWheelEvent(event);

--- a/TotalCrossVM/src/event/sdl/event_sdl.h
+++ b/TotalCrossVM/src/event/sdl/event_sdl.h
@@ -1,0 +1,19 @@
+// Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#ifndef TC_EVENT_SDL_H
+#define TC_EVENT_SDL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void sdlEventWindowCreated(void);
+void sdlEventWindowDestroying(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/TotalCrossVM/src/event/sdl/specialkeys_c.h
+++ b/TotalCrossVM/src/event/sdl/specialkeys_c.h
@@ -1,0 +1,85 @@
+// Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#if __APPLE__
+ #include "SDL.h"
+#else
+ #include "SDL2/SDL.h"
+#endif
+
+int32 privateKeyPortable2Device(PortableSpecialKeys key)
+{
+   switch (key)
+   {
+      case SK_PAGE_UP       : return SDLK_PAGEUP;
+      case SK_PAGE_DOWN     : return SDLK_PAGEDOWN;
+      case SK_HOME          : return SDLK_HOME;
+      case SK_END           : return SDLK_END;
+      case SK_UP            : return SDLK_UP;
+      case SK_DOWN          : return SDLK_DOWN;
+      case SK_LEFT          : return SDLK_LEFT;
+      case SK_RIGHT         : return SDLK_RIGHT;
+      case SK_INSERT        : return SDLK_INSERT;
+      case SK_ENTER         : return SDLK_RETURN;
+      case SK_TAB           : return SDLK_TAB;
+      case SK_BACKSPACE     : return SDLK_BACKSPACE;
+      case SK_ESCAPE        : return SDLK_ESCAPE;
+      case SK_DELETE        : return SDLK_DELETE;
+      case SK_MENU          : return SDLK_F6;
+      case SK_KEYBOARD_ABC  : return SDLK_F11;
+      case SK_HARD1         : return SDLK_F1;
+      case SK_HARD2         : return SDLK_F2;
+      case SK_HARD3         : return SDLK_F3;
+      case SK_HARD4         : return SDLK_F4;
+      case SK_CALC          : return SDLK_F7;
+      case SK_FIND          : return SDLK_F8;
+      case SK_ACTION        : return SDLK_F12;
+      case SK_SCREEN_CHANGE : return SDLK_F9;
+      default: // avoid warning "enumeration value 'XXX' not handled in switch"
+         break;
+   }
+   return key < 0 ? -key : key;
+}
+
+PortableSpecialKeys privateKeyDevice2Portable(int32 key)
+{
+   switch (key)
+   {
+      case SDLK_PAGEUP    : return SK_PAGE_UP;
+      case SDLK_PAGEDOWN  : return SK_PAGE_DOWN;
+      case SDLK_HOME      : return SK_HOME;
+      case SDLK_END       : return SK_END;
+      case SDLK_UP        : return SK_UP;
+      case SDLK_DOWN      : return SK_DOWN;
+      case SDLK_LEFT      : return SK_LEFT;
+      case SDLK_RIGHT     : return SK_RIGHT;
+      case SDLK_INSERT    : return SK_INSERT;
+      case SDLK_RETURN    : return SK_ENTER;
+      case SDLK_TAB       : return SK_TAB;
+      case SDLK_BACKSPACE : return SK_BACKSPACE;
+      case SDLK_ESCAPE    : return SK_ESCAPE;
+      case SDLK_DELETE    : return SK_DELETE;
+      case SDLK_F1        : return SK_HARD1;
+      case SDLK_F2        : return SK_HARD2;
+      case SDLK_F3        : return SK_HARD3;
+      case SDLK_F4        : return SK_HARD4;
+      case SDLK_F6        : return SK_MENU;
+      case SDLK_F7        : return SK_CALC;
+      case SDLK_F8        : return SK_FIND;
+      case SDLK_F9        : return SK_SCREEN_CHANGE;
+      case SDLK_F10       : return SK_HOME;
+      case SDLK_F11       : return SK_KEYBOARD_ABC;
+      case SDLK_F12       : return SK_ACTION;
+   }
+   return key;
+}
+
+PortableModifiers privateKeyGetPortableModifiers(int32 mods)
+{
+   if (mods == -1)
+      return PM_NONE;
+   return (((mods & KMOD_LSHIFT) || (mods & KMOD_RSHIFT)) ? PM_SHIFT   : PM_NONE) |
+          (((mods & KMOD_LCTRL) || (mods & KMOD_RCTRL)) ? PM_CONTROL : PM_NONE) |
+          (((mods & KMOD_LALT) || (mods & KMOD_RALT)) ? PM_ALT     : PM_NONE);
+}

--- a/TotalCrossVM/src/event/specialkeys.c
+++ b/TotalCrossVM/src/event/specialkeys.c
@@ -1,21 +1,28 @@
 // Copyright (C) 2000-2013 SuperWaba Ltda.
-// Copyright (C) 2014-2020 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
-
-
 
 #include "tcvm.h"
 
 // Platform-specific code
-#if defined(WINCE) || defined(WIN32)
- #include "win/specialkeys_c.h"
-#elif defined(darwin)
- #include "darwin/specialkeys_c.h"
-#elif defined(ANDROID)
- #include "android/specialkeys_c.h"
-#elif defined(linux)
- #include "linux/specialkeys_c.h"
+#if TC_WINDOWING_SDL
+ #include "sdl/specialkeys_c.h"
+#elif TC_WINDOWING_NATIVE
+ #if TC_OS_WINDOWS || TC_OS_WINCE
+  #include "win/specialkeys_c.h"
+ #elif TC_OS_ANDROID
+  #include "android/specialkeys_c.h"
+ #elif TC_OS_IOS
+  #include "darwin/specialkeys_c.h"
+ #elif TC_OS_LINUX
+  #include "linux/specialkeys_c.h"
+ #else
+  #error Unsupported native special-key backend
+ #endif
+#else
+ #error No special-key backend selected
 #endif
 //
 

--- a/TotalCrossVM/src/event/win/event_c.h
+++ b/TotalCrossVM/src/event/win/event_c.h
@@ -1,5 +1,6 @@
 // Copyright (C) 2000-2013 SuperWaba Ltda.
-// Copyright (C) 2014-2020 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -14,20 +15,6 @@
 void markWholeScreenDirty(Context currentContext);
 void screenChange(Context currentContext, int32 newWidth, int32 newHeight, int hRes, int vRes, bool nothingChanged);
 void getScreenSize(int32 *w, int32* h); // ui/win/gfx_Graphics_c.h
-
-BOOL APIENTRY DllMain(HANDLE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved)
-{
-   switch (ul_reason_for_call)
-	{
-		case DLL_PROCESS_ATTACH:
-			hModuleTCVM = hModule;
-		case DLL_THREAD_ATTACH:
-		case DLL_THREAD_DETACH:
-		case DLL_PROCESS_DETACH:
-			break;
-   }
-   return TRUE;
-}
 
 static void hideWinCEStuff()
 {

--- a/TotalCrossVM/src/event/win/event_c.h
+++ b/TotalCrossVM/src/event/win/event_c.h
@@ -11,6 +11,8 @@
  #include "win/aygshellLib.h"
 #endif
 
+#include "../../nm/ui/Window.h"
+
 
 void markWholeScreenDirty(Context currentContext);
 void screenChange(Context currentContext, int32 newWidth, int32 newHeight, int hRes, int vRes, bool nothingChanged);
@@ -362,10 +364,14 @@ cont:
                if (keysMatch(*keys, key))
                {
                   key = keyDevice2Portable(*keys);
-                  if (key == SK_SCREEN_CHANGE)
-                  {
-                     if (*tcSettings.screenWidthPtr != *tcSettings.screenHeightPtr)
-                        screenChange(mainContext, *tcSettings.screenHeightPtr, *tcSettings.screenWidthPtr, *tcSettings.screenHeightInDPIPtr, *tcSettings.screenWidthInDPIPtr, false);
+                     if (key == SK_SCREEN_CHANGE)
+                     {
+                        if (*tcSettings.screenWidthPtr != *tcSettings.screenHeightPtr)
+                        {
+                           windowBackendSetSize(*tcSettings.screenHeightPtr,
+                              *tcSettings.screenWidthPtr);
+                           screenChange(mainContext, *tcSettings.screenHeightPtr, *tcSettings.screenWidthPtr, *tcSettings.screenHeightInDPIPtr, *tcSettings.screenWidthInDPIPtr, false);
+                        }
                   }
                   else
                   {
@@ -389,6 +395,8 @@ cont:
                   int t = screen.minScreenW;
                   screen.minScreenW = screen.minScreenH;
                   screen.minScreenH = t;
+                  windowBackendSetSize(*tcSettings.screenHeightPtr,
+                     *tcSettings.screenWidthPtr);
                   screenChange(mainContext, *tcSettings.screenHeightPtr, *tcSettings.screenWidthPtr, *tcSettings.screenHeightInDPIPtr, *tcSettings.screenWidthInDPIPtr, false);
                }
             }

--- a/TotalCrossVM/src/event/win/event_c.h
+++ b/TotalCrossVM/src/event/win/event_c.h
@@ -364,14 +364,18 @@ cont:
                if (keysMatch(*keys, key))
                {
                   key = keyDevice2Portable(*keys);
-                     if (key == SK_SCREEN_CHANGE)
+                  if (key == SK_SCREEN_CHANGE)
+                  {
+                     int32 targetWidth = *tcSettings.screenHeightPtr;
+                     int32 targetHeight = *tcSettings.screenWidthPtr;
+                     int32 targetHRes = *tcSettings.screenHeightInDPIPtr;
+                     int32 targetVRes = *tcSettings.screenWidthInDPIPtr;
+                     if (targetWidth != targetHeight)
                      {
-                        if (*tcSettings.screenWidthPtr != *tcSettings.screenHeightPtr)
-                        {
-                           windowBackendSetSize(*tcSettings.screenHeightPtr,
-                              *tcSettings.screenWidthPtr);
-                           screenChange(mainContext, *tcSettings.screenHeightPtr, *tcSettings.screenWidthPtr, *tcSettings.screenHeightInDPIPtr, *tcSettings.screenWidthInDPIPtr, false);
-                        }
+                        windowBackendSetSize(targetWidth, targetHeight);
+                        screenChange(mainContext, targetWidth, targetHeight,
+                           targetHRes, targetVRes, false);
+                     }
                   }
                   else
                   {
@@ -392,12 +396,16 @@ cont:
                else
                if (*tcSettings.screenWidthPtr != *tcSettings.screenHeightPtr)
                {
+                  int32 targetWidth = *tcSettings.screenHeightPtr;
+                  int32 targetHeight = *tcSettings.screenWidthPtr;
+                  int32 targetHRes = *tcSettings.screenHeightInDPIPtr;
+                  int32 targetVRes = *tcSettings.screenWidthInDPIPtr;
                   int t = screen.minScreenW;
                   screen.minScreenW = screen.minScreenH;
                   screen.minScreenH = t;
-                  windowBackendSetSize(*tcSettings.screenHeightPtr,
-                     *tcSettings.screenWidthPtr);
-                  screenChange(mainContext, *tcSettings.screenHeightPtr, *tcSettings.screenWidthPtr, *tcSettings.screenHeightInDPIPtr, *tcSettings.screenWidthInDPIPtr, false);
+                  windowBackendSetSize(targetWidth, targetHeight);
+                  screenChange(mainContext, targetWidth, targetHeight,
+                     targetHRes, targetVRes, false);
                }
             }
          }

--- a/TotalCrossVM/src/init/globals.c
+++ b/TotalCrossVM/src/init/globals.c
@@ -47,8 +47,10 @@ bool destroyingApplication = false;
 TCObject mainClass = { 0 };  // the instance being executed
 bool isMainWindow = false;   // extends MainWindow ?
 #if TC_OS_DESKTOP
-int32 defScrX = -1, defScrY = -1, defScrW = -1, defScrH = -1;
-TCInitialWindowState initialWindowState = TC_INITIAL_WINDOW_NORMAL;
+TCWindowStartupOptions desktopWindowStartupOptions = {
+   false, -1, -1, -1, -1, -1, -1,
+   TC_INITIAL_WINDOW_NORMAL, false, 0
+};
 #endif
 #if defined(ANDROID)
 JavaVM* androidJVM;

--- a/TotalCrossVM/src/init/globals.c
+++ b/TotalCrossVM/src/init/globals.c
@@ -46,6 +46,10 @@ bool rebootOnExit = false;
 bool destroyingApplication = false;
 TCObject mainClass = { 0 };  // the instance being executed
 bool isMainWindow = false;   // extends MainWindow ?
+#if TC_OS_DESKTOP
+int32 defScrX = -1, defScrY = -1, defScrW = -1, defScrH = -1;
+TCInitialWindowState initialWindowState = TC_INITIAL_WINDOW_NORMAL;
+#endif
 #if defined(ANDROID)
 JavaVM* androidJVM;
 jobject applicationObj, applicationContext;

--- a/TotalCrossVM/src/init/globals.h
+++ b/TotalCrossVM/src/init/globals.h
@@ -47,6 +47,17 @@ extern bool rebootOnExit;
 extern bool destroyingApplication;
 extern TCObject mainClass;  // the instance being executed
 extern bool isMainWindow;   // extends MainWindow ?
+#if TC_OS_DESKTOP
+typedef enum TCInitialWindowState
+{
+   TC_INITIAL_WINDOW_NORMAL,
+   TC_INITIAL_WINDOW_FULLSCREEN,
+   TC_INITIAL_WINDOW_MAXIMIZED
+} TCInitialWindowState;
+
+extern int32 defScrX, defScrY, defScrW, defScrH;
+extern TCInitialWindowState initialWindowState;
+#endif
 #if defined(ANDROID)
 extern JavaVM* androidJVM;
 extern jobject applicationObj, applicationContext;

--- a/TotalCrossVM/src/init/globals.h
+++ b/TotalCrossVM/src/init/globals.h
@@ -13,6 +13,8 @@
 extern "C" {
 #endif
 
+#include "../nm/ui/WindowStartup.h"
+
 // tcclass.c
 extern Hashtable htLoadedClasses;
 extern TCClassArray vLoadedClasses;
@@ -48,15 +50,7 @@ extern bool destroyingApplication;
 extern TCObject mainClass;  // the instance being executed
 extern bool isMainWindow;   // extends MainWindow ?
 #if TC_OS_DESKTOP
-typedef enum TCInitialWindowState
-{
-   TC_INITIAL_WINDOW_NORMAL,
-   TC_INITIAL_WINDOW_FULLSCREEN,
-   TC_INITIAL_WINDOW_MAXIMIZED
-} TCInitialWindowState;
-
-extern int32 defScrX, defScrY, defScrW, defScrH;
-extern TCInitialWindowState initialWindowState;
+extern TCWindowStartupOptions desktopWindowStartupOptions;
 #endif
 #if defined(ANDROID)
 extern JavaVM* androidJVM;

--- a/TotalCrossVM/src/init/settings.c
+++ b/TotalCrossVM/src/init/settings.c
@@ -246,7 +246,9 @@ void updateScreenSettings(ScreenSurface screen) // will be called from initGraph
    double contentScale = screen->contentScale > 0 ? screen->contentScale : 1;
 
 #if defined (WIN32) || defined (WINCE)
+#if !TC_WINDOWING_SDL
    contentScale = min32(screen->screenW, screen->screenH) <= 240 ? 0.75 : contentScale;
+#endif
 #endif
    *tcSettings.screenWidthPtr = (int32)(screen->screenW / contentScale + 0.5);
    *tcSettings.screenHeightPtr = (int32)(screen->screenH / contentScale + 0.5);

--- a/TotalCrossVM/src/init/startup.c
+++ b/TotalCrossVM/src/init/startup.c
@@ -12,6 +12,9 @@
 #include "tcvm.h"
 #include "tcz.h"
 #include "nativeProcAddressesTC.h"
+#if TC_WINDOWING_SDL
+ #include "tcsdl.h"
+#endif
 
 #if defined (WINCE) || defined (WIN32)
  #include "malloc.h"
@@ -224,8 +227,19 @@ TC_API int32 startProgram(Context currentContext)
    if (currentContext->thrownException == null && keepRunning)
    {
       checkFullScreenPlatform();
-      if (*tcSettings.isFullScreenPtr) // Settings.isFullScreen is set at the static initializer
+#if TC_OS_DESKTOP
+#if !TC_WINDOWING_SDL
+      if (initialWindowState == TC_INITIAL_WINDOW_FULLSCREEN
+         || (initialWindowState == TC_INITIAL_WINDOW_NORMAL && *tcSettings.isFullScreenPtr))
          setFullScreen();
+#else
+      if (initialWindowState == TC_INITIAL_WINDOW_NORMAL && *tcSettings.isFullScreenPtr)
+         TCSDL_SetFullscreen(true);
+#endif
+#else
+      if (*tcSettings.isFullScreenPtr)
+         setFullScreen();
+#endif
       // 4. Retrieve user settings
       retrieveSettingsChangedAtStaticInitializer(currentContext);
       // 5. create an instance and call the constructor
@@ -275,6 +289,152 @@ static void loadExceptionClasses(Context currentContext)
 #define ALLOW_TEST_SUITE true
 #endif
 
+#if TC_OS_DESKTOP
+typedef enum
+{
+   STARTUP_OPTION_SCREEN_BOUNDS,
+   STARTUP_OPTION_FULLSCREEN,
+   STARTUP_OPTION_MAXIMIZED,
+   STARTUP_OPTION_SDL_PIXEL_FORMAT
+} TCStartupOptionKind;
+
+typedef struct
+{
+   const char *name;
+   TCStartupOptionKind kind;
+} TCStartupOption;
+
+static const TCStartupOption startupOptions[] =
+{
+   { "/scr", STARTUP_OPTION_SCREEN_BOUNDS },
+   { "/fullscreen", STARTUP_OPTION_FULLSCREEN },
+   { "/maximized", STARTUP_OPTION_MAXIMIZED },
+   { "/sdlPixelFormat", STARTUP_OPTION_SDL_PIXEL_FORMAT }
+};
+
+static bool isStartupOption(CharP command, CharP position, const char *option)
+{
+   size_t optionLength = xstrlen(option);
+   return (position == command || *(position - 1) == ' ')
+      && strncmp(position, option, optionLength) == 0
+      && (position[optionLength] == ' ' || position[optionLength] == '\0');
+}
+
+static bool parseScreenBounds(CharP value)
+{
+   int count = 0;
+   int32 x, y, width, height;
+   if (sscanf(value, "%d,%d,%d,%d%n", &x, &y, &width, &height, &count) != 4
+      || (value[count] != '\0' && value[count] != ' ')
+      || x < -2 || y < -2 || width == 0 || height == 0 || width < -1 || height < -1)
+   {
+      alert("Format: <other arguments> /scr x,y,width,height\nPass -1 to use the default and -2 to center on screen.");
+      return false;
+   }
+   defScrX = x;
+   defScrY = y;
+   defScrW = width;
+   defScrH = height;
+   return true;
+}
+
+static const TCStartupOption *findStartupOption(CharP command, CharP position)
+{
+   size_t i;
+   for (i = 0; i < sizeof(startupOptions) / sizeof(startupOptions[0]); ++i)
+      if (isStartupOption(command, position, startupOptions[i].name))
+         return &startupOptions[i];
+   return null;
+}
+
+static bool parseInitialWindowState(TCInitialWindowState state)
+{
+   if (initialWindowState != TC_INITIAL_WINDOW_NORMAL && initialWindowState != state)
+   {
+      alert("/fullscreen and /maximized cannot be combined.");
+      return false;
+   }
+   initialWindowState = state;
+   return true;
+}
+
+static bool parseDesktopStartupOptions(CharP command)
+{
+   CharP read = command;
+   CharP write = command;
+   CharP commandEnd = xstrstr(command, " /cmd ");
+   while (*read != '\0' && (commandEnd == null || read < commandEnd))
+   {
+      const TCStartupOption *option = findStartupOption(command, read);
+      if (option != null && option->kind == STARTUP_OPTION_SCREEN_BOUNDS)
+      {
+         CharP value = read + xstrlen(option->name);
+         while (*value == ' ')
+            value++;
+         if (!parseScreenBounds(value))
+            return false;
+         read = value;
+         while (*read != '\0' && *read != ' ')
+            read++;
+         continue;
+      }
+      if (option != null && option->kind == STARTUP_OPTION_FULLSCREEN)
+      {
+         if (!parseInitialWindowState(TC_INITIAL_WINDOW_FULLSCREEN))
+            return false;
+         read += xstrlen(option->name);
+         continue;
+      }
+      if (option != null && option->kind == STARTUP_OPTION_MAXIMIZED)
+      {
+         if (!parseInitialWindowState(TC_INITIAL_WINDOW_MAXIMIZED))
+            return false;
+         read += xstrlen(option->name);
+         continue;
+      }
+      if (option != null && option->kind == STARTUP_OPTION_SDL_PIXEL_FORMAT)
+      {
+         CharP value = read + xstrlen(option->name);
+         CharP valueEnd;
+         while (*value == ' ')
+            value++;
+         valueEnd = value;
+         while (*valueEnd != '\0' && *valueEnd != ' ')
+            valueEnd++;
+         if (valueEnd == value)
+         {
+            alert("Format: /sdlPixelFormat <auto|argb8888|rgb565>");
+            return false;
+         }
+#if TC_WINDOWING_SDL
+         {
+            char saved = *valueEnd;
+            bool valid;
+            *valueEnd = '\0';
+            valid = TCSDL_SetPixelFormatRequest(value);
+            *valueEnd = saved;
+            if (!valid)
+            {
+               alert("Format: /sdlPixelFormat <auto|argb8888|rgb565>");
+               return false;
+            }
+         }
+#else
+         alert("/sdlPixelFormat requires SDL windowing.");
+         return false;
+#endif
+         read = valueEnd;
+         continue;
+      }
+      *write++ = *read++;
+   }
+   while (*read != '\0')
+      *write++ = *read++;
+   *write = '\0';
+   return true;
+}
+#endif
+
 TC_API int32 startVM(CharP argsOriginal, Context* cOut)
 {
    CharP cmdline;
@@ -292,14 +452,10 @@ TC_API int32 startVM(CharP argsOriginal, Context* cOut)
     if (isWakeUpCall(argsOriginal))
       return 109;
  #endif
-#elif defined WIN32
-   if (argsOriginalLen > 0 && xstrstr(argsOriginal, "/scr"))
-   {
-      argsOriginal = parseScreenBounds(argsOriginal, &defScrX, &defScrY, &defScrW, &defScrH);
-      if (!argsOriginal)
-         return 110;
-      argsOriginalLen = xstrlen(argsOriginal);
-   }
+#elif TC_OS_DESKTOP
+   if (argsOriginalLen > 0 && !parseDesktopStartupOptions(argsOriginal))
+      return 110;
+   argsOriginalLen = xstrlen(argsOriginal);
 #endif
 
    xstrncpy(args, argsOriginal, min32(sizeof(args)-1, argsOriginalLen));

--- a/TotalCrossVM/src/init/startup.c
+++ b/TotalCrossVM/src/init/startup.c
@@ -229,11 +229,11 @@ TC_API int32 startProgram(Context currentContext)
       checkFullScreenPlatform();
 #if TC_OS_DESKTOP
 #if !TC_WINDOWING_SDL
-      if (initialWindowState == TC_INITIAL_WINDOW_FULLSCREEN
-         || (initialWindowState == TC_INITIAL_WINDOW_NORMAL && *tcSettings.isFullScreenPtr))
+      if (desktopWindowStartupOptions.initialState == TC_INITIAL_WINDOW_FULLSCREEN
+         || (desktopWindowStartupOptions.initialState == TC_INITIAL_WINDOW_NORMAL && *tcSettings.isFullScreenPtr))
          setFullScreen();
 #else
-      if (initialWindowState == TC_INITIAL_WINDOW_NORMAL && *tcSettings.isFullScreenPtr)
+      if (desktopWindowStartupOptions.initialState == TC_INITIAL_WINDOW_NORMAL && *tcSettings.isFullScreenPtr)
          TCSDL_SetFullscreen(true);
 #endif
 #else
@@ -356,10 +356,11 @@ static CharP parseScreenBounds(CharP value)
       alert("Format: <other arguments> /scr x,y,width,height\nPass -1 to use the default and -2 to center on screen.");
       return null;
    }
-   defScrX = x;
-   defScrY = y;
-   defScrW = width;
-   defScrH = height;
+   desktopWindowStartupOptions.x = x;
+   desktopWindowStartupOptions.y = y;
+   desktopWindowStartupOptions.width = width;
+   desktopWindowStartupOptions.height = height;
+   desktopWindowStartupOptions.screenSpecified = true;
    return value + count;
 }
 
@@ -374,12 +375,13 @@ static const TCStartupOption *findStartupOption(CharP command, CharP position)
 
 static bool parseInitialWindowState(TCInitialWindowState state)
 {
-   if (initialWindowState != TC_INITIAL_WINDOW_NORMAL && initialWindowState != state)
+   if (desktopWindowStartupOptions.initialState != TC_INITIAL_WINDOW_NORMAL
+      && desktopWindowStartupOptions.initialState != state)
    {
       alert("/fullscreen and /maximized cannot be combined.");
       return false;
    }
-   initialWindowState = state;
+   desktopWindowStartupOptions.initialState = state;
    return true;
 }
 
@@ -413,6 +415,7 @@ static bool filterDesktopCommandLine(CharP command,
    int32 commandSize = xstrlen(command) + 1;
 
    xmemzero(options, sizeof(*options));
+   windowResetCommandLineOptions(&desktopWindowStartupOptions);
 
    while (*read != '\0')
    {

--- a/TotalCrossVM/src/init/startup.c
+++ b/TotalCrossVM/src/init/startup.c
@@ -289,6 +289,23 @@ static void loadExceptionClasses(Context currentContext)
 #define ALLOW_TEST_SUITE true
 #endif
 
+static CharP findCommandSeparator(CharP command)
+{
+#if TC_OS_DESKTOP
+   CharP search = command;
+   CharP separator;
+   while ((separator = xstrstr(search, " /cmd")) != null)
+   {
+      if (separator[5] == ' ' || separator[5] == '\0')
+         return separator;
+      search = separator + 5;
+   }
+   return null;
+#else
+   return xstrstr(command, " /cmd ");
+#endif
+}
+
 #if TC_OS_DESKTOP
 typedef enum
 {
@@ -312,6 +329,14 @@ static const TCStartupOption startupOptions[] =
    { "/sdlPixelFormat", STARTUP_OPTION_SDL_PIXEL_FORMAT }
 };
 
+typedef struct
+{
+   bool traceRequested;
+   bool testSuiteRequested;
+   bool pathRequested;
+   char path[MAX_PATHNAME];
+} DesktopCommandLineOptions;
+
 static bool isStartupOption(CharP command, CharP position, const char *option)
 {
    size_t optionLength = xstrlen(option);
@@ -320,7 +345,7 @@ static bool isStartupOption(CharP command, CharP position, const char *option)
       && (position[optionLength] == ' ' || position[optionLength] == '\0');
 }
 
-static bool parseScreenBounds(CharP value)
+static CharP parseScreenBounds(CharP value)
 {
    int count = 0;
    int32 x, y, width, height;
@@ -329,13 +354,13 @@ static bool parseScreenBounds(CharP value)
       || x < -2 || y < -2 || width == 0 || height == 0 || width < -1 || height < -1)
    {
       alert("Format: <other arguments> /scr x,y,width,height\nPass -1 to use the default and -2 to center on screen.");
-      return false;
+      return null;
    }
    defScrX = x;
    defScrY = y;
    defScrW = width;
    defScrH = height;
-   return true;
+   return value + count;
 }
 
 static const TCStartupOption *findStartupOption(CharP command, CharP position)
@@ -358,43 +383,77 @@ static bool parseInitialWindowState(TCInitialWindowState state)
    return true;
 }
 
-static bool parseDesktopStartupOptions(CharP command)
+static bool appendCommandToken(CharP *write, CharP output, int32 outputSize,
+   bool *hasToken, CharP token, CharP tokenEnd)
+{
+   if (token == tokenEnd)
+      return true;
+   if (*hasToken)
+   {
+      if (*write - output >= outputSize - 1)
+         return false;
+      *(*write)++ = ' ';
+   }
+   while (token < tokenEnd)
+   {
+      if (*write - output >= outputSize - 1)
+         return false;
+      *(*write)++ = *token++;
+   }
+   *hasToken = true;
+   return true;
+}
+
+static bool filterDesktopCommandLine(CharP command,
+   DesktopCommandLineOptions *options)
 {
    CharP read = command;
    CharP write = command;
-   CharP commandEnd = xstrstr(command, " /cmd ");
-   while (*read != '\0' && (commandEnd == null || read < commandEnd))
+   bool hasToken = false;
+   int32 commandSize = xstrlen(command) + 1;
+
+   xmemzero(options, sizeof(*options));
+
+   while (*read != '\0')
    {
-      const TCStartupOption *option = findStartupOption(command, read);
+      CharP token;
+      CharP tokenEnd;
+      const TCStartupOption *option;
+
+      while (*read == ' ')
+         read++;
+      if (*read == '\0')
+         break;
+      token = read;
+      while (*read != '\0' && *read != ' ')
+         read++;
+      tokenEnd = read;
+      option = findStartupOption(command, token);
       if (option != null && option->kind == STARTUP_OPTION_SCREEN_BOUNDS)
       {
-         CharP value = read + xstrlen(option->name);
+         CharP value = read;
          while (*value == ' ')
             value++;
-         if (!parseScreenBounds(value))
+         read = parseScreenBounds(value);
+         if (read == null)
             return false;
-         read = value;
-         while (*read != '\0' && *read != ' ')
-            read++;
          continue;
       }
       if (option != null && option->kind == STARTUP_OPTION_FULLSCREEN)
       {
          if (!parseInitialWindowState(TC_INITIAL_WINDOW_FULLSCREEN))
             return false;
-         read += xstrlen(option->name);
          continue;
       }
       if (option != null && option->kind == STARTUP_OPTION_MAXIMIZED)
       {
          if (!parseInitialWindowState(TC_INITIAL_WINDOW_MAXIMIZED))
             return false;
-         read += xstrlen(option->name);
          continue;
       }
       if (option != null && option->kind == STARTUP_OPTION_SDL_PIXEL_FORMAT)
       {
-         CharP value = read + xstrlen(option->name);
+         CharP value = read;
          CharP valueEnd;
          while (*value == ' ')
             value++;
@@ -426,13 +485,64 @@ static bool parseDesktopStartupOptions(CharP command)
          read = valueEnd;
          continue;
       }
-      *write++ = *read++;
+      if (isStartupOption(command, token, "-t"))
+      {
+         options->traceRequested = true;
+         continue;
+      }
+      if (isStartupOption(command, token, "-p"))
+      {
+         CharP path = read;
+         CharP pathEnd;
+         options->pathRequested = true;
+         while (*path == ' ')
+            path++;
+         pathEnd = path;
+         while (*pathEnd != '\0' && *pathEnd != ' ')
+            pathEnd++;
+         if (pathEnd != path)
+            xstrncpy(options->path, path, sizeof(options->path) - 1);
+         read = pathEnd;
+         continue;
+      }
+      if (isStartupOption(command, token, "-testsuite"))
+      {
+         options->testSuiteRequested = true;
+         continue;
+      }
+      if (!appendCommandToken(&write, command, commandSize, &hasToken,
+         token, tokenEnd))
+         return false;
    }
-   while (*read != '\0')
-      *write++ = *read++;
    *write = '\0';
    return true;
 }
+
+static bool prepareDesktopCommandLines(CharP vmCommandLine,
+   CharP applicationCommandLine, int32 applicationCommandLineSize,
+   DesktopCommandLineOptions *options)
+{
+   CharP separator;
+
+   if (!filterDesktopCommandLine(vmCommandLine, options))
+      return false;
+   separator = findCommandSeparator(vmCommandLine);
+   if (separator == null)
+   {
+      *applicationCommandLine = '\0';
+      return true;
+   }
+   if (separator[5] == '\0')
+      *applicationCommandLine = '\0';
+   else
+      xstrncpy(applicationCommandLine, separator + 6,
+         applicationCommandLineSize - 1);
+   return true;
+}
+
+#ifdef ENABLE_TEST_SUITE
+#include "startup_test.h"
+#endif
 #endif
 
 TC_API int32 startVM(CharP argsOriginal, Context* cOut)
@@ -441,9 +551,15 @@ TC_API int32 startVM(CharP argsOriginal, Context* cOut)
    TCZFile loadedTCZ;
    char args[256];
    char argsLower[256];
+#if TC_OS_DESKTOP
+   char vmCommandLine[512];
+   char applicationCommandLine[256] = { 0 };
+   DesktopCommandLineOptions desktopCommandLineOptions = { 0 };
+#endif
    CharP tczName;
    int32 argsOriginalLen = argsOriginal ? xstrlen(argsOriginal) : 0;
    CharP c;
+   CharP commandLineToParse;
    Context currentContext;
    TCObject name;
 
@@ -453,9 +569,15 @@ TC_API int32 startVM(CharP argsOriginal, Context* cOut)
       return 109;
  #endif
 #elif TC_OS_DESKTOP
-   if (argsOriginalLen > 0 && !parseDesktopStartupOptions(argsOriginal))
-      return 110;
-   argsOriginalLen = xstrlen(argsOriginal);
+   if (argsOriginalLen > 0)
+   {
+      xstrncpy(vmCommandLine, argsOriginal, sizeof(vmCommandLine) - 1);
+      if (!prepareDesktopCommandLines(vmCommandLine, applicationCommandLine,
+         sizeof(applicationCommandLine), &desktopCommandLineOptions))
+         return 110;
+      argsOriginal = vmCommandLine;
+      argsOriginalLen = xstrlen(vmCommandLine);
+   }
 #endif
 
    xstrncpy(args, argsOriginal, min32(sizeof(args)-1, argsOriginalLen));
@@ -476,22 +598,43 @@ TC_API int32 startVM(CharP argsOriginal, Context* cOut)
 
    initException(); // load exceptions
 
+#if TC_OS_DESKTOP
+   if (desktopCommandLineOptions.traceRequested)
+      traceOn = true;
+   if (desktopCommandLineOptions.pathRequested)
+   {
+      closeDebug();
+      xstrcpy(appPath, desktopCommandLineOptions.path);
+   }
+#endif
+
    xstrcpy(argsLower, args);
    CharPToLower(argsLower);
    if (xstrstr(argsLower, "launcher") && 0) // if executing the default Launcher, instead of creating a launcher for an application, run the testsuite
       xstrcpy(args, " /cmd -testsuite");
 
-   cmdline = xstrstr(args, " /cmd "); // check if there's a cmd line
+   cmdline = findCommandSeparator(args); // check if there's a cmd line
    if (cmdline) // if yes, split the cmdline and the tczName
    {
       *cmdline = 0;
-      cmdline += 6;
+      cmdline += cmdline[5] == ' ' ? 6 : 5;
    }
+
+#if TC_OS_DESKTOP
+   commandLineToParse = cmdline == null ? null : applicationCommandLine;
+#else
+   commandLineToParse = cmdline;
+#endif
 
    if (cmdline || !*args) // parse the command line
    {
-      bool loop = true;
-      if (ALLOW_TEST_SUITE && (!*args || xstrstr(cmdline,"-testsuite")))
+      if (ALLOW_TEST_SUITE && (!*args ||
+#if TC_OS_DESKTOP
+         desktopCommandLineOptions.testSuiteRequested
+#else
+         xstrstr(commandLineToParse,"-testsuite")
+#endif
+         ))
       {
          #ifdef ENABLE_TEST_SUITE
           initSettings(currentContext, "", null);
@@ -516,19 +659,24 @@ TC_API int32 startVM(CharP argsOriginal, Context* cOut)
          #endif
           return exitProgram(-1);
       }
-      c = cmdline;
-      if (cmdline) 
+#if TC_OS_DESKTOP
+      if (commandLineToParse != null)
+         xstrncpy(commandLine, commandLineToParse, sizeof(commandLine) - 1);
+#else
+      bool loop = true;
+      c = commandLineToParse;
+      if (commandLineToParse)
       while (loop)
       {
-         switch (*cmdline++)
+         switch (*commandLineToParse++)
          {
             case 0:
-               cmdline--;
+               commandLineToParse--;
                loop = false;
                break;
             case '-': // possible options
             {
-               switch (toLower(*cmdline++))
+               switch (toLower(*commandLineToParse++))
                {
                   case 't':
                   {
@@ -539,12 +687,12 @@ TC_API int32 startVM(CharP argsOriginal, Context* cOut)
                   case 'p': // required on systems that can't determine the executable directory of the current process
                   {
                      closeDebug(); // close debug file before an appPath change, not terrible :-(
-                     cmdline = nextArgPath(cmdline, appPath);
+                     commandLineToParse = nextArgPath(commandLineToParse, appPath);
                      goto jumpArgument;
                   }
                   break;
 jumpArgument:
-                  c = cmdline;
+                  c = commandLineToParse;
                   default:
                      break;
                }
@@ -557,7 +705,8 @@ jumpArgument:
       while (*c == ' ' && *c != 0)
          c++;
       if (commandLine != null && c != null)
-         xstrcpy(commandLine, c);
+         xstrncpy(commandLine, c, sizeof(commandLine) - 1);
+#endif
    }
 
 #if defined(ENABLE_TRACE) && (defined(WINCE) || defined(ANDROID)) && !defined(DEBUG)

--- a/TotalCrossVM/src/init/startup_test.h
+++ b/TotalCrossVM/src/init/startup_test.h
@@ -1,0 +1,73 @@
+// Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+TESTCASE(startup_filterApplicationCommandLine)
+{
+#if TC_OS_DESKTOP && TC_WINDOWING_SDL
+   char vmCommandLine[512] =
+      "App.tcz -t /cmdlike /scr -2,-2,800,600 /cmd foo /fullscreen bar "
+      "-p /tmp/app baz -testsuite qux /sdlPixelFormat auto "
+      "/scrSomething /cmdlike -testsuitelike";
+   char applicationCommandLine[256];
+   char oldAppPath[MAX_PATHNAME];
+   TCWindowStartupOptions oldStartupOptions = desktopWindowStartupOptions;
+   DesktopCommandLineOptions desktopCommandLineOptions;
+
+   xstrcpy(oldAppPath, appPath);
+   desktopWindowStartupOptions.initialState = TC_INITIAL_WINDOW_NORMAL;
+   if (!prepareDesktopCommandLines(vmCommandLine, applicationCommandLine,
+      sizeof(applicationCommandLine), &desktopCommandLineOptions))
+   {
+      TEST_FAIL(tc, "Could not prepare the desktop command line");
+      goto cleanup;
+   }
+   if (!desktopCommandLineOptions.testSuiteRequested
+      || !desktopCommandLineOptions.traceRequested
+      || !desktopCommandLineOptions.pathRequested
+      || xstrcmp(desktopCommandLineOptions.path, "/tmp/app") != 0
+      || desktopWindowStartupOptions.x != -2
+      || desktopWindowStartupOptions.y != -2
+      || desktopWindowStartupOptions.width != 800
+      || desktopWindowStartupOptions.height != 600
+      || !desktopWindowStartupOptions.screenSpecified
+      || desktopWindowStartupOptions.initialState != TC_INITIAL_WINDOW_FULLSCREEN)
+   {
+      TEST_FAIL(tc, "Desktop VM options were not parsed correctly");
+      goto cleanup;
+   }
+   if (xstrcmp(vmCommandLine,
+      "App.tcz /cmdlike /cmd foo bar baz qux /scrSomething /cmdlike "
+      "-testsuitelike") != 0
+      || xstrcmp(applicationCommandLine,
+         "foo bar baz qux /scrSomething /cmdlike -testsuitelike") != 0)
+   {
+      TEST_FAIL(tc, "Desktop command-line compaction was incorrect");
+      goto cleanup;
+   }
+
+   xstrcpy(vmCommandLine,
+      "App.tcz /cmd /admin W DEBUG /scr -2, -2, 480, 720");
+   desktopWindowStartupOptions.initialState = TC_INITIAL_WINDOW_NORMAL;
+   if (!prepareDesktopCommandLines(vmCommandLine, applicationCommandLine,
+      sizeof(applicationCommandLine), &desktopCommandLineOptions)
+      || desktopWindowStartupOptions.x != -2
+      || desktopWindowStartupOptions.y != -2
+      || desktopWindowStartupOptions.width != 480
+      || desktopWindowStartupOptions.height != 720
+      || !desktopWindowStartupOptions.screenSpecified
+      || xstrcmp(vmCommandLine, "App.tcz /cmd /admin W DEBUG") != 0
+      || xstrcmp(applicationCommandLine, "/admin W DEBUG") != 0)
+   {
+      TEST_FAIL(tc, "Screen bounds payload was not fully filtered");
+      goto cleanup;
+   }
+
+cleanup:
+   xstrcpy(appPath, oldAppPath);
+   desktopWindowStartupOptions = oldStartupOptions;
+#else
+   TEST_SKIP;
+#endif
+   finish: ;
+}

--- a/TotalCrossVM/src/init/tcsdl.cpp
+++ b/TotalCrossVM/src/init/tcsdl.cpp
@@ -11,14 +11,136 @@
 #endif
 
 #include <cmath>
+#include <cctype>
 #include <cstdio>
 #include <cstdlib>
 
-static const Uint32 TCSDL_PIXEL_FORMAT = SDL_PIXELFORMAT_ARGB8888;
+enum TCSDLRequestedPixelFormat
+{
+   TCSDL_PIXEL_FORMAT_AUTO,
+   TCSDL_PIXEL_FORMAT_ARGB8888_REQUEST,
+   TCSDL_PIXEL_FORMAT_RGB565_REQUEST
+};
+
 static SDL_Renderer *renderer;
 static SDL_Texture *texture;
 static SDL_Window *window;
 static bool sdlInitialized;
+static TCSDLRequestedPixelFormat requestedPixelFormat = TCSDL_PIXEL_FORMAT_AUTO;
+static bool commandLinePixelFormatSet;
+static Uint32 selectedPixelFormat = SDL_PIXELFORMAT_UNKNOWN;
+
+static bool equalsIgnoreCase(const char *value, const char *expected)
+{
+   while (*value != '\0' && *expected != '\0')
+   {
+      if (std::tolower((unsigned char)*value) != std::tolower((unsigned char)*expected))
+         return false;
+      value++;
+      expected++;
+   }
+   return *value == '\0' && *expected == '\0';
+}
+
+static bool parsePixelFormat(const char *value, TCSDLRequestedPixelFormat *parsed)
+{
+   if (equalsIgnoreCase(value, "auto"))
+      *parsed = TCSDL_PIXEL_FORMAT_AUTO;
+   else if (equalsIgnoreCase(value, "argb8888"))
+      *parsed = TCSDL_PIXEL_FORMAT_ARGB8888_REQUEST;
+   else if (equalsIgnoreCase(value, "rgb565"))
+      *parsed = TCSDL_PIXEL_FORMAT_RGB565_REQUEST;
+   else
+      return false;
+   return true;
+}
+
+static Uint32 requestedSDLFormat(TCSDLRequestedPixelFormat requested)
+{
+   return requested == TCSDL_PIXEL_FORMAT_ARGB8888_REQUEST ? SDL_PIXELFORMAT_ARGB8888
+      : requested == TCSDL_PIXEL_FORMAT_RGB565_REQUEST ? SDL_PIXELFORMAT_RGB565
+      : SDL_PIXELFORMAT_UNKNOWN;
+}
+
+static bool isSupportedPixelFormat(Uint32 format)
+{
+   return format == SDL_PIXELFORMAT_ARGB8888 || format == SDL_PIXELFORMAT_RGB565;
+}
+
+static bool rendererSupportsPixelFormat(Uint32 format)
+{
+   SDL_RendererInfo info;
+   if (SDL_GetRendererInfo(renderer, &info) != 0 || info.num_texture_formats <= 0)
+      return true;
+   for (Uint32 i = 0; i < info.num_texture_formats; ++i)
+      if (info.texture_formats[i] == format)
+         return true;
+   return false;
+}
+
+static SDL_Texture *createStreamingTexture(Uint32 format, int width, int height)
+{
+   if (!rendererSupportsPixelFormat(format))
+   {
+      SDL_SetError("renderer does not advertise this texture format");
+      return NULL;
+   }
+   return SDL_CreateTexture(renderer, format, SDL_TEXTUREACCESS_STREAMING, width, height);
+}
+
+static bool addCandidate(Uint32 *candidates, int *count, Uint32 candidate)
+{
+   if (!isSupportedPixelFormat(candidate))
+      return false;
+   for (int i = 0; i < *count; ++i)
+      if (candidates[i] == candidate)
+         return false;
+   candidates[(*count)++] = candidate;
+   return true;
+}
+
+static bool selectPixelFormat(ScreenSurface screen)
+{
+   Uint32 candidates[3];
+   int candidateCount = 0;
+   if (requestedPixelFormat == TCSDL_PIXEL_FORMAT_AUTO)
+   {
+      addCandidate(candidates, &candidateCount, SDL_GetWindowPixelFormat(window));
+      addCandidate(candidates, &candidateCount, SDL_PIXELFORMAT_ARGB8888);
+      addCandidate(candidates, &candidateCount, SDL_PIXELFORMAT_RGB565);
+   }
+   else
+      addCandidate(candidates, &candidateCount, requestedSDLFormat(requestedPixelFormat));
+
+   for (int i = 0; i < candidateCount; ++i)
+   {
+      texture = createStreamingTexture(candidates[i], screen->screenW, screen->screenH);
+      if (texture != NULL)
+      {
+         selectedPixelFormat = candidates[i];
+         return true;
+      }
+      if (requestedPixelFormat != TCSDL_PIXEL_FORMAT_AUTO)
+      {
+         fprintf(stderr, "SDL_CreateTexture(%s): %s\n",
+            SDL_GetPixelFormatName(candidates[i]), SDL_GetError());
+         return false;
+      }
+   }
+   fprintf(stderr, "SDL_CreateTexture(): no supported streaming pixel format: %s\n",
+      SDL_GetError());
+   return false;
+}
+
+bool TCSDL_SetPixelFormatRequest(const char *value)
+{
+   TCSDLRequestedPixelFormat parsed;
+   if (!parsePixelFormat(value, &parsed))
+      return false;
+   requestedPixelFormat = parsed;
+   commandLinePixelFormatSet = true;
+   return true;
+}
 
 static int32 environmentDimension(const char *name, int32 fallback)
 {
@@ -89,6 +211,22 @@ bool TCSDL_Init(ScreenSurface screen, const char *title, bool fullScreen)
    }
    sdlInitialized = true;
 
+   if (!commandLinePixelFormatSet)
+   {
+      const char *value = getenv("TC_SDL_PIXEL_FORMAT");
+      TCSDLRequestedPixelFormat parsed;
+      if (value != NULL && *value != '\0')
+      {
+         if (parsePixelFormat(value, &parsed))
+            requestedPixelFormat = parsed;
+         else
+         {
+            requestedPixelFormat = TCSDL_PIXEL_FORMAT_AUTO;
+            fprintf(stderr, "Ignoring invalid TC_SDL_PIXEL_FORMAT; expected auto, argb8888, or rgb565.\n");
+         }
+      }
+   }
+
    if (SDL_GetCurrentDisplayMode(0, &displayMode) == 0)
    {
       width = displayMode.w;
@@ -96,13 +234,24 @@ bool TCSDL_Init(ScreenSurface screen, const char *title, bool fullScreen)
    }
    width = environmentDimension("TC_WIDTH", width);
    height = environmentDimension("TC_HEIGHT", height);
+   if (defScrW > 0)
+      width = defScrW;
+   if (defScrH > 0)
+      height = defScrH;
 
-   if (fullScreen)
+   if (initialWindowState == TC_INITIAL_WINDOW_FULLSCREEN
+      || (initialWindowState == TC_INITIAL_WINDOW_NORMAL && fullScreen))
       flags |= SDL_WINDOW_FULLSCREEN;
+   else if (initialWindowState == TC_INITIAL_WINDOW_MAXIMIZED)
+      flags |= SDL_WINDOW_MAXIMIZED;
    if (tcSettings.resizableWindow != NULL && *tcSettings.resizableWindow)
       flags |= SDL_WINDOW_RESIZABLE;
 
-   window = SDL_CreateWindow(title, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
+   int32 x = defScrX == -2 ? SDL_WINDOWPOS_CENTERED
+      : defScrX >= 0 ? defScrX : SDL_WINDOWPOS_UNDEFINED;
+   int32 y = defScrY == -2 ? SDL_WINDOWPOS_CENTERED
+      : defScrY >= 0 ? defScrY : SDL_WINDOWPOS_UNDEFINED;
+   window = SDL_CreateWindow(title, x, y,
       width, height, flags);
    if (window == NULL)
    {
@@ -153,26 +302,53 @@ bool TCSDL_Init(ScreenSurface screen, const char *title, bool fullScreen)
    return true;
 }
 
+bool TCSDL_SetFullscreen(bool fullscreen)
+{
+   if (window == NULL)
+      return false;
+   return SDL_SetWindowFullscreen(window, fullscreen ? SDL_WINDOW_FULLSCREEN : 0) == 0;
+}
+
 bool TCSDL_CreateBackBuffer(ScreenSurface screen)
 {
    if (screen == NULL || SCREEN_EX(screen) == NULL || renderer == NULL
       || screen->screenW <= 0 || screen->screenH <= 0)
       return false;
 
-   screen->bpp = 32;
-   screen->pitch = screen->screenW * sizeof(Pixel32);
-   screen->pixelformat = TCSDL_PIXEL_FORMAT;
-   screen->pixels = (uint8*)xmalloc((size_t)screen->pitch * screen->screenH);
-   if (screen->pixels == NULL)
-      return false;
-
-   texture = SDL_CreateTexture(renderer, TCSDL_PIXEL_FORMAT, SDL_TEXTUREACCESS_STREAMING,
-      screen->screenW, screen->screenH);
-   if (texture == NULL)
+   if (selectedPixelFormat == SDL_PIXELFORMAT_UNKNOWN)
    {
-      xfree(screen->pixels);
-      screen->pixels = NULL;
-      fprintf(stderr, "SDL_CreateTexture(): %s\n", SDL_GetError());
+      if (!selectPixelFormat(screen))
+         return false;
+   }
+   else
+   {
+      texture = createStreamingTexture(selectedPixelFormat, screen->screenW, screen->screenH);
+      if (texture == NULL)
+      {
+         fprintf(stderr, "SDL_CreateTexture(%s): %s\n",
+            SDL_GetPixelFormatName(selectedPixelFormat), SDL_GetError());
+         return false;
+      }
+   }
+
+   SDL_PixelFormat *format = SDL_AllocFormat(selectedPixelFormat);
+   if (format == NULL)
+   {
+      fprintf(stderr, "SDL_AllocFormat(%s): %s\n",
+         SDL_GetPixelFormatName(selectedPixelFormat), SDL_GetError());
+      SDL_DestroyTexture(texture);
+      texture = NULL;
+      return false;
+   }
+   screen->bpp = format->BitsPerPixel;
+   screen->pitch = format->BytesPerPixel * screen->screenW;
+   screen->pixelformat = selectedPixelFormat;
+   screen->pixels = (uint8*)xmalloc((size_t)screen->pitch * screen->screenH);
+   SDL_FreeFormat(format);
+   if (screen->pixels == NULL)
+   {
+      SDL_DestroyTexture(texture);
+      texture = NULL;
       return false;
    }
    SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_NONE);
@@ -217,6 +393,7 @@ void TCSDL_DestroyWindow(ScreenSurface screen)
       SDL_DestroyWindow(window);
       window = NULL;
    }
+   selectedPixelFormat = SDL_PIXELFORMAT_UNKNOWN;
    if (screen != NULL && screen->extension != NULL)
    {
       xfree(screen->extension);

--- a/TotalCrossVM/src/init/tcsdl.cpp
+++ b/TotalCrossVM/src/init/tcsdl.cpp
@@ -1,332 +1,252 @@
 // Copyright (C) 2000-2013 SuperWaba Ltda.
 // Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
-// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
-
-#define DISPLAY_INDEX 0
-#define NO_FLAGS 0
-#define IS_NULL(x)      ((x) == NULL)
-#define NOT_SUCCESS(x)  ((x) != 0)
-#define SUCCESS(x)      ((x) == 0)
 
 #include "tcsdl.h"
 #if defined(WIN32) && !defined(WINCE)
 #include "SDL2/SDL_syswm.h"
 #endif
-#include <iostream>
-#include <vector>
 
-static SDL_Renderer* renderer = NULL;
-static SDL_Texture* texture = NULL;
-static SDL_Window *window = NULL; 
-static SDL_Surface *surface = NULL;
-static bool usesTexture;
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
 
-/*
- * Init steps to create a window and texture to Skia handling
- *
- * Args:
- * - ScreenSurface from TotalCross globals
- *
- * Return:
- * - false on failure
- * - true on success
- */
-bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen) {
+static const Uint32 TCSDL_PIXEL_FORMAT = SDL_PIXELFORMAT_ARGB8888;
+static SDL_Renderer *renderer;
+static SDL_Texture *texture;
+static SDL_Window *window;
+static bool sdlInitialized;
 
-	std::cout << "Testing video drivers..." << '\n';
-	std::vector< bool > drivers(SDL_GetNumVideoDrivers());
+static int32 environmentDimension(const char *name, int32 fallback)
+{
+   const char *value = getenv(name);
+   if (value == NULL || *value == '\0')
+      return fallback;
+   char *end = NULL;
+   long parsed = strtol(value, &end, 10);
+   return end != value && *end == '\0' && parsed > 0 ? (int32)parsed : fallback;
+}
 
-	std::cout << "SDL_VIDEODRIVER available:";
-	for (int i = 0; i < drivers.size(); ++i) {
-		std::cout << " " << SDL_GetVideoDriver(i);
-	}
-	std::cout << '\n';
+bool TCSDL_QueryWindowMetrics(ScreenSurface screen, TScreenConfiguration *configuration)
+{
+   int logicalWidth, logicalHeight;
+   int physicalWidth, physicalHeight;
 
-#if __APPLE__
-	// Trackpad support for Macbook
-	SDL_SetHint(SDL_HINT_TRACKPAD_IS_TOUCH_ONLY, "1");
-#endif
+   if (screen == NULL || configuration == NULL || window == NULL || renderer == NULL)
+      return false;
+   SDL_GetWindowSize(window, &logicalWidth, &logicalHeight);
+   if (logicalWidth <= 0 || logicalHeight <= 0
+      || SDL_GetRendererOutputSize(renderer, &physicalWidth, &physicalHeight) != 0
+      || physicalWidth <= 0 || physicalHeight <= 0)
+      return false;
 
-	// Only init video (without audio)
-	if (NOT_SUCCESS(SDL_Init(SDL_INIT_VIDEO))) {
-		std::cerr << "SDL_Init(): " << SDL_GetError() << '\n';
-		return false;
-	}
-	std::cout << "SDL_VIDEODRIVER selected : " << SDL_GetCurrentVideoDriver() << '\n';
+   double scaleX = (double)physicalWidth / logicalWidth;
+   double scaleY = (double)physicalHeight / logicalHeight;
+   if (std::fabs(scaleX - scaleY) > 0.01)
+      fprintf(stderr, "SDL returned non-uniform window scale: %.4f x %.4f\n", scaleX, scaleY);
 
-	SDL_Rect viewport;
-#if __APPLE__
-	// Get the desktop area represented by a display, with the primary
-	// display located at 0,0 based on viewport allocated on initial position
-	int (*TCSDL_GetDisplayBounds)(int, SDL_Rect*) = 
-#ifdef __arm__                  
-	&SDL_GetDisplayBounds;
-#else                           
-	&SDL_GetDisplayUsableBounds;
-#endif
-
-	if(NOT_SUCCESS(TCSDL_GetDisplayBounds(DISPLAY_INDEX, &viewport))) {
-		printf("SDL_GetDisplayBounds failed: %s\n", SDL_GetError());
-		return false;
-	}
-
-	// Adjust height on desktop, it should not affect fullscreen (y should be 0)
-	viewport.h -= viewport.y;
+   double contentScale = (scaleX + scaleY) / 2.0;
+   configuration->width = physicalWidth;
+   configuration->height = physicalHeight;
+#if defined(WIN32) && !defined(WINCE)
+   UINT dpi = mainHWnd != NULL ? GetDpiForWindow(mainHWnd) : 0;
+   configuration->hRes = dpi != 0 ? (int32)dpi : (int32)std::lround(contentScale * 96.0);
+   configuration->vRes = configuration->hRes;
 #else
-	SDL_DisplayMode DM;
-	// Get current display mode of all displays.
-  	for(int i = 0; i < SDL_GetNumVideoDisplays(); ++i){
-		int should_be_zero = SDL_GetCurrentDisplayMode(i, &DM);
-
-		if(should_be_zero != 0) {
-			std::cerr << "SDL_GetCurrentDisplayMode() failed for video display #" << i << ": " << SDL_GetError() << '\n';
-		} else {
-			std::cout << "SDL_DisplayMode #" << i << ": current display mode is " << DM.w << "x" << DM.h << "x" << DM.refresh_rate << '\n';
-		}
-	}
-	viewport.x = SDL_WINDOWPOS_UNDEFINED; 
-	viewport.y = SDL_WINDOWPOS_UNDEFINED;
-	viewport.w = DM.w;
-	viewport.h = DM.h;
+   configuration->hRes = (int32)std::lround(contentScale * 96.0);
+   configuration->vRes = configuration->hRes;
 #endif
+   configuration->contentScale = contentScale > 0 ? contentScale : 1;
+   configuration->fontScale = screen->fontScale > 0 ? screen->fontScale : 1;
+   configuration->deviceFontHeight = screen->deviceFontHeight;
+   configuration->generation = screen->surfaceGeneration + 1;
+   configuration->surfaceReady = true;
+   configuration->nativeSurfaceChanged = false;
+   return true;
+}
 
-	if (getenv("TC_WIDTH") != NULL) {
-		viewport.w = std::stoi(getenv("TC_WIDTH"));
-	}
-	if (getenv("TC_HEIGHT") != NULL) {
-		viewport.h = std::stoi(getenv("TC_HEIGHT"));
-	}
-
-	uint32 flags; 
-#ifdef __APPLE__
-	flags = SDL_WINDOW_SHOWN | SDL_WINDOW_ALLOW_HIGHDPI;
-#else
-	if(getenv("TC_FULLSCREEN") == NULL) {
-		flags = SDL_WINDOW_FULLSCREEN;
-	} else {
-		flags = SDL_WINDOW_SHOWN;
-		viewport.w -= viewport.w*0.09;
-		viewport.h -= viewport.h*0.09;
-	}
-#endif
-
-	// Create the window
-	if (IS_NULL(window = SDL_CreateWindow(
-							 title,
-							 viewport.x,
-							 viewport.y,
-							 viewport.w,
-							 viewport.h,
-							 flags
-						 ))) {
-		std::cerr << "SDL_CreateWindow(): " << SDL_GetError() << '\n';
-		return false;
-	}
+bool TCSDL_Init(ScreenSurface screen, const char *title, bool fullScreen)
+{
+   SDL_DisplayMode displayMode;
+   int32 width = 800;
+   int32 height = 600;
+   Uint32 flags = SDL_WINDOW_SHOWN | SDL_WINDOW_ALLOW_HIGHDPI;
 
 #if defined(WIN32) && !defined(WINCE)
-	SDL_SysWMinfo windowInfo;
-	SDL_VERSION(&windowInfo.version);
-	if (SDL_GetWindowWMInfo(window, &windowInfo) == SDL_TRUE
-		&& windowInfo.subsystem == SDL_SYSWM_WINDOWS)
-	{
-		mainHWnd = windowInfo.info.win.window;
-	}
+   SDL_SetHint(SDL_HINT_WINDOWS_DPI_SCALING, "1");
+#endif
+#if __APPLE__
+   SDL_SetHint(SDL_HINT_TRACKPAD_IS_TOUCH_ONLY, "1");
 #endif
 
-	std::cout << "SDL_RENDER_DRIVER available:";
-	for (int i = 0; i < SDL_GetNumRenderDrivers(); ++i) {
-		SDL_RendererInfo info;
-		SDL_GetRenderDriverInfo(i, &info);
-		std::cout << " " << info.name;
-	}
-	std::cout << '\n';
+   if (SDL_Init(SDL_INIT_VIDEO) != 0)
+   {
+      fprintf(stderr, "SDL_Init(): %s\n", SDL_GetError());
+      return false;
+   }
+   sdlInitialized = true;
 
-	// Create a 2D rendering context for a window
-	if (IS_NULL(renderer = SDL_CreateRenderer(
-							window, 
-							-1, 
-/*
-	Some devices crash when opengl is used, so for now,
-	we'll force the usage of the software renderer until we
-	find a way to test for hardware accelerated graphics
-	support without crashing.
-*/
-#if !defined ANDROID && (defined __APPLE__ && defined __aarch64__ && !defined darwin) || (defined linux && defined __arm__)
-							SDL_RENDERER_SOFTWARE
-#else
-							NO_FLAGS
+   if (SDL_GetCurrentDisplayMode(0, &displayMode) == 0)
+   {
+      width = displayMode.w;
+      height = displayMode.h;
+   }
+   width = environmentDimension("TC_WIDTH", width);
+   height = environmentDimension("TC_HEIGHT", height);
+
+   if (fullScreen)
+      flags |= SDL_WINDOW_FULLSCREEN;
+   if (tcSettings.resizableWindow != NULL && *tcSettings.resizableWindow)
+      flags |= SDL_WINDOW_RESIZABLE;
+
+   window = SDL_CreateWindow(title, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
+      width, height, flags);
+   if (window == NULL)
+   {
+      fprintf(stderr, "SDL_CreateWindow(): %s\n", SDL_GetError());
+      TCSDL_DestroyWindow(screen);
+      return false;
+   }
+
+#if defined(WIN32) && !defined(WINCE)
+   SDL_SysWMinfo windowInfo;
+   SDL_VERSION(&windowInfo.version);
+   if (SDL_GetWindowWMInfo(window, &windowInfo) == SDL_TRUE
+      && windowInfo.subsystem == SDL_SYSWM_WINDOWS)
+      mainHWnd = windowInfo.info.win.window;
 #endif
-	))) {
-		std::cerr << "SDL_CreateRenderer(): " << SDL_GetError() << '\n';
-		std::cout << '\n' << "HINT: try to export SDL_RENDER_DRIVER environment variable with an available render driver!" << '\n';
-		return false;
-	}
 
-	// Get renderer driver information
-	SDL_RendererInfo rendererInfo;
-	if (NOT_SUCCESS(SDL_GetRendererInfo(renderer, &rendererInfo))) {
-		std::cerr << "SDL_GetRendererInfo(): " << SDL_GetError() << '\n';
-		return 0;
-	}
-	std::cout << "SDL_RENDER_DRIVER selected : " << rendererInfo.name << '\n';
+   renderer = SDL_CreateRenderer(window, -1, 0);
+   if (renderer == NULL)
+   {
+      fprintf(stderr, "SDL_CreateRenderer(): %s\n", SDL_GetError());
+      TCSDL_DestroyWindow(screen);
+      return false;
+   }
 
-	// Get window pixel format
-	Uint32 windowPixelFormat;
-	if (SDL_PIXELFORMAT_UNKNOWN == (windowPixelFormat = SDL_GetWindowPixelFormat(window))) {
-		std::cerr << "SDL_GetWindowPixelFormat(): " << SDL_GetError() << '\n';
-		return false;
-	}
-	std::cout << "SDL_PIXEL_FORMAT: " << SDL_GetPixelFormatName(windowPixelFormat) << '\n';
+   if (screen->extension == NULL)
+      screen->extension = (ScreenSurfaceEx)xmalloc(sizeof(TScreenSurfaceEx));
+   if (screen->extension == NULL)
+   {
+      TCSDL_DestroyWindow(screen);
+      return false;
+   }
+   xmemzero(screen->extension, sizeof(TScreenSurfaceEx));
+   SCREEN_EX(screen)->window = window;
+   SCREEN_EX(screen)->renderer = renderer;
 
-	usesTexture = std::string(rendererInfo.name).compare(std::string("software"));
-	int physicalWidth = viewport.w;
-	int physicalHeight = viewport.h;
-	if (usesTexture) {
-		SDL_GetRendererOutputSize(renderer, &physicalWidth, &physicalHeight);
-	} else {
-		surface = SDL_GetWindowSurface(window);
-		physicalWidth = surface->w;
-		physicalHeight = surface->h;
-	}
-	if (physicalWidth <= 0 || physicalHeight <= 0) {
-		std::cerr << "SDL returned an invalid drawable size" << '\n';
-		return false;
-	}
-
-	if(usesTexture) {
-		// MUST USE SDL_TEXTUREACCESS_STREAMING, CANNOT BE REPLACED WITH SDL_CreateTextureFromSurface
-		if (IS_NULL(texture = SDL_CreateTexture(
-								renderer,
-								windowPixelFormat,
-								SDL_TEXTUREACCESS_STREAMING,
-								physicalWidth,
-								physicalHeight))) {
-			std::cerr << "SDL_CreateTexturet(): " << SDL_GetError() << '\n';
-			return false;
-		}
-	} else {
-		surface = SDL_GetWindowSurface(window);
-	}
-
-	// Get pixel format struct
-	SDL_PixelFormat* pixelformat;
-	if (IS_NULL(pixelformat = SDL_AllocFormat(windowPixelFormat))) {
-		std::cerr << "SDL_AllocFormat(): " << SDL_GetError() << '\n';
-		return false;
-	}
-
-	// The backing store is physical; Java-facing dimensions are derived from
-	// contentScale when Settings is initialized.
-	screen->screenW = physicalWidth;
-	screen->screenH = physicalHeight;
-	screen->contentScale = (double)physicalWidth / viewport.w;
-	// Adjusts screen's BPP
-	screen->bpp = pixelformat->BitsPerPixel;
-	// Set surface pitch
-	screen->pitch = pixelformat->BytesPerPixel * screen->screenW;
-	// pixel order
-	screen->pixelformat = windowPixelFormat;
-
-	if (usesTexture) {
-		// Adjusts screen's pixel surface
-		if (IS_NULL(screen->pixels = (uint8*) malloc(screen->pitch * screen->screenH))) {
-			std::cerr << "Failed to alloc " << (screen->pitch * screen->screenH) << " bytes for pixel surface" << '\n';
-			return false;
-		}
-	}else {
-		screen->pixels = (uint8*) surface->pixels;
-	}
-
-	if (IS_NULL(screen->extension = (ScreenSurfaceEx) malloc(sizeof(TScreenSurfaceEx)))) {
-		if (usesTexture) {
-			free(screen->pixels);
-		}
-		std::cerr << "Failed to alloc TScreenSurfaceEx of " << sizeof(TScreenSurfaceEx) << " bytes" << '\n';
-		return false;
-	}
-	SCREEN_EX(screen)->window = window;
-	SCREEN_EX(screen)->renderer = renderer;
-	SCREEN_EX(screen)->texture = texture;
-	SCREEN_EX(screen)->surface = surface;
-
-	SDL_FreeFormat(pixelformat);
-
-	return true;
+   TScreenConfiguration configuration;
+   if (!TCSDL_QueryWindowMetrics(screen, &configuration))
+   {
+      TCSDL_DestroyWindow(screen);
+      return false;
+   }
+   screenApplyConfiguration(screen, &configuration);
+   screenConsumePendingChanges(screen);
+   return true;
 }
 
-/*
- * Update the given texture rectangle with new pixel data.
- *
- * # MUST BE REVIEWED
- *
- * SDL_UpdateTexture it's too slow and our implementation
- * depends on it
- */
-void TCSDL_UpdateTexture(int w, int h, int pitch, void* pixels) {
-	if(usesTexture) {
-		// Update the given texture rectangle with new pixel data.
-		SDL_UpdateTexture(texture, NULL, pixels, pitch);
-	} else {
-		surface = SDL_GetWindowSurface(window);
-	}
-	// Call SDL render present
-	TCSDL_Present();
+bool TCSDL_CreateBackBuffer(ScreenSurface screen)
+{
+   if (screen == NULL || SCREEN_EX(screen) == NULL || renderer == NULL
+      || screen->screenW <= 0 || screen->screenH <= 0)
+      return false;
+
+   screen->bpp = 32;
+   screen->pitch = screen->screenW * sizeof(Pixel32);
+   screen->pixelformat = TCSDL_PIXEL_FORMAT;
+   screen->pixels = (uint8*)xmalloc((size_t)screen->pitch * screen->screenH);
+   if (screen->pixels == NULL)
+      return false;
+
+   texture = SDL_CreateTexture(renderer, TCSDL_PIXEL_FORMAT, SDL_TEXTUREACCESS_STREAMING,
+      screen->screenW, screen->screenH);
+   if (texture == NULL)
+   {
+      xfree(screen->pixels);
+      screen->pixels = NULL;
+      fprintf(stderr, "SDL_CreateTexture(): %s\n", SDL_GetError());
+      return false;
+   }
+   SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_NONE);
+   SCREEN_EX(screen)->texture = texture;
+   return true;
 }
 
-/*
- * Update the screen with rendering performed
- */
-void TCSDL_Present() {
-  if(usesTexture) {
-    // Copy a portion of the texture to the current rendering target
-    SDL_RenderCopy(renderer, texture, NULL, NULL);
-    // Update the screen with rendering performed
-    SDL_RenderPresent(renderer);
-    // Clears the entire rendering targe
-    SDL_RenderClear(renderer);
-  } else {
-    SDL_UpdateWindowSurface(window);
-  }
+void TCSDL_DestroyBackBuffer(ScreenSurface screen)
+{
+   if (screen == NULL)
+      return;
+   if (SCREEN_EX(screen) != NULL && SCREEN_EX(screen)->texture != NULL)
+   {
+      SDL_DestroyTexture(SCREEN_EX(screen)->texture);
+      SCREEN_EX(screen)->texture = NULL;
+      texture = NULL;
+   }
+   if (screen->pixels != NULL)
+   {
+      xfree(screen->pixels);
+      screen->pixels = NULL;
+   }
+   screen->pitch = 0;
 }
 
-/*
- * Destroy all SDL allocated variables
- */
-void TCSDL_Destroy(ScreenSurface screen) {
-	if (usesTexture && screen->pixels != NULL) {
-		free(screen->pixels);
-	}
-
-	if (SCREEN_EX(screen) != NULL) {
-		if (SCREEN_EX(screen)->surface != NULL) {
-			SDL_FreeSurface(SCREEN_EX(screen)->surface);
-		}
-		if (SCREEN_EX(screen)->texture != NULL) {
-			SDL_DestroyTexture(SCREEN_EX(screen)->texture);
-		}
-		if (SCREEN_EX(screen)->renderer != NULL) {
-			SDL_DestroyRenderer(SCREEN_EX(screen)->renderer);
-		}
-		if (SCREEN_EX(screen)->window != NULL) {
-			#if defined(WIN32) && !defined(WINCE)
-			mainHWnd = NULL;
-			#endif
-			SDL_DestroyWindow(SCREEN_EX(screen)->window);
-		}
-		free(SCREEN_EX(screen));
-	}
-	SDL_Quit();
+void TCSDL_DestroyWindow(ScreenSurface screen)
+{
+   if (screen != NULL)
+      TCSDL_DestroyBackBuffer(screen);
+   if (renderer != NULL)
+   {
+      SDL_DestroyRenderer(renderer);
+      renderer = NULL;
+   }
+   if (window != NULL)
+   {
+#if defined(WIN32) && !defined(WINCE)
+      mainHWnd = NULL;
+#endif
+      SDL_DestroyWindow(window);
+      window = NULL;
+   }
+   if (screen != NULL && screen->extension != NULL)
+   {
+      xfree(screen->extension);
+      screen->extension = NULL;
+   }
+   if (sdlInitialized)
+   {
+      SDL_Quit();
+      sdlInitialized = false;
+   }
 }
 
-void TCSDL_GetWindowSize(ScreenSurface screen, int32* width, int32* height) {
-	SDL_GetWindowSize(SCREEN_EX(screen)->window, width, height);
+void TCSDL_UpdateTexture(int w, int h, int pitch, void *pixels)
+{
+   UNUSED(w)
+   UNUSED(h)
+   if (texture == NULL || pixels == NULL)
+      return;
+   SDL_UpdateTexture(texture, NULL, pixels, pitch);
+   TCSDL_Present();
 }
 
-void TCSDL_WindowSizeChanged(ScreenSurface screen, int32 width, int32 height) {
-	SCREEN_EX(screen)->surface = surface = SDL_GetWindowSurface(SCREEN_EX(screen)->window);
-	screen->screenW = surface->w;
-	screen->screenH = surface->h;
-	screen->contentScale = width > 0 ? (double)surface->w / width : 1;
+void TCSDL_GetWindowSize(ScreenSurface screen, int32 *width, int32 *height)
+{
+   if (width != NULL)
+      *width = 0;
+   if (height != NULL)
+      *height = 0;
+   if (screen != NULL && SCREEN_EX(screen) != NULL && SCREEN_EX(screen)->window != NULL)
+      SDL_GetWindowSize(SCREEN_EX(screen)->window, width, height);
+}
+
+void TCSDL_Present()
+{
+   if (renderer == NULL || texture == NULL)
+      return;
+   SDL_RenderClear(renderer);
+   SDL_RenderCopy(renderer, texture, NULL, NULL);
+   SDL_RenderPresent(renderer);
 }

--- a/TotalCrossVM/src/init/tcsdl.cpp
+++ b/TotalCrossVM/src/init/tcsdl.cpp
@@ -11,6 +11,9 @@
 #define SUCCESS(x)      ((x) == 0)
 
 #include "tcsdl.h"
+#if defined(WIN32) && !defined(WINCE)
+#include "SDL2/SDL_syswm.h"
+#endif
 #include <iostream>
 #include <vector>
 
@@ -121,6 +124,16 @@ bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen) {
 		std::cerr << "SDL_CreateWindow(): " << SDL_GetError() << '\n';
 		return false;
 	}
+
+#if defined(WIN32) && !defined(WINCE)
+	SDL_SysWMinfo windowInfo;
+	SDL_VERSION(&windowInfo.version);
+	if (SDL_GetWindowWMInfo(window, &windowInfo) == SDL_TRUE
+		&& windowInfo.subsystem == SDL_SYSWM_WINDOWS)
+	{
+		mainHWnd = windowInfo.info.win.window;
+	}
+#endif
 
 	std::cout << "SDL_RENDER_DRIVER available:";
 	for (int i = 0; i < SDL_GetNumRenderDrivers(); ++i) {
@@ -297,6 +310,9 @@ void TCSDL_Destroy(ScreenSurface screen) {
 			SDL_DestroyRenderer(SCREEN_EX(screen)->renderer);
 		}
 		if (SCREEN_EX(screen)->window != NULL) {
+			#if defined(WIN32) && !defined(WINCE)
+			mainHWnd = NULL;
+			#endif
 			SDL_DestroyWindow(SCREEN_EX(screen)->window);
 		}
 		free(SCREEN_EX(screen));

--- a/TotalCrossVM/src/init/tcsdl.cpp
+++ b/TotalCrossVM/src/init/tcsdl.cpp
@@ -6,6 +6,7 @@
 
 #include "tcsdl.h"
 #include "../event/sdl/event_sdl.h"
+#include "../nm/ui/Window.h"
 #if defined(WIN32) && !defined(WINCE)
 #include "SDL2/SDL_syswm.h"
 #endif
@@ -142,16 +143,6 @@ bool TCSDL_SetPixelFormatRequest(const char *value)
    return true;
 }
 
-static int32 environmentDimension(const char *name, int32 fallback)
-{
-   const char *value = getenv(name);
-   if (value == NULL || *value == '\0')
-      return fallback;
-   char *end = NULL;
-   long parsed = strtol(value, &end, 10);
-   return end != value && *end == '\0' && parsed > 0 ? (int32)parsed : fallback;
-}
-
 bool TCSDL_QueryWindowMetrics(ScreenSurface screen, TScreenConfiguration *configuration)
 {
    int logicalWidth, logicalHeight;
@@ -190,11 +181,20 @@ bool TCSDL_QueryWindowMetrics(ScreenSurface screen, TScreenConfiguration *config
    return true;
 }
 
-bool TCSDL_Init(ScreenSurface screen, const char *title, bool fullScreen)
+static int32 sdlWindowPosition(TCWindowPositionMode mode, int32 position)
+{
+   return mode == TC_WINDOW_POSITION_CENTER ? SDL_WINDOWPOS_CENTERED
+      : mode == TC_WINDOW_POSITION_EXPLICIT ? position : SDL_WINDOWPOS_UNDEFINED;
+}
+
+bool TCSDL_Init(ScreenSurface screen, const char *title, bool fullScreen, int16 appTczAttr)
 {
    SDL_DisplayMode displayMode;
-   int32 width = 800;
-   int32 height = 600;
+   SDL_Rect displayBounds;
+   SDL_Rect usableBounds;
+   TCDisplayMetrics display = { 0 };
+   TCWindowStartupOptions options = desktopWindowStartupOptions;
+   TCWindowStartupConfiguration startupConfiguration;
    Uint32 flags = SDL_WINDOW_SHOWN | SDL_WINDOW_ALLOW_HIGHDPI;
 
 #if defined(WIN32) && !defined(WINCE)
@@ -227,32 +227,53 @@ bool TCSDL_Init(ScreenSurface screen, const char *title, bool fullScreen)
       }
    }
 
-   if (SDL_GetCurrentDisplayMode(0, &displayMode) == 0)
+   if (SDL_GetDisplayBounds(0, &displayBounds) == 0)
    {
-      width = displayMode.w;
-      height = displayMode.h;
+      display.width = displayBounds.w;
+      display.height = displayBounds.h;
    }
-   width = environmentDimension("TC_WIDTH", width);
-   height = environmentDimension("TC_HEIGHT", height);
-   if (defScrW > 0)
-      width = defScrW;
-   if (defScrH > 0)
-      height = defScrH;
+   if (SDL_GetDisplayUsableBounds(0, &usableBounds) == 0)
+   {
+      display.usableWidth = usableBounds.w;
+      display.usableHeight = usableBounds.h;
+   }
+   if ((display.width <= 0 || display.height <= 0)
+      && SDL_GetCurrentDisplayMode(0, &displayMode) == 0)
+   {
+      display.width = displayMode.w;
+      display.height = displayMode.h;
+   }
+   if (display.width <= 0 || display.height <= 0)
+   {
+      display.width = 800;
+      display.height = 600;
+   }
+   if (display.usableWidth <= 0)
+      display.usableWidth = display.width;
+   if (display.usableHeight <= 0)
+      display.usableHeight = display.height;
 
-   if (initialWindowState == TC_INITIAL_WINDOW_FULLSCREEN
-      || (initialWindowState == TC_INITIAL_WINDOW_NORMAL && fullScreen))
+   options.appTczAttr = appTczAttr;
+   options.legacyFullscreen = fullScreen;
+   windowLoadStartupEnvironment(&options);
+   if (!windowResolveStartupConfiguration(&options, &display, &startupConfiguration))
+   {
+      fprintf(stderr, "Could not resolve the initial SDL window size.\n");
+      TCSDL_DestroyWindow(screen);
+      return false;
+   }
+
+   if (startupConfiguration.fullscreen)
       flags |= SDL_WINDOW_FULLSCREEN;
-   else if (initialWindowState == TC_INITIAL_WINDOW_MAXIMIZED)
+   else if (startupConfiguration.maximized)
       flags |= SDL_WINDOW_MAXIMIZED;
-   if (tcSettings.resizableWindow != NULL && *tcSettings.resizableWindow)
+   if (startupConfiguration.resizable)
       flags |= SDL_WINDOW_RESIZABLE;
 
-   int32 x = defScrX == -2 ? SDL_WINDOWPOS_CENTERED
-      : defScrX >= 0 ? defScrX : SDL_WINDOWPOS_UNDEFINED;
-   int32 y = defScrY == -2 ? SDL_WINDOWPOS_CENTERED
-      : defScrY >= 0 ? defScrY : SDL_WINDOWPOS_UNDEFINED;
-   window = SDL_CreateWindow(title, x, y,
-      width, height, flags);
+   window = SDL_CreateWindow(title,
+      sdlWindowPosition(startupConfiguration.xMode, startupConfiguration.x),
+      sdlWindowPosition(startupConfiguration.yMode, startupConfiguration.y),
+      startupConfiguration.width, startupConfiguration.height, flags);
    if (window == NULL)
    {
       fprintf(stderr, "SDL_CreateWindow(): %s\n", SDL_GetError());

--- a/TotalCrossVM/src/init/tcsdl.cpp
+++ b/TotalCrossVM/src/init/tcsdl.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "tcsdl.h"
+#include "../event/sdl/event_sdl.h"
 #if defined(WIN32) && !defined(WINCE)
 #include "SDL2/SDL_syswm.h"
 #endif
@@ -109,13 +110,17 @@ bool TCSDL_Init(ScreenSurface screen, const char *title, bool fullScreen)
       TCSDL_DestroyWindow(screen);
       return false;
    }
+   sdlEventWindowCreated();
 
 #if defined(WIN32) && !defined(WINCE)
    SDL_SysWMinfo windowInfo;
    SDL_VERSION(&windowInfo.version);
    if (SDL_GetWindowWMInfo(window, &windowInfo) == SDL_TRUE
       && windowInfo.subsystem == SDL_SYSWM_WINDOWS)
+   {
       mainHWnd = windowInfo.info.win.window;
+      sdlInstallWindowsMessageHook();
+   }
 #endif
 
    renderer = SDL_CreateRenderer(window, -1, 0);
@@ -205,8 +210,10 @@ void TCSDL_DestroyWindow(ScreenSurface screen)
    if (window != NULL)
    {
 #if defined(WIN32) && !defined(WINCE)
+      sdlRemoveWindowsMessageHook();
       mainHWnd = NULL;
 #endif
+      sdlEventWindowDestroying();
       SDL_DestroyWindow(window);
       window = NULL;
    }

--- a/TotalCrossVM/src/init/tcsdl.cpp
+++ b/TotalCrossVM/src/init/tcsdl.cpp
@@ -309,6 +309,14 @@ bool TCSDL_SetFullscreen(bool fullscreen)
    return SDL_SetWindowFullscreen(window, fullscreen ? SDL_WINDOW_FULLSCREEN : 0) == 0;
 }
 
+bool TCSDL_SetWindowSize(int32 width, int32 height)
+{
+   if (window == NULL || width <= 0 || height <= 0)
+      return false;
+   SDL_SetWindowSize(window, width, height);
+   return true;
+}
+
 bool TCSDL_CreateBackBuffer(ScreenSurface screen)
 {
    if (screen == NULL || SCREEN_EX(screen) == NULL || renderer == NULL

--- a/TotalCrossVM/src/init/tcsdl.h
+++ b/TotalCrossVM/src/init/tcsdl.h
@@ -20,6 +20,8 @@ extern "C" {
     #include "GraphicsPrimitives.h"
 
     bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen);
+    bool TCSDL_SetPixelFormatRequest(const char* value);
+    bool TCSDL_SetFullscreen(bool fullscreen);
     bool TCSDL_QueryWindowMetrics(ScreenSurface screen, TScreenConfiguration* configuration);
     bool TCSDL_CreateBackBuffer(ScreenSurface screen);
     void TCSDL_DestroyBackBuffer(ScreenSurface screen);

--- a/TotalCrossVM/src/init/tcsdl.h
+++ b/TotalCrossVM/src/init/tcsdl.h
@@ -20,11 +20,13 @@ extern "C" {
     #include "GraphicsPrimitives.h"
 
     bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen);
+    bool TCSDL_QueryWindowMetrics(ScreenSurface screen, TScreenConfiguration* configuration);
+    bool TCSDL_CreateBackBuffer(ScreenSurface screen);
+    void TCSDL_DestroyBackBuffer(ScreenSurface screen);
+    void TCSDL_DestroyWindow(ScreenSurface screen);
     void TCSDL_UpdateTexture(int w, int h, int pitch,void *pixels);
     void TCSDL_Present();
-    void TCSDL_Destroy(ScreenSurface screen);
     void TCSDL_GetWindowSize(ScreenSurface screen, int32* width, int32* height);
-    void TCSDL_WindowSizeChanged(ScreenSurface screen, int32 width, int32 height);
 
 #ifdef __cplusplus
 }

--- a/TotalCrossVM/src/init/tcsdl.h
+++ b/TotalCrossVM/src/init/tcsdl.h
@@ -19,7 +19,7 @@ extern "C" {
     #endif
     #include "GraphicsPrimitives.h"
 
-    bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen);
+    bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen, int16 appTczAttr);
     bool TCSDL_SetPixelFormatRequest(const char* value);
     bool TCSDL_SetFullscreen(bool fullscreen);
     // Returns whether the resize request was submitted; SDL event metrics confirm its result.

--- a/TotalCrossVM/src/init/tcsdl.h
+++ b/TotalCrossVM/src/init/tcsdl.h
@@ -27,6 +27,10 @@ extern "C" {
     void TCSDL_UpdateTexture(int w, int h, int pitch,void *pixels);
     void TCSDL_Present();
     void TCSDL_GetWindowSize(ScreenSurface screen, int32* width, int32* height);
+#if defined(WIN32) && !defined(WINCE)
+    void sdlInstallWindowsMessageHook();
+    void sdlRemoveWindowsMessageHook();
+#endif
 
 #ifdef __cplusplus
 }

--- a/TotalCrossVM/src/init/tcsdl.h
+++ b/TotalCrossVM/src/init/tcsdl.h
@@ -22,6 +22,8 @@ extern "C" {
     bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen);
     bool TCSDL_SetPixelFormatRequest(const char* value);
     bool TCSDL_SetFullscreen(bool fullscreen);
+    // Returns whether the resize request was submitted; SDL event metrics confirm its result.
+    bool TCSDL_SetWindowSize(int32 width, int32 height);
     bool TCSDL_QueryWindowMetrics(ScreenSurface screen, TScreenConfiguration* configuration);
     bool TCSDL_CreateBackBuffer(ScreenSurface screen);
     void TCSDL_DestroyBackBuffer(ScreenSurface screen);

--- a/TotalCrossVM/src/init/win/startup_c.h
+++ b/TotalCrossVM/src/init/win/startup_c.h
@@ -191,29 +191,6 @@ static bool isWakeUpCall(CharP args)
    return false;
 }
 
-#if !defined(WINCE)
-int32 defScrX=-1,defScrY=-1,defScrW=-1,defScrH=-1;
-static CharP parseScreenBounds(CharP cmd, int32 *xx, int32 *yy, int32 *ww, int32 *hh)
-{
-   CharP scr = xstrstr(cmd, "/scr"),s2;
-   int n;
-   if (!scr) return null;
-   n = sscanf(scr + 5,"%d,%d,%d,%d", xx, yy, ww, hh);
-   if (n != 4)
-   {
-      alert("Format: <other arguments> /scr x,y,width,height\nPass -1 to use the default and -2 to center on screen.\nEx: \"/scr -2,100,320,-1\"\nwill open a window horizontally centered at\ny=100, w=320, h=320 (default is 0,0,240,320).");
-      return null;
-   }
-   *scr = 0; // cut at the scr
-   while (scr > cmd && *(scr-1) == ' ') // trim
-      *(scr-1) = 0;
-   s2 = xstrstr(cmd, " /cmd"); // if only /cmd remained at end, remove it.
-   if (s2 == scr-6)
-      *s2 = 0;
-   return cmd;
-}
-#endif
-
 void screenChange(Context currentContext, int32 newWidth, int32 newHeight, int32 hRes, int32 vRes, bool nothingChanged); // GraphicsPrimitives_c.h
 
 void appSetFullScreen();

--- a/TotalCrossVM/src/init/win/startup_c.h
+++ b/TotalCrossVM/src/init/win/startup_c.h
@@ -1,7 +1,16 @@
 // Copyright (C) 2000-2013 SuperWaba Ltda.
-// Copyright (C) 2014-2020 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
+
+BOOL APIENTRY DllMain(HANDLE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
+{
+   UNUSED(lpReserved)
+   if (ul_reason_for_call == DLL_PROCESS_ATTACH)
+      hModuleTCVM = hModule;
+   return TRUE;
+}
 
 TC_API DWORD TSV_Close(DWORD dwData) {return 0;}
 TC_API DWORD TSV_Deinit(DWORD dwData) {return 0;}

--- a/TotalCrossVM/src/nm/sys/win/Vm_c.h
+++ b/TotalCrossVM/src/nm/sys/win/Vm_c.h
@@ -1,5 +1,6 @@
 // Copyright (C) 2000-2013 SuperWaba Ltda.
-// Copyright (C) 2014-2020 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -237,6 +238,112 @@ void vmSetAutoOff(bool enable)
 
 //////////// START OF KEY INTERCEPTION FUNCTIONS
 //XXX: O que s�o hot keys? N�o fa�o a menor id�ia do que fazer aqui e acho que nem faz sentido
+static int32 vmPortableKeyToWin32(PortableSpecialKeys key)
+{
+   switch (key)
+   {
+      case SK_PAGE_UP       : return VK_PRIOR;
+      case SK_PAGE_DOWN     : return VK_NEXT;
+      case SK_HOME          : return VK_HOME;
+      case SK_END           : return VK_END;
+      case SK_UP            : return VK_UP;
+      case SK_DOWN          : return VK_DOWN;
+      case SK_LEFT          : return VK_LEFT;
+      case SK_RIGHT         : return VK_RIGHT;
+      case SK_INSERT        : return VK_INSERT;
+      case SK_ENTER         : return VK_RETURN;
+      case SK_TAB           : return VK_TAB;
+      case SK_BACKSPACE     : return VK_BACK;
+      case SK_ESCAPE        : return VK_ESCAPE;
+      case SK_DELETE        : return VK_DELETE;
+      case SK_MENU          : return VK_F6;
+      case SK_KEYBOARD_ABC  : return VK_F11;
+      case SK_HARD1         : return VK_F1;
+      case SK_HARD2         : return VK_F2;
+      case SK_HARD3         : return VK_F3;
+      case SK_HARD4         : return VK_F4;
+      case SK_CALC          : return VK_F7;
+      case SK_FIND          : return VK_F8;
+      case SK_ACTION        : return VK_F12;
+      case SK_SCREEN_CHANGE : return VK_F9;
+      case SK_F1            : return VK_F1;
+      case SK_F2            : return VK_F2;
+      case SK_F3            : return VK_F3;
+      case SK_F4            : return VK_F4;
+      case SK_F5            : return VK_F5;
+      case SK_F6            : return VK_F6;
+      case SK_F7            : return VK_F7;
+      case SK_F8            : return VK_F8;
+      case SK_F9            : return VK_F9;
+      case SK_F10           : return VK_F10;
+      case SK_F11           : return VK_F11;
+      case SK_F12           : return VK_F12;
+      case SK_F13           : return VK_F13;
+      case SK_F14           : return VK_F14;
+      case SK_F15           : return VK_F15;
+      case SK_F16           : return VK_F16;
+      case SK_F17           : return VK_F17;
+      case SK_F18           : return VK_F18;
+      case SK_F19           : return VK_F19;
+      case SK_F20           : return VK_F20;
+      case SK_F21           : return VK_F21;
+      case SK_F22           : return VK_F22;
+      case SK_F23           : return VK_F23;
+      case SK_F24           : return VK_F24;
+      default:
+         break;
+   }
+   return key < 0 ? -key : key;
+}
+
+PortableSpecialKeys vmWin32KeyToPortable(int32 key)
+{
+   switch (key)
+   {
+      case VK_PRIOR : return SK_PAGE_UP;
+      case VK_NEXT  : return SK_PAGE_DOWN;
+      case VK_HOME  : return SK_HOME;
+      case VK_END   : return SK_END;
+      case VK_UP    : return SK_UP;
+      case VK_DOWN  : return SK_DOWN;
+      case VK_LEFT  : return SK_LEFT;
+      case VK_RIGHT : return SK_RIGHT;
+      case VK_INSERT: return SK_INSERT;
+      case VK_RETURN: return SK_ENTER;
+      case VK_TAB   : return SK_TAB;
+      case VK_BACK  : return SK_BACKSPACE;
+      case VK_ESCAPE: return SK_ESCAPE;
+      case VK_DELETE: return SK_DELETE;
+      case VK_F1    : return SK_HARD1;
+      case VK_F2    : return SK_HARD2;
+      case VK_F3    : return SK_HARD3;
+      case VK_F4    : return SK_HARD4;
+      case VK_F5    : return SK_F5;
+      case VK_F6    : return SK_MENU;
+      case VK_F7    : return SK_CALC;
+      case VK_F8    : return SK_FIND;
+      case VK_F9    : return SK_SCREEN_CHANGE;
+      case VK_F10   : return SK_HOME;
+      case VK_F11   : return SK_KEYBOARD_ABC;
+      case VK_F12   : return SK_ACTION;
+      case VK_F13   : return SK_F13;
+      case VK_F14   : return SK_F14;
+      case VK_F15   : return SK_F15;
+      case VK_F16   : return SK_F16;
+      case VK_F17   : return SK_F17;
+      case VK_F18   : return SK_F18;
+      case VK_F19   : return SK_F19;
+      case VK_F20   : return SK_F20;
+      case VK_F21   : return SK_F21;
+      case VK_F22   : return SK_F22;
+      case VK_F23   : return SK_F23;
+      case VK_F24   : return SK_F24;
+      default:
+         break;
+   }
+   return (PortableSpecialKeys)key;
+}
+
 void registerHotkeys(Int32Array keys, bool isRegister)
 {
    if (mainHWnd != null)
@@ -304,7 +411,7 @@ static void vmInterceptSpecialKeys(int32* keys, int32 len)
       {
          // map the TotalCross keys into the device-specific keys
          for (; len-- > 0; keys++, dk++)
-            *dk = keyPortable2Device(*keys);
+            *dk = vmPortableKeyToWin32(*keys);
          registerHotkeys(interceptedSpecialKeys, true);
       }
    }
@@ -387,7 +494,7 @@ static TCObject vmClipboardPaste(Context currentContext)
 
 static bool vmIsKeyDown(int32 key)
 {
-   key = keyPortable2Device(key);
+   key = vmPortableKeyToWin32(key);
    return (GetAsyncKeyState(key) & 0x8000) != 0;
 }
 

--- a/TotalCrossVM/src/nm/ui/GraphicsPrimitives.h
+++ b/TotalCrossVM/src/nm/ui/GraphicsPrimitives.h
@@ -13,13 +13,17 @@
 #include "skia/skia.h"
 #endif
 
-#if defined(WINCE) || defined(WIN32)
+#if defined(WINCE)
+ #include "win/gfx_ex.h"
+#elif TC_WINDOWING_SDL
+ #include "sdl/gfx_ex.h"
+#elif defined(WIN32)
  #include "win/gfx_ex.h"
 #elif defined(darwin)
  #include "darwin/gfx_ex.h"
 #elif defined(ANDROID)
  #include "android/gfx_ex.h"
-#elif defined(linux) || defined TC_WINDOWING_SDL
+#elif defined(linux)
  #include "linux/gfx_ex.h"
 #endif
 #include "xtypes.h"

--- a/TotalCrossVM/src/nm/ui/GraphicsPrimitives_c.h
+++ b/TotalCrossVM/src/nm/ui/GraphicsPrimitives_c.h
@@ -59,7 +59,7 @@ void graphicsDestroyPrimitives();
 static bool createScreenSurface(Context currentContext, bool isScreenChange);
 
 void updateScreen(Context currentContext);
-void privateScreenChange(int32 w, int32 h);
+void graphicsScreenChange(int32 w, int32 h);
 void markWholeScreenDirty(Context currentContext);
 static bool translateAndClip(TCObject g, int32 *pX, int32 *pY, int32 *pWidth, int32 *pHeight);
 
@@ -170,7 +170,7 @@ void screenChangeCommitted(Context currentContext, ScreenChangeFlags changes)
    *tcSettings.deviceFontHeightPtr = screen.deviceFontHeight;
 
    markWholeScreenDirty(currentContext);
-   privateScreenChange(screen.screenW, screen.screenH);
+   graphicsScreenChange(screen.screenW, screen.screenH);
 
    if ((changes & SCREEN_CHANGE_RECREATE_SURFACE) != 0)
    {

--- a/TotalCrossVM/src/nm/ui/Window.c
+++ b/TotalCrossVM/src/nm/ui/Window.c
@@ -8,33 +8,47 @@
 #include "WindowSafeArea.h"
 #include "GraphicsPrimitives.h"
 
-#if TC_WINDOWING_SDL && defined (WIN32) && !defined (WINCE)
+#if TC_WINDOWING_SDL
  #include "sdl/Window_c.h"
-#elif defined (WINCE) || defined (WIN32)
- #include "win/Window_c.h"
-#elif defined (darwin)
- #include "darwin/Window_c.h"
-#elif defined(ANDROID)
- #include "android/Window_c.h"
+#elif TC_WINDOWING_NATIVE
+ #if TC_OS_WINDOWS || TC_OS_WINCE
+  #include "win/Window_c.h"
+ #elif TC_OS_LINUX
+  #include "linux/Window_c.h"
+ #elif TC_OS_ANDROID
+  #include "android/Window_c.h"
+ #elif TC_OS_IOS
+  #include "darwin/Window_c.h"
+ #else
+  #error Unsupported native Window backend
+ #endif
 #else
- #include "linux/Window_c.h"
+ #error No Window backend selected
+#endif
+
+bool windowBackendSetSize(int32 width, int32 height)
+{
+   return windowBackendSetSizeImpl(width, height);
+}
+
+#if TC_OS_WINDOWS || TC_OS_WINCE
+ #include "win/WindowServices_c.h"
+#elif TC_OS_MACOS
+ #include "macos/WindowServices_c.h"
+#elif TC_OS_LINUX
+ #include "linux/WindowServices_c.h"
+#elif TC_OS_ANDROID
+ #include "android/WindowServices_c.h"
+#elif TC_OS_IOS
+ #include "darwin/WindowServices_c.h"
+#else
+ #error Unsupported Window platform services
 #endif
 
 //////////////////////////////////////////////////////////////////////////
 TC_API void tuW_isSipShown(NMParams p) // totalcross/ui/Window native public static boolean isSipShown();
 {     
-   int32 ret = 0;
-#if defined (WINCE) && _WIN32_WCE >= 300
-   if (*tcSettings.virtualKeyboardPtr)
-      ret = windowGetSIP();
-#elif defined(darwin)
-   ret = windowGetSIP();
-#elif defined (ANDROID)
-   ret = windowGetSIP();
-#elif defined (WIN32) && !defined(WINCE) // for windows 8 and up tablet devices
-   ret = windowGetSIP();
-#endif   
-   p->retI = ret;
+   p->retI = windowPlatformIsSIPShown();
 }
 //////////////////////////////////////////////////////////////////////////
 TC_API void tuW_setSIP_icb(NMParams p) // totalcross/ui/Window native public static void setSIP(int sipOption, totalcross.ui.Control control, boolean secret);
@@ -44,18 +58,12 @@ TC_API void tuW_setSIP_icb(NMParams p) // totalcross/ui/Window native public sta
    if (sipOption < SIP_HIDE || sipOption > SIP_SHOW)
       throwIllegalArgumentExceptionI(p->currentContext, "sipOption", sipOption);
    else
-#if defined (WINCE) && _WIN32_WCE >= 300
-   if (*tcSettings.virtualKeyboardPtr)
-      windowSetSIP(sipOption, p->i32[1]);
-#elif defined(darwin)
-   windowSetSIP(p->currentContext, sipOption, p->obj[0] /*control*/, p->i32[1] /*numeric*/);
-#elif defined (ANDROID)
-   windowSetSIP(sipOption, p->i32[1] /*numeric*/);
-#elif defined (WIN32) && !defined(WINCE) // for windows 8 and up tablet devices
-   windowSetSIP(sipOption, p->i32[1]);
-#else
-   ;
-#endif
+      windowPlatformSetSIP(
+         p->currentContext,
+         sipOption,
+         p->obj[0] /*control*/,
+         p->i32[1] /*numeric*/
+      );
 }
 //////////////////////////////////////////////////////////////////////////
 TC_API void tuW_pumpEvents(NMParams p) // totalcross/ui/Window native public static void pumpEvents();
@@ -65,17 +73,12 @@ TC_API void tuW_pumpEvents(NMParams p) // totalcross/ui/Window native public sta
 //////////////////////////////////////////////////////////////////////////
 TC_API void tuW_setDeviceTitle_s(NMParams p) // totalcross/ui/Window native public static void setDeviceTitle(String title);
 {
-   UNUSED(p);
-#ifndef darwin
-   windowSetDeviceTitle(p->obj[0]); // guich@tc113_32: changed 1 to 0
-#endif
+   windowBackendSetDeviceTitle(p->obj[0]); // guich@tc113_32: changed 1 to 0
 }
 //////////////////////////////////////////////////////////////////////////
 TC_API void tuW_setOrientation_i(NMParams p) // totalcross/ui/Window native public static void setOrientation(int orientation);
 {
-#ifdef ANDROID
-   windowSetOrientation(p->i32[0]);
-#endif
+   windowPlatformSetOrientation(p->i32[0]);
 }
 //////////////////////////////////////////////////////////////////////////
 TCObject* safeAreaInsets;
@@ -134,10 +137,9 @@ TC_API void tuW_getSafeAreaInsets(NMParams p) // totalcross/ui/Window public sta
    if (safeAreaInsets == null) {
       safeAreaInsets = getStaticFieldObject(p->currentContext, loadClass(p->currentContext, "totalcross.ui.Window", true), "safeAreaInsets");
    }
-#if defined darwin || defined ANDROID
    if (!safeAreaInsetsInitialized && safeAreaInsets != null && p->currentContext->thrownException == null) {
       int32 top = 0, left = 0, bottom = 0, right = 0;
-      windowGetSafeAreaInsets(
+      windowPlatformGetSafeAreaInsets(
          &top,
          &left,
          &bottom,
@@ -149,7 +151,6 @@ TC_API void tuW_getSafeAreaInsets(NMParams p) // totalcross/ui/Window public sta
       FIELD_I32(*safeAreaInsets, 3) = 0; //windowPhysicalToLogical(right);
       safeAreaInsetsInitialized = true;
    }
-#endif
    p->retO = (*safeAreaInsets);
 }
 

--- a/TotalCrossVM/src/nm/ui/Window.c
+++ b/TotalCrossVM/src/nm/ui/Window.c
@@ -8,7 +8,9 @@
 #include "WindowSafeArea.h"
 #include "GraphicsPrimitives.h"
 
-#if defined (WINCE) || defined (WIN32)
+#if TC_WINDOWING_SDL && defined (WIN32) && !defined (WINCE)
+ #include "sdl/Window_c.h"
+#elif defined (WINCE) || defined (WIN32)
  #include "win/Window_c.h"
 #elif defined (darwin)
  #include "darwin/Window_c.h"

--- a/TotalCrossVM/src/nm/ui/Window.h
+++ b/TotalCrossVM/src/nm/ui/Window.h
@@ -8,15 +8,8 @@
 #define WINDOW_H
 
 #include "tcvm.h"
+#include "WindowSIP.h"
 
-enum TCSIP
-{
-   SIP_HIDE    = 10000, /** Used to hide the virtual keyboard */
-   SIP_TOP     = 10001, /** Used to place the keyboard on top of screen */
-   SIP_BOTTOM  = 10002, /** Used to place the keyboard on bottom of screen */
-   SIP_SHOW    = 10003,  /** Used to show the virtual keyboard, without changing the position */
-   SIP_ENABLE_NUMERICPAD = 10004,
-   SIP_DISABLE_NUMERICPAD = 10005
-};
+bool windowBackendSetSize(int32 width, int32 height);
 
 #endif

--- a/TotalCrossVM/src/nm/ui/Window.h
+++ b/TotalCrossVM/src/nm/ui/Window.h
@@ -9,7 +9,16 @@
 
 #include "tcvm.h"
 #include "WindowSIP.h"
+#include "WindowStartup.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 bool windowBackendSetSize(int32 width, int32 height);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/TotalCrossVM/src/nm/ui/WindowSIP.h
+++ b/TotalCrossVM/src/nm/ui/WindowSIP.h
@@ -1,0 +1,19 @@
+// Copyright (C) 2020-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#ifndef WINDOW_SIP_H
+#define WINDOW_SIP_H
+
+enum TCSIP
+{
+   SIP_HIDE    = 10000, /** Used to hide the virtual keyboard */
+   SIP_TOP     = 10001, /** Used to place the keyboard on top of screen */
+   SIP_BOTTOM  = 10002, /** Used to place the keyboard on bottom of screen */
+   SIP_SHOW    = 10003,  /** Used to show the virtual keyboard, without changing the position */
+   SIP_ENABLE_NUMERICPAD = 10004,
+   SIP_DISABLE_NUMERICPAD = 10005
+};
+
+#endif

--- a/TotalCrossVM/src/nm/ui/WindowStartup.c
+++ b/TotalCrossVM/src/nm/ui/WindowStartup.c
@@ -1,0 +1,149 @@
+// Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "WindowStartup.h"
+#include "../../tcvm/tcvm.h"
+
+#include <stdlib.h>
+
+static int32 environmentDimension(const char *name)
+{
+   const char *value = getenv(name);
+   char *end = null;
+   long parsed;
+
+   if (value == null || *value == '\0')
+      return -1;
+   parsed = strtol(value, &end, 10);
+   return end != value && *end == '\0' && parsed > 0 ? (int32)parsed : -1;
+}
+
+void windowResetCommandLineOptions(TCWindowStartupOptions *options)
+{
+   if (options == null)
+      return;
+   options->screenSpecified = false;
+   options->x = -1;
+   options->y = -1;
+   options->width = -1;
+   options->height = -1;
+   options->initialState = TC_INITIAL_WINDOW_NORMAL;
+}
+
+void windowLoadStartupEnvironment(TCWindowStartupOptions *options)
+{
+   if (options == null)
+      return;
+   options->environmentWidth = -1;
+   options->environmentHeight = -1;
+#if TC_OS_DESKTOP
+   options->environmentWidth = environmentDimension("TC_WIDTH");
+   options->environmentHeight = environmentDimension("TC_HEIGHT");
+#endif
+}
+
+static bool hasTczSize(int16 appTczAttr)
+{
+   return (appTczAttr & (ATTR_WINDOWSIZE_320X480
+      | ATTR_WINDOWSIZE_480X640 | ATTR_WINDOWSIZE_600X800)) != 0;
+}
+
+static void resolveTczSize(int16 appTczAttr, const TCDisplayMetrics *display,
+   int32 *width, int32 *height)
+{
+   if (appTczAttr & ATTR_WINDOWSIZE_320X480)
+   {
+      *width = 320;
+      *height = 480;
+   }
+   else if (appTczAttr & ATTR_WINDOWSIZE_480X640)
+   {
+      *width = 480;
+      *height = 640;
+   }
+   else if (appTczAttr & ATTR_WINDOWSIZE_600X800)
+   {
+      *width = 600;
+      *height = display->usableHeight > 0 && display->usableHeight < 800
+         ? display->usableHeight : 800;
+   }
+   else
+   {
+      *width = -1;
+      *height = -1;
+   }
+}
+
+static TCWindowPositionMode resolvePositionMode(int32 position)
+{
+   return position == -2 ? TC_WINDOW_POSITION_CENTER
+      : position >= 0 ? TC_WINDOW_POSITION_EXPLICIT
+      : TC_WINDOW_POSITION_DEFAULT;
+}
+
+bool windowResolveStartupConfiguration(
+   const TCWindowStartupOptions *options,
+   const TCDisplayMetrics *display,
+   TCWindowStartupConfiguration *configuration)
+{
+   int32 tczWidth;
+   int32 tczHeight;
+   int32 defaultWidth;
+   int32 defaultHeight;
+   bool explicitSizeSource;
+   bool tczSizeSource;
+   bool tczSizeUsed;
+
+   if (options == null || display == null || configuration == null
+      || display->width <= 0 || display->height <= 0)
+      return false;
+
+   resolveTczSize(options->appTczAttr, display, &tczWidth, &tczHeight);
+   tczSizeSource = hasTczSize(options->appTczAttr);
+   explicitSizeSource = options->screenSpecified
+      || options->environmentWidth > 0 || options->environmentHeight > 0
+      || tczSizeSource;
+   defaultWidth = display->width / 2;
+   defaultHeight = display->height / 2;
+   configuration->fullscreen = options->initialState == TC_INITIAL_WINDOW_FULLSCREEN
+      || (options->initialState == TC_INITIAL_WINDOW_NORMAL
+         && options->legacyFullscreen);
+   configuration->maximized = !configuration->fullscreen
+      && options->initialState == TC_INITIAL_WINDOW_MAXIMIZED;
+   configuration->resizable = (options->appTczAttr & ATTR_RESIZABLE_WINDOW) != 0
+      && !configuration->fullscreen;
+
+   if (configuration->fullscreen && !explicitSizeSource)
+   {
+      defaultWidth = display->width;
+      defaultHeight = display->height;
+   }
+
+   if (options->screenSpecified)
+   {
+      configuration->width = options->width > 0 ? options->width : display->width / 2;
+      configuration->height = options->height > 0 ? options->height : display->height / 2;
+      configuration->xMode = resolvePositionMode(options->x);
+      configuration->yMode = resolvePositionMode(options->y);
+      configuration->x = options->x;
+      configuration->y = options->y;
+   }
+   else
+   {
+      configuration->width = options->environmentWidth > 0 ? options->environmentWidth
+         : tczWidth > 0 ? tczWidth : defaultWidth;
+      configuration->height = options->environmentHeight > 0 ? options->environmentHeight
+         : tczHeight > 0 ? tczHeight : defaultHeight;
+      tczSizeUsed = (options->environmentWidth <= 0 && tczWidth > 0)
+         || (options->environmentHeight <= 0 && tczHeight > 0);
+      configuration->xMode = tczSizeUsed ? TC_WINDOW_POSITION_CENTER
+         : TC_WINDOW_POSITION_DEFAULT;
+      configuration->yMode = tczSizeUsed ? TC_WINDOW_POSITION_CENTER
+         : TC_WINDOW_POSITION_DEFAULT;
+      configuration->x = 0;
+      configuration->y = 0;
+   }
+
+   return configuration->width > 0 && configuration->height > 0;
+}

--- a/TotalCrossVM/src/nm/ui/WindowStartup.h
+++ b/TotalCrossVM/src/nm/ui/WindowStartup.h
@@ -1,0 +1,78 @@
+// Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#ifndef WINDOW_STARTUP_H
+#define WINDOW_STARTUP_H
+
+#include "../../util/xtypes.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum TCInitialWindowState
+{
+   TC_INITIAL_WINDOW_NORMAL,
+   TC_INITIAL_WINDOW_FULLSCREEN,
+   TC_INITIAL_WINDOW_MAXIMIZED
+} TCInitialWindowState;
+
+typedef enum
+{
+   TC_WINDOW_POSITION_DEFAULT,
+   TC_WINDOW_POSITION_CENTER,
+   TC_WINDOW_POSITION_EXPLICIT
+} TCWindowPositionMode;
+
+typedef struct
+{
+   bool screenSpecified;
+   int32 x;
+   int32 y;
+   int32 width;
+   int32 height;
+
+   int32 environmentWidth;
+   int32 environmentHeight;
+
+   TCInitialWindowState initialState;
+   bool legacyFullscreen;
+   int16 appTczAttr;
+} TCWindowStartupOptions;
+
+typedef struct
+{
+   int32 width;
+   int32 height;
+   int32 usableWidth;
+   int32 usableHeight;
+} TCDisplayMetrics;
+
+typedef struct
+{
+   int32 width;
+   int32 height;
+
+   TCWindowPositionMode xMode;
+   TCWindowPositionMode yMode;
+   int32 x;
+   int32 y;
+
+   bool fullscreen;
+   bool maximized;
+   bool resizable;
+} TCWindowStartupConfiguration;
+
+void windowResetCommandLineOptions(TCWindowStartupOptions *options);
+void windowLoadStartupEnvironment(TCWindowStartupOptions *options);
+bool windowResolveStartupConfiguration(
+   const TCWindowStartupOptions *options,
+   const TCDisplayMetrics *display,
+   TCWindowStartupConfiguration *configuration);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/TotalCrossVM/src/nm/ui/Window_test.h
+++ b/TotalCrossVM/src/nm/ui/Window_test.h
@@ -1,9 +1,141 @@
 // Copyright (C) 2000-2013 SuperWaba Ltda.
-// Copyright (C) 2014-2020 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
+TESTCASE(windowResolveStartupConfiguration)
+{
+#if TC_OS_DESKTOP
+   struct StartupConfigurationCase
+   {
+      int16 appTczAttr;
+      bool screenSpecified;
+      int32 x;
+      int32 y;
+      int32 width;
+      int32 height;
+      int32 environmentWidth;
+      int32 environmentHeight;
+      TCInitialWindowState initialState;
+      bool legacyFullscreen;
+      int32 expectedWidth;
+      int32 expectedHeight;
+      TCWindowPositionMode expectedXMode;
+      TCWindowPositionMode expectedYMode;
+      int32 expectedX;
+      int32 expectedY;
+      bool expectedFullscreen;
+      bool expectedMaximized;
+      bool expectedResizable;
+   } cases[] = {
+      { ATTR_WINDOWSIZE_320X480 | ATTR_RESIZABLE_WINDOW, true, 40, 50, 700, 500,
+        600, 400, TC_INITIAL_WINDOW_NORMAL, false, 700, 500,
+        TC_WINDOW_POSITION_EXPLICIT, TC_WINDOW_POSITION_EXPLICIT, 40, 50,
+        false, false, true },
+      { ATTR_WINDOWSIZE_320X480, true, -2, -1, -1, -1, 600, 400,
+        TC_INITIAL_WINDOW_NORMAL, false, 800, 500,
+        TC_WINDOW_POSITION_CENTER, TC_WINDOW_POSITION_DEFAULT, -2, -1,
+        false, false, false },
+      { ATTR_WINDOWSIZE_320X480, false, -1, -1, -1, -1, 600, 400,
+        TC_INITIAL_WINDOW_NORMAL, false, 600, 400,
+        TC_WINDOW_POSITION_DEFAULT, TC_WINDOW_POSITION_DEFAULT, 0, 0,
+        false, false, false },
+      { ATTR_WINDOWSIZE_320X480, false, -1, -1, -1, -1, 600, -1,
+        TC_INITIAL_WINDOW_NORMAL, false, 600, 480,
+        TC_WINDOW_POSITION_CENTER, TC_WINDOW_POSITION_CENTER, 0, 0,
+        false, false, false },
+      { ATTR_WINDOWSIZE_320X480, false, -1, -1, -1, -1, -1, 400,
+        TC_INITIAL_WINDOW_NORMAL, false, 320, 400,
+        TC_WINDOW_POSITION_CENTER, TC_WINDOW_POSITION_CENTER, 0, 0,
+        false, false, false },
+      { ATTR_WINDOWSIZE_320X480, false, -1, -1, -1, -1, -1, -1,
+        TC_INITIAL_WINDOW_NORMAL, false, 320, 480,
+        TC_WINDOW_POSITION_CENTER, TC_WINDOW_POSITION_CENTER, 0, 0,
+        false, false, false },
+      { ATTR_WINDOWSIZE_480X640, false, -1, -1, -1, -1, -1, -1,
+        TC_INITIAL_WINDOW_NORMAL, false, 480, 640,
+        TC_WINDOW_POSITION_CENTER, TC_WINDOW_POSITION_CENTER, 0, 0,
+        false, false, false },
+      { ATTR_WINDOWSIZE_600X800, false, -1, -1, -1, -1, -1, -1,
+        TC_INITIAL_WINDOW_NORMAL, false, 600, 700,
+        TC_WINDOW_POSITION_CENTER, TC_WINDOW_POSITION_CENTER, 0, 0,
+        false, false, false },
+      { 0, false, -1, -1, -1, -1, -1, -1,
+        TC_INITIAL_WINDOW_NORMAL, false, 800, 500,
+        TC_WINDOW_POSITION_DEFAULT, TC_WINDOW_POSITION_DEFAULT, 0, 0,
+        false, false, false },
+      { 0, false, -1, -1, -1, -1, -1, -1,
+        TC_INITIAL_WINDOW_FULLSCREEN, false, 1600, 1000,
+        TC_WINDOW_POSITION_DEFAULT, TC_WINDOW_POSITION_DEFAULT, 0, 0,
+        true, false, false },
+      { ATTR_WINDOWSIZE_320X480, true, 10, -2, 480, -1, 600, 400,
+        TC_INITIAL_WINDOW_FULLSCREEN, false, 480, 500,
+        TC_WINDOW_POSITION_EXPLICIT, TC_WINDOW_POSITION_CENTER, 10, -2,
+        true, false, false },
+      { ATTR_WINDOWSIZE_320X480, false, -1, -1, -1, -1, 600, 400,
+        TC_INITIAL_WINDOW_FULLSCREEN, false, 600, 400,
+        TC_WINDOW_POSITION_DEFAULT, TC_WINDOW_POSITION_DEFAULT, 0, 0,
+        true, false, false },
+      { ATTR_WINDOWSIZE_480X640, false, -1, -1, -1, -1, -1, -1,
+        TC_INITIAL_WINDOW_FULLSCREEN, false, 480, 640,
+        TC_WINDOW_POSITION_CENTER, TC_WINDOW_POSITION_CENTER, 0, 0,
+        true, false, false },
+      { ATTR_RESIZABLE_WINDOW, false, -1, -1, -1, -1, -1, -1,
+        TC_INITIAL_WINDOW_NORMAL, false, 800, 500,
+        TC_WINDOW_POSITION_DEFAULT, TC_WINDOW_POSITION_DEFAULT, 0, 0,
+        false, false, true },
+      { ATTR_RESIZABLE_WINDOW, false, -1, -1, -1, -1, -1, -1,
+        TC_INITIAL_WINDOW_FULLSCREEN, false, 1600, 1000,
+        TC_WINDOW_POSITION_DEFAULT, TC_WINDOW_POSITION_DEFAULT, 0, 0,
+        true, false, false },
+      { ATTR_RESIZABLE_WINDOW, false, -1, -1, -1, -1, 600, -1,
+        TC_INITIAL_WINDOW_NORMAL, true, 600, 500,
+        TC_WINDOW_POSITION_DEFAULT, TC_WINDOW_POSITION_DEFAULT, 0, 0,
+        true, false, false },
+      { ATTR_RESIZABLE_WINDOW, false, -1, -1, -1, -1, -1, -1,
+        TC_INITIAL_WINDOW_MAXIMIZED, false, 800, 500,
+        TC_WINDOW_POSITION_DEFAULT, TC_WINDOW_POSITION_DEFAULT, 0, 0,
+        false, true, true },
+   };
+   TCDisplayMetrics display = { 1600, 1000, 1600, 700 };
+   TCWindowStartupOptions options;
+   TCWindowStartupConfiguration configuration;
+   int32 i;
 
+   for (i = 0; i < (int32)(sizeof(cases) / sizeof(cases[0])); i++)
+   {
+      xmemzero(&options, sizeof(options));
+      options.screenSpecified = cases[i].screenSpecified;
+      options.x = cases[i].x;
+      options.y = cases[i].y;
+      options.width = cases[i].width;
+      options.height = cases[i].height;
+      options.environmentWidth = cases[i].environmentWidth;
+      options.environmentHeight = cases[i].environmentHeight;
+      options.initialState = cases[i].initialState;
+      options.legacyFullscreen = cases[i].legacyFullscreen;
+      options.appTczAttr = cases[i].appTczAttr;
+      if (!windowResolveStartupConfiguration(&options, &display, &configuration)
+         || configuration.width != cases[i].expectedWidth
+         || configuration.height != cases[i].expectedHeight
+         || configuration.xMode != cases[i].expectedXMode
+         || configuration.yMode != cases[i].expectedYMode
+         || configuration.x != cases[i].expectedX
+         || configuration.y != cases[i].expectedY
+         || configuration.fullscreen != cases[i].expectedFullscreen
+         || configuration.maximized != cases[i].expectedMaximized
+         || configuration.resizable != cases[i].expectedResizable)
+      {
+         TEST_FAIL(tc, "Startup window configuration policy case failed");
+         goto finish;
+      }
+   }
+#else
+   TEST_SKIP;
+#endif
+   finish: ;
+}
 
 TESTCASE(tuW_pumpEvents) // totalcross/ui/Window native public static void pumpEvents();
 {

--- a/TotalCrossVM/src/nm/ui/android/WindowServices_c.h
+++ b/TotalCrossVM/src/nm/ui/android/WindowServices_c.h
@@ -1,0 +1,53 @@
+// Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "../Window.h"
+
+static void windowPlatformSetSIP(
+   Context currentContext,
+   int32 sipOption,
+   TCObject control,
+   bool numeric)
+{
+   UNUSED(currentContext)
+   UNUSED(control)
+   JNIEnv* env = getJNIEnv();
+   jmethodID m = (*env)->GetStaticMethodID(env, applicationClass, "setSIP", "(IZ)V");
+   (*env)->CallStaticVoidMethod(env, applicationClass, m, (jint) sipOption, numeric);
+}
+
+static bool windowPlatformIsSIPShown(void)
+{
+   JNIEnv* env = getJNIEnv();
+   jmethodID m = (*env)->GetStaticMethodID(env, applicationClass, "getSIP", "()Z");
+   return (*env)->CallStaticBooleanMethod(env, applicationClass, m);
+}
+
+static void windowPlatformSetOrientation(int32 orientation)
+{
+   JNIEnv* env = getJNIEnv();
+   jmethodID m = (*env)->GetStaticMethodID(env, applicationClass, "setOrientation", "(I)V");
+   (*env)->CallStaticVoidMethod(env, applicationClass, m, orientation);
+}
+
+static void windowPlatformGetSafeAreaInsets(
+   int32 *top,
+   int32 *left,
+   int32 *bottom,
+   int32 *right)
+{
+   JNIEnv *env = getJNIEnv();
+   jmethodID m = (*env)->GetStaticMethodID(env, applicationClass, "getSafeAreaInsets", "()[I");
+   jintArray array = (jintArray) (*env)->CallStaticObjectMethod(env, applicationClass, m);
+   if (array == null)
+      return;
+
+   jint *values = (*env)->GetIntArrayElements(env, array, NULL);
+   *top = values[0];
+   *left = values[1];
+   *bottom = values[2];
+   *right = values[3];
+   (*env)->ReleaseIntArrayElements(env, array, values, JNI_ABORT);
+   (*env)->DeleteLocalRef(env, array);
+}

--- a/TotalCrossVM/src/nm/ui/android/Window_c.h
+++ b/TotalCrossVM/src/nm/ui/android/Window_c.h
@@ -1,62 +1,22 @@
 // Copyright (C) 2000-2013 SuperWaba Ltda.
-// Copyright (C) 2014-2020 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
 
-
-static void windowSetSIP(int32 sipOption, bool numeric)
+static bool windowBackendSetSizeImpl(int32 width, int32 height)
 {
-   JNIEnv* env = getJNIEnv();
-   jmethodID m = (*env)->GetStaticMethodID(env, applicationClass, "setSIP", "(IZ)V");
-   (*env)->CallStaticVoidMethod(env, applicationClass, m, (jint) sipOption, numeric);
+   UNUSED(width)
+   UNUSED(height)
+   return false;
 }
 
-static bool windowGetSIP()
-{
-   JNIEnv* env = getJNIEnv();
-   jmethodID m = (*env)->GetStaticMethodID(env, applicationClass, "getSIP", "()Z");
-   return (*env)->CallStaticBooleanMethod(env, applicationClass, m);
-}
-
-static void windowSetDeviceTitle(TCObject titleObj)
+static void windowBackendSetDeviceTitle(TCObject titleObj)
 {
    JNIEnv* env = getJNIEnv();
    jmethodID m = (*env)->GetStaticMethodID(env, applicationClass, "setDeviceTitle", "(Ljava/lang/String;)V");
    jstring s = (*env)->NewString(env, String_charsStart(titleObj), String_charsLen(titleObj));
    (*env)->CallStaticVoidMethod(env, applicationClass, m, s);
    (*env)->DeleteLocalRef(env, s);
-}
-
-static void windowSetOrientation(int32 o)
-{
-   JNIEnv* env = getJNIEnv();
-   jmethodID m = (*env)->GetStaticMethodID(env, applicationClass, "setOrientation", "(I)V");
-   (*env)->CallStaticVoidMethod(env, applicationClass, m, o);
-}
-
-static void windowGetSafeAreaInsets(int32 *top, int32 *left, int32 *bottom, int32 *right) {
-    JNIEnv *env = getJNIEnv();
-    jmethodID m = (*env)->GetStaticMethodID(env, applicationClass, "getSafeAreaInsets", "()[I");
-
-    jintArray array = (jintArray) (*env)->CallStaticObjectMethod(env, applicationClass, m);
-    if (array == null) {
-        return;
-    }
-
-    jint *values = (*env)->GetIntArrayElements(env, array, NULL);
-
-    *top = values[0];
-    *left = values[1];
-    *bottom = values[2];
-    *right = values[3];
-
-    (*env)->ReleaseIntArrayElements(
-            env,
-            array,
-            values,
-            JNI_ABORT
-    );
-
-    (*env)->DeleteLocalRef(env, array);
 }

--- a/TotalCrossVM/src/nm/ui/backend/graphics/gles/gfx_Graphics_c.h
+++ b/TotalCrossVM/src/nm/ui/backend/graphics/gles/gfx_Graphics_c.h
@@ -363,7 +363,7 @@ static void setProjectionMatrix(float w, float h)
 
 /////////////////////////////////////////////////////////////////////////
 
-void privateScreenChange(int32 w, int32 h)
+void graphicsScreenChange(int32 w, int32 h)
 {
 #if defined(darwin) || (defined(TC_OS_IOS) && TC_OS_IOS)
    surfaceWillChange = false;

--- a/TotalCrossVM/src/nm/ui/backend/graphics/software/gfx_Graphics_c.h
+++ b/TotalCrossVM/src/nm/ui/backend/graphics/software/gfx_Graphics_c.h
@@ -6,7 +6,7 @@
 
 #include "gfx_ex.h"
 
-void privateScreenChange(int32 w, int32 h)
+void graphicsScreenChange(int32 w, int32 h)
 {
    UNUSED(w)
    UNUSED(h)

--- a/TotalCrossVM/src/nm/ui/backend/graphics/software/gfx_Graphics_c.h
+++ b/TotalCrossVM/src/nm/ui/backend/graphics/software/gfx_Graphics_c.h
@@ -27,7 +27,8 @@ bool graphicsStartup(ScreenSurface screen, int16 appTczAttr)
    *(tcSettings.isFullScreenPtr)=true;
 #endif
 #if TC_WINDOWING_SDL
-   TCSDL_Init(screen, exeName, *(tcSettings.isFullScreenPtr));
+   if (!TCSDL_Init(screen, exeName, *(tcSettings.isFullScreenPtr)))
+      return false;
 #elif !defined HEADLESS
    DFBResult err;
    IDirectFB *_dfb;
@@ -77,6 +78,10 @@ bool graphicsStartup(ScreenSurface screen, int16 appTczAttr)
 
 bool graphicsCreateScreenSurface(ScreenSurface screen)
 {
+#if TC_WINDOWING_SDL
+   if (!TCSDL_CreateBackBuffer(screen))
+      return false;
+#endif
 #if TC_RENDERER_SKIA
    initSkia(screen->screenW, screen->screenH, screen->pixels, (int)screen->pitch, screen->pixelformat);
 #endif
@@ -102,7 +107,12 @@ void graphicsUpdateScreen(Context currentContext, ScreenSurface screen) // scree
 void graphicsDestroy(ScreenSurface screen, bool isScreenChange)
 {
 #if TC_WINDOWING_SDL
-   TCSDL_Destroy(screen);
+   #if TC_RENDERER_SKIA
+   destroySkiaScreen();
+   #endif
+   TCSDL_DestroyBackBuffer(screen);
+   if (!isScreenChange)
+      TCSDL_DestroyWindow(screen);
 #elif !defined HEADLESS
    if (SCREEN_EX(screen)->layer)
       SCREEN_EX(screen)->layer->Release (SCREEN_EX(screen)->layer);
@@ -113,7 +123,11 @@ void graphicsDestroy(ScreenSurface screen, bool isScreenChange)
 
 bool graphicsLock(ScreenSurface screen, bool on)
 {
-#ifndef HEADLESS
+#if TC_WINDOWING_SDL || defined(HEADLESS)
+   UNUSED(screen)
+   UNUSED(on)
+   return true;
+#else
    IDirectFBSurface *surf = SCREEN_EX(screen)->primary;
    IDirectFBDisplayLayer *_layer = SCREEN_EX(screen)->layer;
    if (on)
@@ -127,7 +141,5 @@ bool graphicsLock(ScreenSurface screen, bool on)
       _layer->EnableCursor(_layer, 1);
       return ok;
    }
-#else
-    return true;
 #endif
 }

--- a/TotalCrossVM/src/nm/ui/backend/graphics/software/gfx_Graphics_c.h
+++ b/TotalCrossVM/src/nm/ui/backend/graphics/software/gfx_Graphics_c.h
@@ -27,7 +27,7 @@ bool graphicsStartup(ScreenSurface screen, int16 appTczAttr)
    *(tcSettings.isFullScreenPtr)=true;
 #endif
 #if TC_WINDOWING_SDL
-   if (!TCSDL_Init(screen, exeName, *(tcSettings.isFullScreenPtr)))
+   if (!TCSDL_Init(screen, exeName, *(tcSettings.isFullScreenPtr), appTczAttr))
       return false;
 #elif !defined HEADLESS
    DFBResult err;
@@ -71,7 +71,7 @@ bool graphicsStartup(ScreenSurface screen, int16 appTczAttr)
    screen->screenW = w;
    screen->screenH = h;
 #else
-   TCSDL_Init(screen, exeName, *(tcSettings.isFullScreenPtr));
+   TCSDL_Init(screen, exeName, *(tcSettings.isFullScreenPtr), appTczAttr);
 #endif
    return true;
 }

--- a/TotalCrossVM/src/nm/ui/darwin/WindowServices_c.h
+++ b/TotalCrossVM/src/nm/ui/darwin/WindowServices_c.h
@@ -1,0 +1,43 @@
+// Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void windowSetSIP(Context currentContext, int32 sipOption, TCObject control, bool numeric);
+bool windowGetSIP(void);
+void windowGetSafeAreaInsets(int32 *top, int32 *left, int32 *bottom, int32 *right);
+
+#ifdef __cplusplus
+}
+#endif
+
+static bool windowPlatformIsSIPShown(void)
+{
+   return windowGetSIP();
+}
+
+static void windowPlatformSetSIP(
+   Context currentContext,
+   int32 sipOption,
+   TCObject control,
+   bool numeric)
+{
+   windowSetSIP(currentContext, sipOption, control, numeric);
+}
+
+static void windowPlatformSetOrientation(int32 orientation)
+{
+   UNUSED(orientation)
+}
+
+static void windowPlatformGetSafeAreaInsets(
+   int32 *top,
+   int32 *left,
+   int32 *bottom,
+   int32 *right)
+{
+   windowGetSafeAreaInsets(top, left, bottom, right);
+}

--- a/TotalCrossVM/src/nm/ui/darwin/Window_c.h
+++ b/TotalCrossVM/src/nm/ui/darwin/Window_c.h
@@ -1,5 +1,6 @@
 // Copyright (C) 2000-2013 SuperWaba Ltda.
-// Copyright (C) 2014-2020 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -9,14 +10,17 @@
 extern "C" {
 #endif
 
-void windowSetSIP(Context currentContext, int32 sipOption, TCObject control, bool secret);
-bool windowGetSIP();
-void windowGetSafeAreaInsets(int32* top, int32* left, int32* bottom, int32* right);
+static bool windowBackendSetSizeImpl(int32 width, int32 height)
+{
+   UNUSED(width)
+   UNUSED(height)
+   return false;
+}
 
-/*static void windowSetDeviceTitle(TCObject titleObj)
+static void windowBackendSetDeviceTitle(TCObject titleObj)
 {
    UNUSED(titleObj)
-}*/
+}
 
 #ifdef __cplusplus
 }

--- a/TotalCrossVM/src/nm/ui/darwin/Window_c.m
+++ b/TotalCrossVM/src/nm/ui/darwin/Window_c.m
@@ -8,7 +8,7 @@
 #define Class __Class
 #include "xtypes.h"
 #include "tcvm.h"
-#include "Window_c.h"
+#include "WindowServices_c.h"
 #include "sipargs.h"
 #undef Class
 #include "mainview.h"

--- a/TotalCrossVM/src/nm/ui/darwin/sipargs.h
+++ b/TotalCrossVM/src/nm/ui/darwin/sipargs.h
@@ -1,5 +1,6 @@
 // Copyright (C) 2000-2013 SuperWaba Ltda.
-// Copyright (C) 2014-2020 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -7,14 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #include "xtypes.h"
-
-enum
-{
-   SIP_HIDE    = 10000, /** Used to hide the virtual keyboard */
-   SIP_TOP     = 10001, /** Used to place the keyboard on top of screen */
-   SIP_BOTTOM  = 10002, /** Used to place the keyboard on bottom of screen */
-   SIP_SHOW    = 10003  /** Used to show the virtual keyboard, without changing the position */
-};
+#include "../WindowSIP.h"
 
 struct SipArgs
 {

--- a/TotalCrossVM/src/nm/ui/font_Font.c
+++ b/TotalCrossVM/src/nm/ui/font_Font.c
@@ -40,13 +40,23 @@ TC_API void tufF_fontCreate(NMParams p) // totalcross/ui/font/Font native void f
    }
 
    int32 fontIdx = skia_getTypefaceIndex(nameTTF);
-   if (fontIdx == -1) {
-       if ((file = tczGetFile(nameTTF, false)) != null) {
-           uint8 buffer[file->uncompressedSize];
-           tczRead(file, buffer, file->uncompressedSize);
-           fontIdx = skia_makeTypeface(nameTTF, buffer, file->uncompressedSize);
-       }
-       tczClose(file);
+   if (fontIdx == -1)
+   {
+      file = tczGetFile(nameTTF, false);
+      if (file != null)
+      {
+         uint8 *buffer = (uint8 *)xmalloc(file->uncompressedSize);
+         if (buffer != null)
+         {
+            tczRead(file, buffer, file->uncompressedSize);
+            fontIdx = skia_makeTypeface(
+               nameTTF,
+               buffer,
+               file->uncompressedSize);
+            xfree(buffer);
+         }
+         tczClose(file);
+      }
    }
    Font_skiaIndex(obj) = fontIdx;
    // save reference to SkTypeFace at Font_hvUserFont

--- a/TotalCrossVM/src/nm/ui/gfx_Graphics.c
+++ b/TotalCrossVM/src/nm/ui/gfx_Graphics.c
@@ -14,7 +14,7 @@
 #endif
 #include "GraphicsPrimitives_c.h"
 
-#if defined(WINCE) || defined(WIN32)
+#if defined(WINCE) || (defined(WIN32) && TC_WINDOWING_NATIVE)
  #include "win/gfx_Graphics_c.h"
 #elif TC_GRAPHICS_GLES
  #include "backend/graphics/gles/gfx_Graphics_c.h"

--- a/TotalCrossVM/src/nm/ui/linux/WindowServices_c.h
+++ b/TotalCrossVM/src/nm/ui/linux/WindowServices_c.h
@@ -1,0 +1,36 @@
+// Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "../Window.h"
+
+static bool windowPlatformIsSIPShown(void)
+{
+   return false;
+}
+
+static void windowPlatformSetSIP(
+   Context currentContext,
+   int32 sipOption,
+   TCObject control,
+   bool numeric)
+{
+   UNUSED(currentContext)
+   UNUSED(sipOption)
+   UNUSED(control)
+   UNUSED(numeric)
+}
+
+static void windowPlatformSetOrientation(int32 orientation)
+{
+   UNUSED(orientation)
+}
+
+static void windowPlatformGetSafeAreaInsets(
+   int32 *top,
+   int32 *left,
+   int32 *bottom,
+   int32 *right)
+{
+   *top = *left = *bottom = *right = 0;
+}

--- a/TotalCrossVM/src/nm/ui/linux/Window_c.h
+++ b/TotalCrossVM/src/nm/ui/linux/Window_c.h
@@ -1,32 +1,18 @@
 // Copyright (C) 2000-2013 SuperWaba Ltda.
-// Copyright (C) 2014-2020 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
-#if __APPLE__
-#include "SDL.h"
-#else
-#include "SDL2/SDL.h"
-#endif
 #include "../Window.h"
 
-static int32 sip;
-static bool windowGetSIP()
+static bool windowBackendSetSizeImpl(int32 width, int32 height)
 {
-   return sip != SIP_HIDE;
+   UNUSED(width)
+   UNUSED(height)
+   return false;
 }
 
-static void windowSetSIP(int32 sipOption)
-{
-   sip = sipOption;
-   if(sip == SIP_HIDE) {
-      SDL_StopTextInput();
-   }
-   else {
-      SDL_StartTextInput();
-   }
-}
-
-static void windowSetDeviceTitle(TCObject titleObj)
+static void windowBackendSetDeviceTitle(TCObject titleObj)
 {
    UNUSED(titleObj)
 }

--- a/TotalCrossVM/src/nm/ui/linux/gfx_ex.h
+++ b/TotalCrossVM/src/nm/ui/linux/gfx_ex.h
@@ -10,29 +10,14 @@
 #define SETPIXEL32(r,g,b) (((r) << 16) | ((g) << 8) | (b))           // 00RRGGBB
 #define SETPIXEL565(r,g,b) ((((r) >> 3) << 11) | (((g) >> 2) << 5) | (((b) >> 3))) // bits RRRRRGGGGGGBBBBB
 
-#if TC_WINDOWING_SDL
-#if __APPLE__
-#include "SDL.h"
-#else
-#include "SDL2/SDL.h"
-#endif
-#else
 #include <directfb.h>
-#endif
 
 typedef struct TScreenSurfaceEx
 {
-#if TC_WINDOWING_SDL
-   SDL_Window *window;
-   SDL_Renderer *renderer;
-   SDL_Texture *texture;
-   SDL_Surface* surface;
-#else
    IDirectFB *dfb;
    IDirectFBSurface *primary;
    IDirectFBDisplayLayer *layer;
    IDirectFBEventBuffer *events;
-#endif
 } *ScreenSurfaceEx, TScreenSurfaceEx;
 
 #endif

--- a/TotalCrossVM/src/nm/ui/macos/WindowServices_c.h
+++ b/TotalCrossVM/src/nm/ui/macos/WindowServices_c.h
@@ -1,0 +1,36 @@
+// Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "../Window.h"
+
+static bool windowPlatformIsSIPShown(void)
+{
+   return false;
+}
+
+static void windowPlatformSetSIP(
+   Context currentContext,
+   int32 sipOption,
+   TCObject control,
+   bool numeric)
+{
+   UNUSED(currentContext)
+   UNUSED(sipOption)
+   UNUSED(control)
+   UNUSED(numeric)
+}
+
+static void windowPlatformSetOrientation(int32 orientation)
+{
+   UNUSED(orientation)
+}
+
+static void windowPlatformGetSafeAreaInsets(
+   int32 *top,
+   int32 *left,
+   int32 *bottom,
+   int32 *right)
+{
+   *top = *left = *bottom = *right = 0;
+}

--- a/TotalCrossVM/src/nm/ui/sdl/Window_c.h
+++ b/TotalCrossVM/src/nm/ui/sdl/Window_c.h
@@ -1,0 +1,70 @@
+// Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#if __APPLE__
+#include "SDL.h"
+#else
+#include "SDL2/SDL.h"
+#endif
+#include "../Window.h"
+
+static bool windowGetSIP()
+{
+   return SDL_IsTextInputActive() != SDL_FALSE;
+}
+
+static void windowSetSIP(int32 sipOption, bool numeric)
+{
+   UNUSED(numeric)
+   if (sipOption == SIP_HIDE || sipOption == SIP_DISABLE_NUMERICPAD)
+      SDL_StopTextInput();
+   else
+      SDL_StartTextInput();
+}
+
+static void windowSetDeviceTitle(TCObject titleObj)
+{
+   JCharP chars = String_charsStart(titleObj);
+   int32 length = String_charsLen(titleObj);
+   char *title = (char*)xmalloc((length * 4) + 1);
+   char *out = title;
+   int32 i;
+
+   for (i = 0; i < length; i++)
+   {
+      uint32 codePoint = chars[i];
+      if (codePoint >= 0xD800 && codePoint <= 0xDBFF && i + 1 < length
+         && chars[i + 1] >= 0xDC00 && chars[i + 1] <= 0xDFFF)
+      {
+         codePoint = 0x10000 + ((codePoint - 0xD800) << 10)
+            + (chars[++i] - 0xDC00);
+      }
+
+      if (codePoint < 0x80)
+         *out++ = (char)codePoint;
+      else if (codePoint < 0x800)
+      {
+         *out++ = (char)(0xC0 | (codePoint >> 6));
+         *out++ = (char)(0x80 | (codePoint & 0x3F));
+      }
+      else if (codePoint < 0x10000)
+      {
+         *out++ = (char)(0xE0 | (codePoint >> 12));
+         *out++ = (char)(0x80 | ((codePoint >> 6) & 0x3F));
+         *out++ = (char)(0x80 | (codePoint & 0x3F));
+      }
+      else
+      {
+         *out++ = (char)(0xF0 | (codePoint >> 18));
+         *out++ = (char)(0x80 | ((codePoint >> 12) & 0x3F));
+         *out++ = (char)(0x80 | ((codePoint >> 6) & 0x3F));
+         *out++ = (char)(0x80 | (codePoint & 0x3F));
+      }
+   }
+   *out = '\0';
+
+   if (SCREEN_EX(&screen) != null && SCREEN_EX(&screen)->window != null)
+      SDL_SetWindowTitle(SCREEN_EX(&screen)->window, title);
+   xfree(title);
+}

--- a/TotalCrossVM/src/nm/ui/sdl/Window_c.h
+++ b/TotalCrossVM/src/nm/ui/sdl/Window_c.h
@@ -8,22 +8,14 @@
 #include "SDL2/SDL.h"
 #endif
 #include "../Window.h"
+#include "../../init/tcsdl.h"
 
-static bool windowGetSIP()
+static bool windowBackendSetSizeImpl(int32 width, int32 height)
 {
-   return SDL_IsTextInputActive() != SDL_FALSE;
+   return TCSDL_SetWindowSize(width, height);
 }
 
-static void windowSetSIP(int32 sipOption, bool numeric)
-{
-   UNUSED(numeric)
-   if (sipOption == SIP_HIDE || sipOption == SIP_DISABLE_NUMERICPAD)
-      SDL_StopTextInput();
-   else
-      SDL_StartTextInput();
-}
-
-static void windowSetDeviceTitle(TCObject titleObj)
+static void windowBackendSetDeviceTitle(TCObject titleObj)
 {
    JCharP chars = String_charsStart(titleObj);
    int32 length = String_charsLen(titleObj);

--- a/TotalCrossVM/src/nm/ui/sdl/gfx_ex.h
+++ b/TotalCrossVM/src/nm/ui/sdl/gfx_ex.h
@@ -1,0 +1,22 @@
+// Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#ifndef GFX_EX_H
+#define GFX_EX_H
+
+#if __APPLE__
+#include "SDL.h"
+#else
+#include "SDL2/SDL.h"
+#endif
+
+typedef struct TScreenSurfaceEx
+{
+   SDL_Window *window;
+   SDL_Renderer *renderer;
+   SDL_Texture *texture;
+   SDL_Surface *surface;
+} *ScreenSurfaceEx, TScreenSurfaceEx;
+
+#endif

--- a/TotalCrossVM/src/nm/ui/sdl/gfx_ex.h
+++ b/TotalCrossVM/src/nm/ui/sdl/gfx_ex.h
@@ -5,6 +5,9 @@
 #ifndef GFX_EX_H
 #define GFX_EX_H
 
+#define SETPIXEL32(r,g,b) (((r) << 16) | ((g) << 8) | (b))
+#define SETPIXEL565(r,g,b) ((((r) >> 3) << 11) | (((g) >> 2) << 5) | ((b) >> 3))
+
 #if __APPLE__
 #include "SDL.h"
 #else

--- a/TotalCrossVM/src/nm/ui/skia/skia.cpp
+++ b/TotalCrossVM/src/nm/ui/skia/skia.cpp
@@ -30,6 +30,13 @@
 #endif
 #endif
 
+#if defined(ANDROID)
+#include <jni.h>
+#include <android/bitmap.h>
+#endif
+
+#if TC_GRAPHICS_GLES
+
 #if __APPLE__
 #ifdef darwin
 #include <OpenGLES/ES2/gl.h>
@@ -38,21 +45,20 @@
 #include <OpenGL/gl.h>
 #include <OpenGL/glu.h>
 #endif
-#else
-#if !defined(__arm__) && !defined(ANDROID)
+
+#elif !defined(__arm__) && !defined(ANDROID)
+
 #include <GL/gl.h>
+
 #else
+
 #include <EGL/egl.h>
-// #include <GLES/gl.h>
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
 
-#if defined ANDROID
-#include <jni.h>
-#include <android/bitmap.h>
 #endif
-#endif
-#endif
+
+#endif // TC_GRAPHICS_GLES
 #if TC_WINDOWING_SDL
 #include "../../../init/tcsdl.h"
 #endif
@@ -73,17 +79,6 @@
 #include "include/core/SkPath.h"
 #include "include/effects/SkGradientShader.h"
 #include "include/core/SkTextBlob.h"
-
-#include "include/gpu/gl/GrGLAssembleInterface.h"
-#include "include/gpu/gl/GrGLConfig.h"
-#include "include/gpu/gl/GrGLExtensions.h"
-#include "include/gpu/gl/GrGLFunctions.h"
-#include "include/gpu/gl/GrGLInterface.h"
-#include "include/gpu/gl/GrGLTypes.h"
-
-#include "include/gpu/GrBackendSurface.h"
-#include "include/gpu/GrDirectContext.h"
-#include "include/gpu/GrTypes.h"
 
 #include "include/core/SkColorSpace.h"
 #include "include/effects/SkDashPathEffect.h"
@@ -155,10 +150,11 @@ std::map<std::string, int> typefaceIndexMap;
 void initSkia(int w, int h, void * pixels, int pitch, uint32_t pixelformat)
 {
     SKIA_TRACE()
+    destroySkiaScreen();
 #if TC_GRAPHICS_SOFTWARE
     bitmap.installPixels(SkImageInfo::Make(w,
                                            h,
-                                           (SkColorType) colorType(pixelformat), kPremul_SkAlphaType), (Uint32 *)pixels, pitch);
+                                           (SkColorType) colorType(pixelformat), kPremul_SkAlphaType), pixels, pitch);
     canvas = new SkCanvas(bitmap);
 #elif TC_GRAPHICS_GLES
     // To use Skia's GPU backend, a OpenGL context is needed. Skia uses the "Gr" library to abstract
@@ -205,6 +201,16 @@ void initSkia(int w, int h, void * pixels, int pitch, uint32_t pixelformat)
     backPaint.setAntiAlias(true);
     canvas->clear(SK_ColorWHITE);
     flushSkia();
+}
+
+void destroySkiaScreen()
+{
+#if TC_GRAPHICS_SOFTWARE
+    delete canvas;
+#endif
+    canvas = nullptr;
+    bitmap.reset();
+    surface.reset();
 }
 
 void flushSkia()
@@ -337,21 +343,10 @@ extern "C" JNIEXPORT void JNICALL Java_totalcross_Launcher4A_drawIntoBitmap(JNIE
 
 #if TC_WINDOWING_SDL
 int32 colorType(uint32 pixelformat) {
-    if (SDL_PIXELTYPE(pixelformat) == SDL_PIXELTYPE_PACKED16) {
-        if (SDL_PIXELORDER(pixelformat) == SDL_PACKEDORDER_XRGB) {
-            if (SDL_PIXELLAYOUT(pixelformat) == SDL_PACKEDLAYOUT_565) {
-                return kRGB_565_SkColorType;
-            }
-        }
-    }
-    else if (SDL_PIXELTYPE(pixelformat) == SDL_PIXELTYPE_PACKED32) {
-        if (SDL_PIXELLAYOUT(pixelformat) == SDL_PACKEDLAYOUT_8888) {
-            if (SDL_PIXELORDER(pixelformat) == SDL_PACKEDORDER_XRGB ||
-                SDL_PIXELORDER(pixelformat) == SDL_PACKEDORDER_ARGB) {
-                return kBGRA_8888_SkColorType;
-            }
-        }
-    }
+    if (pixelformat == SDL_PIXELFORMAT_ARGB8888)
+        return kBGRA_8888_SkColorType;
+    if (pixelformat == SDL_PIXELFORMAT_RGB565)
+        return kRGB_565_SkColorType;
     debug("Unsupported pixel format %s, try mapping your color format on %s - %s", SDL_GetPixelFormatName(pixelformat), __FILE__, __FUNCTION__);
     return kUnknown_SkColorType;
 }

--- a/TotalCrossVM/src/nm/ui/skia/skia.h
+++ b/TotalCrossVM/src/nm/ui/skia/skia.h
@@ -26,6 +26,7 @@ typedef Pixel32 Pixel;
 int32 colorType(uint32 pixelformat);
 #endif
 void initSkia(int w, int h, void * pixels, int pitch, uint32 pixelformat);
+void destroySkiaScreen();
 void flushSkia();
 
 int skia_makeTypeface(char* name, void *data, int32 size);

--- a/TotalCrossVM/src/nm/ui/skia/skia_internal.h
+++ b/TotalCrossVM/src/nm/ui/skia/skia_internal.h
@@ -30,6 +30,7 @@
 #include "include/core/SkTypeface.h"
 #include "include/effects/SkDashPathEffect.h"
 #include "include/effects/SkGradientShader.h"
+#if TC_GRAPHICS_GLES
 #include "include/gpu/GrBackendSurface.h"
 #include "include/gpu/GrDirectContext.h"
 #include "include/gpu/GrTypes.h"
@@ -39,6 +40,7 @@
 #include "include/gpu/gl/GrGLFunctions.h"
 #include "include/gpu/gl/GrGLInterface.h"
 #include "include/gpu/gl/GrGLTypes.h"
+#endif
 #include "include/utils/SkRandom.h"
 
 static inline SkColor skiaColorFromPixel(Pixel pixel) {

--- a/TotalCrossVM/src/nm/ui/skia/skia_surface.cpp
+++ b/TotalCrossVM/src/nm/ui/skia/skia_surface.cpp
@@ -47,7 +47,7 @@ int skia_makeBitmap(int32 id, void *data, int32 w, int32 h) {
 
     auto imageSurface = std::make_unique<SkiaImageSurface>();
     imageSurface->bitmap.installPixels(
-        SkImageInfo::Make(w, h, kN32_SkColorType, kUnpremul_SkAlphaType),
+        SkImageInfo::Make(w, h, kRGBA_8888_SkColorType, kUnpremul_SkAlphaType),
         converted,
         sizeof(Pixel) * static_cast<size_t>(w),
         releaseProc,

--- a/TotalCrossVM/src/nm/ui/skia/skia_surface_test.cpp
+++ b/TotalCrossVM/src/nm/ui/skia/skia_surface_test.cpp
@@ -25,6 +25,15 @@ int main() {
         return 1;
     }
 
+    Pixel channelOrderPixel = 0x1020E0FF;
+    const Pixel expectedChannelOrder = 0xFF1020E0;
+    const int channelOrderSurface = skia_makeBitmap(-1, &channelOrderPixel, 1, 1);
+    if (channelOrderSurface < 0 ||
+        !expectEqual(skia_getPixel(channelOrderSurface, 0, 0), expectedChannelOrder,
+                     "asymmetric image channels")) {
+        return 1;
+    }
+
     const Pixel expected = skia_getPixel(source, 0, 0);
     skia_drawSurface(destination, source, 0, 0, 2, 2, 1, 1, 3, 3, 255);
     if (!expectEqual(skia_getPixel(destination, 1, 1), expected, "identity copy")) {
@@ -84,6 +93,7 @@ int main() {
 
     skia_deleteBitmap(source);
     skia_deleteBitmap(destination);
+    skia_deleteBitmap(channelOrderSurface);
     skia_deleteBitmap(primitiveDestination);
     skia_deleteBitmap(clippedDestination);
     std::puts("skia surface copy assertions passed");

--- a/TotalCrossVM/src/nm/ui/win/WindowServices_c.h
+++ b/TotalCrossVM/src/nm/ui/win/WindowServices_c.h
@@ -1,0 +1,188 @@
+// Copyright (C) 2000-2013 SuperWaba Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "../Window.h"
+#include "../GraphicsPrimitives.h"
+
+#if TC_OS_WINCE && _WIN32_WCE >= 300
+ #include <Sipapi.h>
+ #include "win/aygshellLib.h"
+#endif
+
+#if TC_OS_WINCE && _WIN32_WCE >= 300
+
+static SHIME_MODE oldMode = SHIME_MODE_NONE;
+
+#define IM_NUMBERS                    2
+#define IME_ESC_PRIVATE_FIRST         0x0800
+#define IME_ESC_SET_MODE              (IME_ESC_PRIVATE_FIRST)
+#define EM_SETINPUTMODE               0x00DE
+
+#endif
+
+static bool isShown;
+
+static bool windowPlatformIsSIPShown(void)
+{
+#if TC_OS_WINCE && _WIN32_WCE >= 300
+   if (!*tcSettings.virtualKeyboardPtr)
+      return false;
+#endif
+   return isShown;
+}
+
+static void windowPlatformSetSIP(
+   Context currentContext,
+   int32 sipOption,
+   TCObject control,
+   bool numeric)
+{
+   UNUSED(currentContext)
+   UNUSED(control)
+
+#if TC_OS_WINCE && _WIN32_WCE >= 300
+   if (!*tcSettings.virtualKeyboardPtr)
+      return;
+#endif
+
+   isShown = sipOption != SIP_HIDE && sipOption != SIP_DISABLE_NUMERICPAD;
+   if (numeric)
+      sipOption = sipOption == SIP_HIDE ? SIP_DISABLE_NUMERICPAD : SIP_ENABLE_NUMERICPAD;
+
+#if TC_OS_WINDOWS
+   switch (sipOption)
+   {
+      case SIP_HIDE:
+      {
+         HWND iHandle = FindWindow("IPTIP_Main_Window", "");
+         if (iHandle > 0)
+            SendMessage(iHandle, WM_SYSCOMMAND, SC_CLOSE, 0);
+         break;
+      }
+      default:
+         ShellExecute(NULL, "open", "C:\\Program Files\\Common Files\\Microsoft Shared\\ink\\TabTip.exe", NULL, NULL, SW_SHOWNORMAL);
+         break;
+   }
+#elif TC_OS_WINCE && _WIN32_WCE >= 300
+   CLSID Clsid;
+   RECT sipRect;
+   int32 scrW = GetSystemMetrics(SM_CXSCREEN);
+   int32 scrH = GetSystemMetrics(SM_CYSCREEN);
+
+   if (vkSettings.bottom > scrH || vkSettings.right > scrW)
+   {
+      int32 w = min32(scrW, scrH);
+      int32 h = scrH - scrW;
+      vkSettings.left = (scrW - w) / 2;
+      vkSettings.right = vkSettings.left + w;
+      vkSettings.bottom += h;
+      vkSettings.top += h;
+   }
+
+   switch (sipOption)
+   {
+#ifndef WIN32_PLATFORM_HPC2000
+      case SIP_ENABLE_NUMERICPAD:
+         if (_SHGetImeMode != null && _SHSetImeMode != null)
+         {
+            _SHGetImeMode(mainHWnd, &oldMode);
+            _SHSetImeMode(mainHWnd, SHIME_MODE_NUMBERS);
+         }
+         else
+         {
+            HRESULT hC = ImmGetContext(mainHWnd);
+            ImmSetOpenStatus(hC, TRUE);
+            ImmEscape(0, hC, IME_ESC_SET_MODE, (LPVOID)IM_NUMBERS);
+            SendMessage(null, EM_SETINPUTMODE, 0, IM_NUMBERS);
+         }
+         break;
+      case SIP_DISABLE_NUMERICPAD:
+         if (_SHSetImeMode != null)
+            _SHSetImeMode(mainHWnd, oldMode);
+         break;
+#endif
+      case SIP_HIDE:
+#ifndef WIN32_PLATFORM_HPC2000
+         if (_SHFullScreen != null)
+            _SHFullScreen(mainHWnd, SHFS_HIDESIPBUTTON);
+#endif
+         SipShowIM(SIPF_OFF);
+         {
+            HWND hsipbtn;
+            bSipUp = false;
+            hsipbtn = FindWindow(_T("MS_SIPBUTTON"), _T("MS_SIPBUTTON"));
+            SetWindowPos(hsipbtn, HWND_BOTTOM, 0, 0, 0, 0,
+               SWP_NOMOVE | SWP_NOSIZE | SWP_HIDEWINDOW);
+         }
+         break;
+      case SIP_TOP:
+      case SIP_BOTTOM:
+         if (sipOption == SIP_TOP)
+         {
+            sipRect.bottom = screen.screenY + (vkSettings.bottom - vkSettings.top) + vkSettings.topGap;
+            sipRect.top = screen.screenY + vkSettings.topGap;
+         }
+         else if (!isWindowsMobile)
+         {
+            sipRect.bottom = screen.screenY + screen.screenH;
+            sipRect.top = sipRect.bottom - (vkSettings.bottom - vkSettings.top);
+         }
+         else
+         {
+            sipRect.bottom = vkSettings.bottom;
+            sipRect.top = vkSettings.top;
+         }
+         sipRect.left = vkSettings.left;
+         sipRect.right = vkSettings.right;
+         vkSettings.changed = true;
+
+#ifndef WIN32_PLATFORM_HPC2000
+         if (_SHFullScreen != null)
+            _SHFullScreen(mainHWnd, SHFS_SHOWSIPBUTTON);
+#endif
+         SipSetDefaultRect(&sipRect);
+         SipGetCurrentIM(&Clsid);
+         SipSetCurrentIM(&Clsid);
+         SipShowIM(SIPF_ON);
+         {
+            HWND hsipbtn;
+            bSipUp = true;
+            hsipbtn = FindWindow(_T("MS_SIPBUTTON"), _T("MS_SIPBUTTON"));
+            SetWindowPos(hsipbtn, HWND_TOP, 0, 0, 0, 0,
+               SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+         }
+         break;
+      case SIP_SHOW:
+#ifndef WIN32_PLATFORM_HPC2000
+         if (_SHFullScreen != null)
+            _SHFullScreen(mainHWnd, SHFS_SHOWSIPBUTTON);
+#endif
+         SipShowIM(SIPF_ON);
+         {
+            HWND hsipbtn;
+            bSipUp = true;
+            hsipbtn = FindWindow(_T("MS_SIPBUTTON"), _T("MS_SIPBUTTON"));
+            SetWindowPos(hsipbtn, HWND_TOP, 0, 0, 0, 0,
+               SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+         }
+         break;
+   }
+#endif
+}
+
+static void windowPlatformSetOrientation(int32 orientation)
+{
+   UNUSED(orientation)
+}
+
+static void windowPlatformGetSafeAreaInsets(
+   int32 *top,
+   int32 *left,
+   int32 *bottom,
+   int32 *right)
+{
+   *top = *left = *bottom = *right = 0;
+}

--- a/TotalCrossVM/src/nm/ui/win/Window_c.h
+++ b/TotalCrossVM/src/nm/ui/win/Window_c.h
@@ -1,192 +1,38 @@
 // Copyright (C) 2000-2013 SuperWaba Ltda.
-// Copyright (C) 2014-2020 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
+#include "../Window.h"
 
-
-#if defined (WINCE) && _WIN32_WCE >= 300
- #include <Sipapi.h>
- #include "win/aygshellLib.h"
-#endif
-#include "../GraphicsPrimitives.h"
-
-/*****   windowSetSIP   *****
- *
- * typedef struct _RECT {
- *  LONG left;
- *  LONG top;
- *  LONG right;
- *  LONG bottom;
- * } RECT;
- *
- * OS Versions: Windows CE 1.0 and later.
- * Header: Windef.h.
- *
- * SipShowIM
- * SipSetDefaultRect
- * SipGetCurrentIM
- * SipSetCurrentIM
- *
- * OS Versions: Windows CE 2.10 and later.
- * Header: Sipapi.h.
- * Link Library: Coredll.lib.
- *
- *******************************/
-
-#if defined (WINCE) && _WIN32_WCE >= 300
-
-static SHIME_MODE oldMode = SHIME_MODE_NONE;
-
-#define IM_NUMBERS         2
-#define IME_ESC_PRIVATE_FIRST           0x0800
-#define IME_ESC_SET_MODE                   (IME_ESC_PRIVATE_FIRST)
-#define EM_SETINPUTMODE       0x00DE    // Sets default input mode when control gets focus. lParam should be be EIM_*|EIMMF_*.
-
-#endif
-
-static bool isShown;
-static bool windowGetSIP()
+void adjustWindowSizeWithBorders(int32 resizableWindow, int32* w, int32* h)
 {
-   return isShown;
-}
-static void windowSetSIP(int32 sipOption, bool numeric)
-{
-   isShown = sipOption != SIP_HIDE && sipOption != SIP_DISABLE_NUMERICPAD;
-   if (numeric)
-      sipOption = sipOption == SIP_HIDE ? SIP_DISABLE_NUMERICPAD : SIP_ENABLE_NUMERICPAD;
-   
-{
-#if defined(WIN32) && !defined(WINCE)
-   switch (sipOption)
-   {
-      case SIP_HIDE:
-         {
-         HWND iHandle = FindWindow("IPTIP_Main_Window", "");
-         if (iHandle > 0)
-            SendMessage(iHandle, WM_SYSCOMMAND, SC_CLOSE, 0);
-         break;
-         }
-      default:
-         ShellExecute(NULL, "open", "C:\\Program Files\\Common Files\\Microsoft Shared\\ink\\TabTip.exe", NULL, NULL, SW_SHOWNORMAL);
-         break;
-   }
-#elif defined (WINCE) && _WIN32_WCE >= 300
-   CLSID Clsid;
-   RECT sipRect;
-   int32 scrW = GetSystemMetrics(SM_CXSCREEN);
-   int32 scrH = GetSystemMetrics(SM_CYSCREEN);
-
-   if (vkSettings.bottom > scrH || vkSettings.right > scrW) // guich@tc110_99
-   {
-      int32 w = min32(scrW,scrH); // if the screen has been rotated, then the width is surely the width in portrait (mininum value)
-      int32 h = scrH - scrW;
-      vkSettings.left = (scrW - w) / 2; // center
-      vkSettings.right = vkSettings.left + w;
-      vkSettings.bottom += h;
-      vkSettings.top += h;
-   }
-
-   switch (sipOption)
-   {
-#ifndef WIN32_PLATFORM_HPC2000
-      case SIP_ENABLE_NUMERICPAD:
-         if (_SHGetImeMode != null && _SHSetImeMode != null)
-         {
-            _SHGetImeMode(mainHWnd, &oldMode);
-            _SHSetImeMode(mainHWnd, SHIME_MODE_NUMBERS);
-         }
-         else
-         {
-            HRESULT hC = ImmGetContext(mainHWnd);
-            ImmSetOpenStatus(hC, TRUE);
-            ImmEscape(0, hC, IME_ESC_SET_MODE, (LPVOID)IM_NUMBERS);
-            SendMessage(null, EM_SETINPUTMODE, 0, IM_NUMBERS);
-         }
-         break;
-      case SIP_DISABLE_NUMERICPAD:
-         if (_SHSetImeMode != null)
-            _SHSetImeMode(mainHWnd, oldMode);
-         break;
-#endif
-      case SIP_HIDE:
-#ifndef WIN32_PLATFORM_HPC2000
-		  if (_SHFullScreen != null) {
-			_SHFullScreen(mainHWnd, SHFS_HIDESIPBUTTON);
-		  }
-#endif
-         SipShowIM(SIPF_OFF);
-         {  //flsobral@tc114_50: fixed the SIP keyboard button not being properly displayed on some WinCE devices.
-            HWND hsipbtn;
-            bSipUp = false;
-            hsipbtn = FindWindow(_T("MS_SIPBUTTON"), _T("MS_SIPBUTTON"));
-            SetWindowPos(hsipbtn, HWND_BOTTOM, 0,0, 0,0, SWP_NOMOVE | SWP_NOSIZE | SWP_HIDEWINDOW);
-         }
-         break;
-      case SIP_TOP:
-      case SIP_BOTTOM:
-         if (sipOption == SIP_TOP)
-         {
-            sipRect.bottom = screen.screenY + (vkSettings.bottom - vkSettings.top) + vkSettings.topGap;
-            sipRect.top = screen.screenY + vkSettings.topGap;
-         }
-         else
-         {
-            if (!isWindowsMobile)
-            {
-               // flsobral@tc113_24: SIP bottom position is always relative to the screen, not to its original position.
-               sipRect.bottom = screen.screenY + screen.screenH;
-               sipRect.top = sipRect.bottom - (vkSettings.bottom - vkSettings.top);
-            }
-            else
-            {
-               // flsobral@tc113_42: SIP is relative to the screen only on WindowsCE, WM devices use the original SIP position.
-               sipRect.bottom = vkSettings.bottom;
-               sipRect.top = vkSettings.top;
-            }
-         }
-         sipRect.left = vkSettings.left;
-         sipRect.right = vkSettings.right;
-         vkSettings.changed = true;
-
-#ifndef WIN32_PLATFORM_HPC2000
-		 if (_SHFullScreen != null) {
-			_SHFullScreen(mainHWnd, SHFS_SHOWSIPBUTTON);
-		 }
-#endif
-         SipSetDefaultRect(&sipRect);
-         SipGetCurrentIM(&Clsid);
-         SipSetCurrentIM(&Clsid);
-         SipShowIM(SIPF_ON);
-         {  //flsobral@tc114_50: fixed the SIP keyboard button not being properly displayed on some WinCE devices.
-            HWND hsipbtn;
-            bSipUp = true;
-            hsipbtn = FindWindow(_T("MS_SIPBUTTON"), _T("MS_SIPBUTTON"));
-            SetWindowPos(hsipbtn, HWND_TOP, 0,0, 0,0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
-         }
-         break;
-      case SIP_SHOW:
-#ifndef WIN32_PLATFORM_HPC2000
-		  if (_SHFullScreen != null) {
-			_SHFullScreen(mainHWnd, SHFS_SHOWSIPBUTTON);
-		  }
-#endif
-         SipShowIM(SIPF_ON);
-         {  //flsobral@tc114_50: fixed the SIP keyboard button not being properly displayed on some WinCE devices.
-            HWND hsipbtn;
-            bSipUp = true;
-            hsipbtn = FindWindow(_T("MS_SIPBUTTON"), _T("MS_SIPBUTTON"));
-            SetWindowPos(hsipbtn, HWND_TOP, 0,0, 0,0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW); // sets z-order to top but doesn't reposition or resize
-         }
-         break;
-   }
+#ifndef WINCE // windows ce already does this for us
+   *w += GetSystemMetrics(resizableWindow ? SM_CXSIZEFRAME : SM_CXFIXEDFRAME)*2;
+   *h += GetSystemMetrics(resizableWindow ? SM_CYSIZEFRAME : SM_CYFIXEDFRAME)*2 + GetSystemMetrics(SM_CYCAPTION);
+#else
+   UNUSED(resizableWindow)
+   UNUSED(w)
+   UNUSED(h)
 #endif
 }
+
+static bool windowBackendSetSizeImpl(int32 width, int32 height)
+{
+#ifndef WINCE // windows ce already does this for us
+   adjustWindowSizeWithBorders(*tcSettings.resizableWindow, &width, &height);
+   return SetWindowPos(mainHWnd, 0, 0, 0, width, height, SWP_NOMOVE) != 0;
+#else
+   UNUSED(width)
+   UNUSED(height)
+   return true;
+#endif
 }
 
-static void windowSetDeviceTitle(TCObject titleObj)
+static void windowBackendSetDeviceTitle(TCObject titleObj)
 {
    TCHAR buf[30];
-   JCharP2TCHARPBuf(String_charsStart(titleObj), min32(String_charsLen(titleObj),29), buf); // guich@tc113_32: limit to buf's size (and reduced to 30 chars)
+   JCharP2TCHARPBuf(String_charsStart(titleObj), min32(String_charsLen(titleObj), 29), buf);
    SetWindowText(mainHWnd, buf);
 }

--- a/TotalCrossVM/src/nm/ui/win/gfx_Graphics_c.h
+++ b/TotalCrossVM/src/nm/ui/win/gfx_Graphics_c.h
@@ -4,6 +4,8 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
+#include "../Window.h"
+
 void graphicsScreenChange(int32 w, int32 h)
 {
    UNUSED(w)
@@ -50,10 +52,6 @@ void getScreenSize(int32 *w, int32* h)
 #endif
 }
 
-#if !defined(WINCE)
-extern int32 defScrX,defScrY,defScrW,defScrH;
-#endif
-
 bool graphicsStartup(ScreenSurface screen, int16 appTczAttr)
 {
    DWORD style;
@@ -63,7 +61,16 @@ bool graphicsStartup(ScreenSurface screen, int16 appTczAttr)
    HANDLE instance = GetModuleHandle(0);
    char* dot;
    HDC deviceContext;
-   bool resizableWindow = appTczAttr & ATTR_RESIZABLE_WINDOW;
+   bool resizableWindow;
+   int32 windowedWidth, windowedHeight;
+   int32 requestedX, requestedY;
+   bool defaultX, defaultY;
+   RECT actualWindowRect;
+#if !defined(WINCE)
+   TCDisplayMetrics display;
+   TCWindowStartupOptions startupOptions = desktopWindowStartupOptions;
+   TCWindowStartupConfiguration configuration;
+#endif
 
    screen->extension = (TScreenSurfaceEx*)xmalloc(sizeof(TScreenSurfaceEx));
 
@@ -74,25 +81,36 @@ bool graphicsStartup(ScreenSurface screen, int16 appTczAttr)
    screen->bpp = GetDeviceCaps(deviceContext,BITSPIXEL) * GetDeviceCaps(deviceContext,PLANES);
    DeleteDC(deviceContext);
 
-   if (appTczAttr & ATTR_WINDOWSIZE_320X480) {defScrX=defScrY=-2; width = 320; height = 480;} else
-   if (appTczAttr & ATTR_WINDOWSIZE_480X640) {defScrX=defScrY=-2; width = 480; height = 640;} else
-   if (appTczAttr & ATTR_WINDOWSIZE_600X800) {defScrX=defScrY=-2; width = 600; height = min32(800,rect.bottom-rect.top);} else
-   {
-      width = defScrW == -1 ? 240 : defScrW;
-      height = defScrH == -1 ? 320 : defScrH;
-   }                                                                                                                          
-#ifdef _DEBUG
-   defScrX = defScrY = 0;
-#endif
-
-   rect.left = defScrX == -1 ? 0 : defScrX == -2 ? (rect.left+(rect.right -width )/2) : defScrX;
-   rect.top  = defScrY == -1 ? 0 : defScrY == -2 ? (rect.top +(rect.bottom-height)/2) : defScrY;
+   display.width = GetSystemMetrics(SM_CXSCREEN);
+   display.height = GetSystemMetrics(SM_CYSCREEN);
+   display.usableWidth = rect.right - rect.left;
+   display.usableHeight = rect.bottom - rect.top;
+   startupOptions.appTczAttr = appTczAttr;
+   startupOptions.legacyFullscreen = *tcSettings.isFullScreenPtr;
+   windowLoadStartupEnvironment(&startupOptions);
+   if (!windowResolveStartupConfiguration(&startupOptions, &display, &configuration))
+      return false;
+   width = configuration.width;
+   height = configuration.height;
+   resizableWindow = configuration.resizable;
+   defaultX = configuration.xMode == TC_WINDOW_POSITION_DEFAULT;
+   defaultY = configuration.yMode == TC_WINDOW_POSITION_DEFAULT;
+   requestedX = configuration.xMode == TC_WINDOW_POSITION_CENTER
+      ? rect.left + (rect.right - rect.left - width) / 2 : configuration.x;
+   requestedY = configuration.yMode == TC_WINDOW_POSITION_CENTER
+      ? rect.top + (rect.bottom - rect.top - height) / 2 : configuration.y;
+   rect.left = defaultX ? CW_USEDEFAULT : requestedX;
+   rect.top = defaultY ? CW_USEDEFAULT : requestedY;
    rect.bottom = height;
    rect.right = width;
-   adjustWindowSizeWithBorders(resizableWindow,&rect.right,&rect.bottom);
+   if (!configuration.fullscreen)
+      adjustWindowSizeWithBorders(resizableWindow,&rect.right,&rect.bottom);
 
-   style |= WS_SYSMENU | WS_CAPTION | WS_MINIMIZEBOX;
-   if (resizableWindow) style |= WS_THICKFRAME | WS_MAXIMIZEBOX;
+   if (!configuration.fullscreen)
+   {
+      style |= WS_SYSMENU | WS_CAPTION | WS_MINIMIZEBOX;
+      if (resizableWindow) style |= WS_THICKFRAME | WS_MAXIMIZEBOX;
+   }
 #else
    SystemParametersInfo(SPI_GETWORKAREA, 0, &defaultWorkingArea, 0);
    deviceContext = GetDC(mainHWnd);
@@ -109,18 +127,46 @@ bool graphicsStartup(ScreenSurface screen, int16 appTczAttr)
       height = rect.bottom;
    AdjustWindowRectEx(&rect, style, FALSE, 0);
 #endif
+   windowedWidth = width;
+   windowedHeight = height;
    dot = xstrrchr(mainClassName, '.');
    CharP2TCHARPBuf(dot ? dot+1 : mainClassName, main); // remove the package from the name
    mainHWnd = CreateWindow(exeName, main, style, rect.left, rect.top, rect.right, rect.bottom, NULL, NULL, instance, NULL ); // guich@400_62: move window to desired user position
    if (!mainHWnd)
       return false;
+#if !defined(WINCE)
+   if (defaultX || defaultY)
+   {
+      GetWindowRect(mainHWnd, &actualWindowRect);
+      if (!defaultX || !defaultY)
+      {
+         SetWindowPos(mainHWnd, NULL,
+            defaultX ? actualWindowRect.left : requestedX,
+            defaultY ? actualWindowRect.top : requestedY,
+            0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+      }
+      rect.left = defaultX ? actualWindowRect.left : requestedX;
+      rect.top = defaultY ? actualWindowRect.top : requestedY;
+   }
+   if (configuration.maximized)
+      ShowWindow(mainHWnd, SW_MAXIMIZE);
+#endif
 
    // store the x, y, width, height, hRes and vRes
    screen->screenY = rect.top;
    GetClientRect(mainHWnd, &rect);
+#if !defined(WINCE)
+   if (configuration.maximized)
+   {
+      width = rect.right - rect.left;
+      height = rect.bottom - rect.top;
+   }
+#endif
    screen->screenX = rect.left;
-   screen->minScreenW = screen->screenW = width;
-   screen->minScreenH = screen->screenH = height;
+   screen->minScreenW = windowedWidth;
+   screen->minScreenH = windowedHeight;
+   screen->screenW = width;
+   screen->screenH = height;
    screen->hRes = GetDeviceCaps(deviceContext, LOGPIXELSX);
    screen->vRes = GetDeviceCaps(deviceContext, LOGPIXELSY);
 

--- a/TotalCrossVM/src/nm/ui/win/gfx_Graphics_c.h
+++ b/TotalCrossVM/src/nm/ui/win/gfx_Graphics_c.h
@@ -1,21 +1,13 @@
 // Copyright (C) 2000-2013 SuperWaba Ltda.
-// Copyright (C) 2014-2020 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
-void adjustWindowSizeWithBorders(int32 resizableWindow, int32* w, int32* h)
+void graphicsScreenChange(int32 w, int32 h)
 {
-#ifndef WINCE // windows ce already does this for us
-   *w += GetSystemMetrics(resizableWindow ? SM_CXSIZEFRAME : SM_CXFIXEDFRAME)*2;
-   *h += GetSystemMetrics(resizableWindow ? SM_CYSIZEFRAME : SM_CYFIXEDFRAME)*2 + GetSystemMetrics(SM_CYCAPTION);
-#endif
-}
-void privateScreenChange(int32 w, int32 h)
-{
-#ifndef WINCE // windows ce already does this for us
-   adjustWindowSizeWithBorders(*tcSettings.resizableWindow,&w, &h);
-   SetWindowPos(mainHWnd,0,0,0, w, h, SWP_NOMOVE);
-#endif
+   UNUSED(w)
+   UNUSED(h)
 }
 
 #if defined (WINCE)

--- a/TotalCrossVM/src/tests/tc_tests.c
+++ b/TotalCrossVM/src/tests/tc_tests.c
@@ -1,6 +1,11 @@
+// Copyright (C) 2020-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
 #include "tcvm.h"
 
-#define TEST_COUNT 347
+#define TEST_COUNT 349
 
 // Function prototypes
 void test_VM_PrimitiveTypeSizes(struct TestSuite *tc, Context currentContext);// tcvm/tcvm_test.h
@@ -171,7 +176,9 @@ void test_tuMW_getCommandLine(struct TestSuite *tc, Context currentContext);// n
 void test_tuMW_setTimerInterval_i(struct TestSuite *tc, Context currentContext);// nm/ui/MainWindow_test.h
 void test_tuW_pumpEvents(struct TestSuite *tc, Context currentContext);// nm/ui/Window_test.h
 void test_tuW_setSIP_icb(struct TestSuite *tc, Context currentContext);// nm/ui/Window_test.h
+void test_windowResolveStartupConfiguration(struct TestSuite *tc, Context currentContext);// nm/ui/Window_test.h
 void test_tueE_isAvailable(struct TestSuite *tc, Context currentContext);// nm/ui/event_Event_test.h
+void test_startup_filterApplicationCommandLine(struct TestSuite *tc, Context currentContext);// init/startup_test.h
 void test_tufFM_charWidth_c(struct TestSuite *tc, Context currentContext);// nm/ui/font_FontMetrics_test.h - depends on testtufFM_fontMetricsCreate
 void test_tufFM_stringWidth_Cii(struct TestSuite *tc, Context currentContext);// nm/ui/font_FontMetrics_test.h
 void test_tuiI_imageLoad_s(struct TestSuite *tc, Context currentContext);// nm/ui/image_Image_test.h
@@ -702,6 +709,8 @@ void fillTestCaseArray(testFunc *tests)
    tests[344] = test__str2double;
    tests[345] = test__str2int64;
    tests[346] = test_VM_Cleanup;
+   tests[347] = test_startup_filterApplicationCommandLine;
+   tests[348] = test_windowResolveStartupConfiguration;
 }
 
 void startTestSuite(Context currentContext)
@@ -732,4 +741,3 @@ void startTestSuite(Context currentContext)
 }
 
 #endif
-

--- a/TotalCrossVM/src/tests/window_startup_native_test.c
+++ b/TotalCrossVM/src/tests/window_startup_native_test.c
@@ -1,0 +1,43 @@
+// Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "../tcvm/tcvm.h"
+#include "../tests/tc_testsuite.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+static bool testFail(struct TestSuite *tc, char *message, ...)
+{
+   (void)message;
+   tc->failed++;
+   return false;
+}
+
+static void testOutput(struct TestSuite *tc, char *message, ...)
+{
+   (void)tc;
+   (void)message;
+}
+
+#define xmemzero(buffer, size) memset((buffer), 0, (size))
+#include "../nm/ui/Window_test.h"
+
+int main(void)
+{
+   struct TestSuite testSuite;
+
+   memset(&testSuite, 0, sizeof(testSuite));
+   testSuite.fail = testFail;
+   testSuite.output = testOutput;
+   test_windowResolveStartupConfiguration(&testSuite, null);
+   if (testSuite.failed != 0)
+   {
+      fprintf(stderr, "windowResolveStartupConfiguration failed\n");
+      return 1;
+   }
+   puts("windowResolveStartupConfiguration passed");
+   return 0;
+}

--- a/TotalCrossVM/src/util/xtypes.h
+++ b/TotalCrossVM/src/util/xtypes.h
@@ -97,7 +97,9 @@ typedef JChar* JCharP;
 
 #if !defined HAS_TCHAR
  #if defined(WINCE) || defined(WIN32)
-  #define inline __inline
+  #if !defined(__cplusplus)
+   #define inline __inline
+  #endif
   #if defined(UNICODE) && !defined(__cplusplus)
   typedef uint16 TCHAR;
   #endif

--- a/TotalCrossVM/vc2008/README.md
+++ b/TotalCrossVM/vc2008/README.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (C) 2020-2021 TotalCross Global Mobile Platform Ltda
+Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
+
+SPDX-License-Identifier: LGPL-2.1-only
+-->
+
 # Compiling and Testing TotalCross Virtual Machine for Windows or WinCE
 First things first, in order to compile a virtual machine for Windows desktop, one need to install the following requirements on your machine:
 
@@ -27,6 +34,20 @@ Lastly, press Build and your tcvm.dll will be ready to debug your applcation:
 ![](https://imgur.com/YLo5AaS.png)
 
 Now we are able to develop new features and fix some bugs and Test on your Visual Studio Code.
+
+### Windows desktop graphics backends
+
+Windows desktop builds default to SDL2 windowing with Skia raster rendering
+over the software framebuffer. SDL2 is supplied as the pinned static
+depot-tools dependency; a host SDL installation is not required. To build the
+compatibility fallback explicitly, configure with:
+
+```text
+cmake ..\ -G"Visual Studio 17 2022" -A Win32 -DTC_WINDOWING_SDL=OFF -DTC_RENDERER_SKIA=OFF -DTC_GRAPHICS_SOFTWARE=ON
+```
+
+This selects the original Native + Legacy + Software path. Windows CE remains
+fixed to that native configuration.
 
 ### Windows CE
 

--- a/scripts/prepare-native-dependencies.sh
+++ b/scripts/prepare-native-dependencies.sh
@@ -141,9 +141,11 @@ for target in "${common_targets[@]}"; do
   fetch_dep axtls "$platform" "$arch" AXTLS_GITHUB_TOKEN AXTLS_RELEASE_TAG AXTLS_GITHUB_REPO
   fetch_dep qrcodegen "$platform" "$arch" QRCODEGEN_GITHUB_TOKEN QRCODEGEN_RELEASE_TAG QRCODEGEN_GITHUB_REPO
   fetch_dep skia "$platform" "$arch" SKIA_GITHUB_TOKEN SKIA_RELEASE_TAG SKIA_GITHUB_REPO
-  if [ "$platform" = linux ] || [ "$platform" = macos ]; then
-    fetch_dep sdl2 "$platform" "$arch" SDL2_GITHUB_TOKEN SDL2_RELEASE_TAG SDL2_GITHUB_REPO
-  fi
+  case "$platform" in
+    linux|macos|windows)
+      fetch_dep sdl2 "$platform" "$arch" SDL2_GITHUB_TOKEN SDL2_RELEASE_TAG SDL2_GITHUB_REPO
+      ;;
+  esac
 done
 
 skia_shared_args=("$depot_dir/skia/fetch.sh" --install-shared --github-token-env SKIA_GITHUB_TOKEN)


### PR DESCRIPTION
### What changed
- Introduces an explicit Windows desktop backend architecture so windowing, event delivery, rendering, and graphics storage can evolve independently.
- Makes SDL + Skia + software raster the default modern Windows desktop path while preserving Native + Legacy + Software as a fallback.
- Keeps WinCE on the existing Native + Legacy path and rejects unsupported backend combinations explicitly.

### Windowing and input
- Moves SDL desktop event ownership into the shared SDL path, including text input, modifiers, special keys, mouse/touch events, lifecycle handling, and Windows hotkey bridging.
- Limits SysWM usage to platform services instead of maintaining a second Win32 event pump.
- Centralizes desktop startup policy for TCZ attributes, `/scr`, environment dimensions, positioning, fullscreen, maximized, and resizable state.

### Rendering
- Presents the software framebuffer through an SDL ARGB8888 streaming texture and maps it deterministically to Skia raster storage.
- Makes window, renderer, backbuffer, and Skia lifetimes explicit across resize, recreation, and rotation.
- Separates platform window services from backend-specific rendering and input code.

### Validation and limitations
- Native startup tests, macOS SDL + Skia builds, SDK distribution, and the complete Merge Flow passed across Windows, macOS, Linux, Android, iOS, and SDK jobs.
- Windows CI provides build coverage for both SDL and Native/Legacy paths.
- Interactive Windows runtime checks such as mixed-DPI monitor movement, keyboard/text interaction, hotkeys, and visual comparison remain dependent on a Windows-capable test environment.