### PR TITLE
Task/remove vc runtime distribution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,6 @@ env:
   MBEDTLS_GITHUB_TOKEN: ${{ secrets.MBEDTLS_GITHUB_TOKEN }}
   AXTLS_GITHUB_TOKEN: ${{ secrets.AXTLS_GITHUB_TOKEN }}
   SKIA_GITHUB_TOKEN: ${{ secrets.SKIA_GITHUB_TOKEN }}
-  VCRUNTIME_GITHUB_TOKEN: ${{ secrets.VCRUNTIME_GITHUB_TOKEN }}
   LIBJPEG_TURBO_GITHUB_TOKEN: ${{ secrets.LIBJPEG_TURBO_GITHUB_TOKEN }}
   SDL2_GITHUB_TOKEN: ${{ secrets.SDL2_GITHUB_TOKEN }}
 
@@ -67,8 +66,6 @@ jobs:
         LIBJPEG_TURBO_GITHUB_REPO_OVERRIDE: ${{ secrets.LIBJPEG_TURBO_GITHUB_REPO }}
         SKIA_RELEASE_TAG_OVERRIDE: ${{ secrets.SKIA_RELEASE_TAG }}
         SKIA_GITHUB_REPO_OVERRIDE: ${{ secrets.SKIA_GITHUB_REPO }}
-        VCRUNTIME_RELEASE_TAG_OVERRIDE: ${{ secrets.VCRUNTIME_RELEASE_TAG }}
-        VCRUNTIME_GITHUB_REPO_OVERRIDE: ${{ secrets.VCRUNTIME_GITHUB_REPO }}
         SDL2_RELEASE_TAG_OVERRIDE: ${{ secrets.SDL2_RELEASE_TAG }}
         SDL2_GITHUB_REPO_OVERRIDE: ${{ secrets.SDL2_GITHUB_REPO }}
       run: |
@@ -81,7 +78,6 @@ jobs:
           AXTLS_RELEASE_TAG AXTLS_GITHUB_REPO \
           LIBJPEG_TURBO_RELEASE_TAG LIBJPEG_TURBO_GITHUB_REPO \
           SKIA_RELEASE_TAG SKIA_GITHUB_REPO \
-          VCRUNTIME_RELEASE_TAG VCRUNTIME_GITHUB_REPO \
           SDL2_RELEASE_TAG SDL2_GITHUB_REPO
         do
           value_name="${name}_OVERRIDE"
@@ -119,14 +115,6 @@ jobs:
       with:
         name: prepared-native-dependencies
         path: ${{ runner.temp }}/depot-tools-native-dependencies.tar.gz
-        if-no-files-found: error
-        retention-days: 1
-
-    - name: Upload SDK native runtime
-      uses: actions/upload-artifact@v7
-      with:
-        name: sdk-native-runtime
-        path: TotalCrossVM/deps/totalcross-depot-tools/vcruntime/local/windows/x86
         if-no-files-found: error
         retention-days: 1
 
@@ -537,12 +525,6 @@ jobs:
     - name: Extract source code
       run: tar -xzf source-code.tar.gz
 
-    - name: Download SDK native runtime
-      uses: actions/download-artifact@v7
-      with:
-        name: sdk-native-runtime
-        path: TotalCrossVM/deps/totalcross-depot-tools/vcruntime/local/windows/x86
-
     - name: Setup JDK 17
       uses: actions/setup-java@v5
       with:
@@ -555,19 +537,6 @@ jobs:
         path: ~/.gradle/caches
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
         restore-keys: ${{ runner.os }}-gradle
-
-    - name: Export dependency overrides
-      env:
-        VCRUNTIME_RELEASE_TAG_OVERRIDE: ${{ secrets.VCRUNTIME_RELEASE_TAG }}
-        VCRUNTIME_GITHUB_REPO_OVERRIDE: ${{ secrets.VCRUNTIME_GITHUB_REPO }}
-      run: |
-        for name in VCRUNTIME_RELEASE_TAG VCRUNTIME_GITHUB_REPO
-        do
-          value_name="${name}_OVERRIDE"
-          if [ -n "${!value_name:-}" ]; then
-            printf '%s=%s\n' "$name" "${!value_name}" >> "$GITHUB_ENV"
-          fi
-        done
 
     - name: Build SDK
       working-directory: scripts

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -291,7 +291,6 @@ jobs:
           'win32/Hello World.exe',
           'win32/Hello World.tcz',
           'win32/tcvm.dll',
-          'win32/vcruntime140.dll',
           'android/HelloWorld.aab',
           'android/HelloWorld.apk',
           'ios/Hello World.ipa',

--- a/TotalCrossSDK/build.gradle
+++ b/TotalCrossSDK/build.gradle
@@ -33,99 +33,6 @@ configurations {
     obfuscatedArchive
 }
 
-def depotToolsFetchScript = file("${rootDir}/../TotalCrossVM/deps/fetch-depot-tools.sh")
-def depotToolsDir = file("${rootDir}/../TotalCrossVM/deps/totalcross-depot-tools")
-def depotToolsRefFile = file("${rootDir}/../TotalCrossVM/deps/totalcross-depot-tools.ref")
-def vcruntimeFetchScript = file("${depotToolsDir}/vcruntime/fetch.sh")
-def vcruntimeLocalDir = file("${depotToolsDir}/vcruntime/local/windows/x86")
-def vcruntimeDll = file("${vcruntimeLocalDir}/vcruntime140.dll")
-def vcruntimeManifest = file("${vcruntimeLocalDir}/manifest.txt")
-def vcruntimeNotice = file("${vcruntimeLocalDir}/NOTICE.txt")
-def vcruntimeInputsFingerprint = file("${vcruntimeLocalDir}/totalcross-runtime-inputs.sha256")
-def envOrNull = { name ->
-    def value = System.getenv(name)
-    value ? value : null
-}
-def addOptionalArg = { args, optionName, value ->
-    if (value) {
-        args.add(optionName)
-        args.add(value)
-    }
-}
-def optionalInput = { value ->
-    value ?: ''
-}
-def vcruntimeReleaseTag = envOrNull('VCRUNTIME_RELEASE_TAG')
-def vcruntimeGithubRepo = envOrNull('VCRUNTIME_GITHUB_REPO')
-def effectiveVcruntimeReleaseTag = vcruntimeReleaseTag ?: 'vcruntime-14'
-def effectiveVcruntimeGithubRepo = vcruntimeGithubRepo ?: 'TotalCross/totalcross-depot-tools'
-def vcruntimeInputIdentity = "${effectiveVcruntimeReleaseTag}\u0000${effectiveVcruntimeGithubRepo}\u0000"
-def vcruntimeExpectedFingerprint = java.security.MessageDigest
-    .getInstance('SHA-256')
-    .digest(vcruntimeInputIdentity.getBytes(java.nio.charset.StandardCharsets.UTF_8))
-    .encodeHex()
-    .toString()
-
-def vcruntimePayloadIssues = {
-    def issues = []
-    [vcruntimeDll, vcruntimeManifest, vcruntimeNotice].each { requiredFile ->
-        if (!requiredFile.isFile()) {
-            issues.add("missing ${requiredFile.name}")
-        } else if (requiredFile.length() == 0) {
-            issues.add("empty ${requiredFile.name}")
-        }
-    }
-
-    if (vcruntimeManifest.isFile() && vcruntimeManifest.length() > 0) {
-        def manifestLines = vcruntimeManifest.readLines('UTF-8') as Set
-        [
-            'name=vcruntime',
-            'platform=windows',
-            'arch=x86',
-            'license_notice=NOTICE.txt',
-            'dll=vcruntime140.dll'
-        ].each { expectedLine ->
-            if (!manifestLines.contains(expectedLine)) {
-                issues.add("manifest.txt lacks ${expectedLine}")
-            }
-        }
-    }
-
-    issues
-}
-
-def vcruntimeReadyIssues = {
-    def issues = vcruntimePayloadIssues()
-    if (!vcruntimeInputsFingerprint.isFile()) {
-        issues.add("missing ${vcruntimeInputsFingerprint.name}")
-    } else if (vcruntimeInputsFingerprint.getText('UTF-8').trim() != vcruntimeExpectedFingerprint) {
-        issues.add("runtime inputs do not match the requested release")
-    }
-    issues
-}
-
-def runWithVisibleOutput = { description, command ->
-    def output = providers.exec {
-        commandLine command
-        ignoreExitValue = true
-    }
-    def result = output.result.get()
-    def stdout = output.standardOutput.asText.get().trim()
-    def stderr = output.standardError.asText.get().trim()
-
-    if (stdout) {
-        logger.lifecycle(stdout)
-    }
-    if (stderr) {
-        logger.error(stderr)
-    }
-    if (result.exitValue != 0) {
-        throw new GradleException(
-            "${description} failed with exit code ${result.exitValue}; see command output above."
-        )
-    }
-}
-
 wrapper {
     gradleVersion = '9.6.1'
     distributionType = Wrapper.DistributionType.ALL
@@ -460,64 +367,11 @@ task deployTcui(type: JavaExec, dependsOn: [jar, tcuiJar]) {
     )
 }
 
-task fetchSdkNativeRuntime {
-    group = 'build setup'
-    description = 'Fetches native runtime DLLs distributed with the SDK.'
-
-    inputs.file(depotToolsFetchScript)
-    inputs.file(depotToolsRefFile).optional()
-    inputs.property('vcruntimeReleaseTag', optionalInput(vcruntimeReleaseTag))
-    inputs.property('vcruntimeGithubRepo', optionalInput(vcruntimeGithubRepo))
-    outputs.files(vcruntimeDll, vcruntimeManifest, vcruntimeNotice, vcruntimeInputsFingerprint)
-
-    doLast {
-        def reuseIssues = vcruntimeReadyIssues()
-        if (reuseIssues.isEmpty()) {
-            logger.lifecycle("Reusing prepared vcruntime windows/x86 from ${vcruntimeLocalDir}")
-            return
-        }
-
-        logger.lifecycle(
-            "Prepared vcruntime windows/x86 is unavailable or invalid (${reuseIssues.join('; ')}); fetching it."
-        )
-        runWithVisibleOutput(
-            'Fetching totalcross-depot-tools metadata',
-            ['bash', depotToolsFetchScript.absolutePath]
-        )
-
-        if (!vcruntimeFetchScript.isFile()) {
-            throw GradleException("Could not find vcruntime fetch script at ${vcruntimeFetchScript}")
-        }
-
-        def fetchArgs = [
-            'bash',
-            vcruntimeFetchScript.absolutePath,
-            '--platform', 'windows',
-            '--arch', 'x86',
-            '--github-token-env', 'VCRUNTIME_GITHUB_TOKEN'
-        ]
-        addOptionalArg(fetchArgs, '--release-tag', vcruntimeReleaseTag)
-        addOptionalArg(fetchArgs, '--github-repo', vcruntimeGithubRepo)
-        runWithVisibleOutput('Fetching vcruntime windows/x86', fetchArgs)
-
-        def fetchedPayloadIssues = vcruntimePayloadIssues()
-        if (!fetchedPayloadIssues.isEmpty()) {
-            throw new GradleException(
-                "Fetched vcruntime windows/x86 is invalid: ${fetchedPayloadIssues.join('; ')}"
-            )
-        }
-        vcruntimeInputsFingerprint.setText(vcruntimeExpectedFingerprint + System.lineSeparator(), 'UTF-8')
-    }
-}
-
-task copySdkDependencies(type: Copy, dependsOn: fetchSdkNativeRuntime) {
+task copySdkDependencies(type: Copy) {
     doFirst {
         delete destinationDir
     }
     from({ configurations.runtimeClasspath.findAll { it.name.endsWith('.jar') } })
-    from(vcruntimeLocalDir) {
-        include '*.dll'
-    }
     into 'dist/libs'
 }
 

--- a/TotalCrossSDK/src/main/java/tc/tools/deployer/Deployer4Win32.java
+++ b/TotalCrossSDK/src/main/java/tc/tools/deployer/Deployer4Win32.java
@@ -98,8 +98,6 @@ public class Deployer4Win32 {
       }
       FileUtils.copyFileToDirectory(new java.io.File(DeploySettings.folderTotalCross3DistVM + "/win32/tcvm.dll"),
           new java.io.File(targetDir));
-      FileUtils.copyFileToDirectory(new java.io.File(DeploySettings.distDir, "libs/vcruntime140.dll"),
-          new java.io.File(targetDir));
     }
     DeployLogger.normal("... Files written to folder " + targetDir);
   }

--- a/scripts/prepare-native-dependencies.sh
+++ b/scripts/prepare-native-dependencies.sh
@@ -158,16 +158,6 @@ if [ "$dry_run" -eq 0 ]; then
   record_prepared_marker skia-shared '' '' "$skia_shared_repo" "$skia_shared_release"
 fi
 
-fetch_dep vcruntime windows x86 VCRUNTIME_GITHUB_TOKEN VCRUNTIME_RELEASE_TAG VCRUNTIME_GITHUB_REPO
-if [ "$dry_run" -eq 0 ]; then
-  vcruntime_runtime_dir="$depot_dir/vcruntime/local/windows/x86"
-  printf '%s\0%s\0' \
-    "${VCRUNTIME_RELEASE_TAG:-$(read_release_pin vcruntime)}" \
-    "${VCRUNTIME_GITHUB_REPO:-TotalCross/totalcross-depot-tools}" \
-    | sha256sum \
-    | cut -d ' ' -f 1 \
-    > "$vcruntime_runtime_dir/totalcross-runtime-inputs.sha256"
-fi
 fetch_dep minizip-ng windows x64 MINIZIP_NG_GITHUB_TOKEN MINIZIP_NG_RELEASE_TAG MINIZIP_NG_GITHUB_REPO
 fetch_dep minizip-ng windows arm64 MINIZIP_NG_GITHUB_TOKEN MINIZIP_NG_RELEASE_TAG MINIZIP_NG_GITHUB_REPO
 fetch_dep minizip-ng ios-simulator arm64 MINIZIP_NG_GITHUB_TOKEN MINIZIP_NG_RELEASE_TAG MINIZIP_NG_GITHUB_REPO


### PR DESCRIPTION
### What changed
- Removes distribution of `vcruntime140.dll` from TotalCross Windows deployment and SDK packaging.
- Stops `Deployer4Win32` from copying the VC runtime DLL beside deployed applications.
- Removes the SDK Gradle tasks and depot-tools fetch logic that downloaded and staged the Microsoft runtime into `dist/libs`.

### Build and packaging
- Simplifies SDK dependency copying so only runtime JAR dependencies are staged.
- Removes VC runtime preparation from native dependency bootstrap and related CI/package workflow inputs.
- Keeps `tcvm.dll` deployment unchanged.

### Result
- TotalCross no longer bundles or manages the Visual C++ runtime as part of its own distribution.
- Windows runtime availability is delegated to the system/application installation environment instead of being copied by the SDK.