### PR TITLE
Feat/image deferred operations

### DIFF
--- a/.agent/plans/image-deferred-operations-plan.md
+++ b/.agent/plans/image-deferred-operations-plan.md
@@ -1,0 +1,262 @@
+<!--
+Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+
+SPDX-License-Identifier: LGPL-2.1-only
+-->
+
+# Define deferred Image operations
+
+This ExecPlan follows `AGENTS.md` and `.agent/PLANS.md`.
+
+## Purpose / Big Picture
+
+Extend the existing lazy-image pipeline so that common Image mutations and
+frame operations remain declarative until a pixel barrier is required. Image
+construction continues to snapshot and validate encoded sources eagerly, while
+pixel decode and deferred transformations happen only when pixels are needed.
+
+The observable result is that an Image loaded from an encoded source can be
+color-adjusted, cropped, reduced to a frame, laid out as a multi-frame strip,
+or drawn at a destination scale without allocating an eager intermediate for
+each call. Existing eager behavior remains the compatibility reference for
+already-materialized Images and for operations whose public semantics depend
+on immediate pixels.
+
+The scope has three functional families:
+
+1. Color mutations: `applyColor`, `applyColor2`, `changeColors`, `applyFade`,
+   and `setTransparentColor`.
+2. Crop and explicit frame extraction: `getClippedInstance` and
+   `getFrameInstance`, including call-time source snapshots and presentation
+   scale behavior.
+3. Frame state and layout: `setCurrentFrame`, `nextFrame`, `prevFrame`,
+   `setFrameCount`, cached variant synchronization, and `FRAME_LAYOUT`.
+
+## Progress
+
+- [ ] Define the immutable deferred operation model and scale invariants.
+- [ ] Define color mutation compatibility, including multi-frame behavior.
+- [ ] Define crop, clipping, explicit frame extraction, and snapshot rules.
+- [ ] Define frame selection, frame layout, cache synchronization, and barriers.
+- [ ] Define focused tests, SDK distribution validation, and macOS smoke gates.
+
+## Starting Architecture and Scope
+
+The existing pipeline is a linked immutable chain rooted in either an encoded
+source snapshot or a detached raster snapshot. A derived Image holds public
+metadata and a private pipeline reference. Appending an operation creates a new
+node; it never mutates an existing node or the shared source. The native drawing
+layer receives only an ordinary materialized Image, so native Graphics code
+does not need to understand pipeline nodes.
+
+Encoded source I/O is eager. Paths, streams, and caller-owned byte ranges are
+consumed or copied during construction. JavaSE retains an owned byte array;
+deployed targets retain an independently owned native encoded bag. No path,
+stream, VM-array address, or borrowed native buffer remains authoritative after
+construction. Structural validation does not decode compressed pixels.
+
+Canonical barriers resolve at content scale 1, adopt the resulting raster into
+the receiver, release cached draw textures, drop cached variants, and clear the
+pipeline. A drawing boundary may instead resolve a deferred pipeline for the
+destination `Graphics.contentScale` without adopting that variant into the
+original Image. Ordinary materialized Images are never regenerated merely
+because a destination is high density.
+
+## Deferred Node Contract
+
+Operation nodes use stable integer kinds and primitive parameters. Their
+metadata records logical dimensions, physical dimensions, frame count, full
+strip width, and the source content scale needed to preserve legacy behavior.
+Nodes are scale-neutral unless the operation explicitly carries physical
+geometry derived from the preceding raster. They must not retain mutable Image
+objects, streams, paths, global caches, or borrowed pixel buffers.
+
+Geometric nodes resolve every geometric step at the requested destination
+scale. Physical bounds use checked arithmetic and `ceil(logical * scale)`;
+public logical bounds are never reconstructed from rounded physical bounds.
+Color-only nodes preserve the scale of their input and execute in exact chain
+order. Hardware presentation fields `hwScaleW` and `hwScaleH` affect display
+metadata, not deferred raster dimensions. `alphaMask` is synchronized onto a
+resolved variant at the public Image boundary.
+
+Each pipeline leaf may retain at most two exact destination-scale variants in
+an LRU cache. A cache hit reuses the materialized variant. A miss resolves from
+the immutable source, and an eviction releases only the evicted variant's
+texture before dropping its Java reference. Failed resolutions are not cached;
+deterministic source decode failures may be cached according to the existing
+source failure contract. No source-level or global decoded-raster cache is
+introduced.
+
+## Color Mutations
+
+When `pipeline != null`, the five mutations append immutable nodes and return
+without crossing a pixel barrier. The leaf cache is invalidated so no variant
+created before the mutation can be returned afterward. The resolver invokes the
+existing eager implementation on a detached materialized copy, preserving the
+established native and JavaSE kernels, alpha behavior, and exception timing.
+
+When `pipeline == null`, each public method keeps the existing eager path and
+the existing pixel-array alias behavior. This distinction is part of the
+compatibility contract: deferral must not alter the behavior of an Image whose
+pixels are already materialized.
+
+The operation order is observable and must remain the linked-node order. Fade
+and transparency do not create a density and therefore preserve their input
+content scale. A fade node captures the current presentation frame at the time
+the call is made, so later frame changes cannot reorder or retarget an earlier
+fade. Multiple fade nodes retain their individual call-time frame semantics.
+
+For deferred multi-frame images, `applyColor`, `applyColor2`, and
+`changeColors` retain the historical reset-to-frame-zero behavior. Fade and
+transparent-color operations retain their established current-frame contract.
+The final resolved image must still expose the expected frame metadata and
+selected visible pixels, including after canonical materialization.
+
+## Crop and Explicit Frame Extraction
+
+`getClippedInstance` appends a crop node rather than drawing immediately into a
+new eager image. It validates positive dimensions and checked allocation
+bounds. If the source is materialized, it first creates an immutable raster
+snapshot containing the complete current frame state and presentation metadata.
+If the source is already deferred, the existing immutable pipeline is extended.
+
+`getFrameInstance(frame)` appends an explicit frame-selection node with the
+selected frame index and the dimensions captured at call time. Both operations
+are isolated from later changes to the source Image: source frame selection,
+frame count, pixels, color mutations, and other presentation state cannot alter
+the derived operation's snapshot.
+
+Crop coordinates and physical bounds must preserve the eager crop baseline at
+content scale 1, 1.5, 2, and other finite positive fractional scales. A
+destination-aware crop following a geometric transform uses the transformed
+physical raster; a natural-scale crop preserves the preceding source content
+scale. Legacy `alphaMask` and `hwScaleW/H` behavior is retained, using the
+legacy-compatible path whenever those fields make direct deferred cropping
+non-equivalent.
+
+The crop resolver must preserve the distinction between the physical full-strip
+width and the logical visible frame width. This is required for crops that are
+followed by frame layout or frame switching, and it prevents a fractional scale
+from changing the selected pixels through integer truncation.
+
+## Frame State and Layout
+
+For a deferred Image, `setCurrentFrame`, `nextFrame`, and `prevFrame` update
+presentation state without appending a node or changing a cache key. The
+selected frame is applied to each resolved full-strip variant immediately
+before it is used. Canonical barriers adopt the selected visible frame while
+retaining the full-strip data and metadata required by the eager model.
+
+`setFrameCount` on a deferred Image appends an immutable, scale-neutral
+`FRAME_LAYOUT` node. It preserves legacy integer truncation, `FC=n` metadata,
+logical dimensions, physical frame width, and the full-strip width. Allocation
+failures are retryable and must not poison the shared encoded source. The
+zero-width case where the requested frame count exceeds the full-strip width
+remains representable with an empty visible buffer and intact full-strip data.
+
+For `CROP -> FRAME_LAYOUT`, the layout node uses the preceding canonical raster
+physical full-strip width. At 2x, 1.5x, and exact fractional scales, frame
+selection, visible pixels, frame switching, metadata, and later canonical
+materialization must agree with the eager barrier baseline. Cached variants
+must synchronize the visible frame without copying stale frame pixels over the
+full strip.
+
+## Compatibility and Invariants
+
+The following invariants are mandatory:
+
+- Public method signatures, exceptions, Image field ordering, and native Image
+  ABI remain unchanged.
+- Materialized Images remain eager for mutations, crop, frame extraction, frame
+  state, and layout.
+- Deferred receivers use only immutable nodes and detached snapshots.
+- Source snapshots are stable against path, stream, byte-array, and source-Image
+  changes after the operation call.
+- Canonical pixel, export, and native barriers resolve exactly once to a
+  scale-one ordinary Image, subject to the existing retry/failure rules.
+- Destination-scale drawing does not materialize or mutate the original
+  deferred Image.
+- Logical dimensions remain stable while physical dimensions follow the exact
+  requested content scale with checked ceiling arithmetic.
+- Color and fade operations do not move across geometric operations.
+- Current-frame presentation state is not a pipeline operation or cache key.
+- Cached variants and their textures have bounded lifetime and no global
+  ownership.
+- Retryable allocation, resource, and resolution failures are not cached, while
+  deterministic content failures may follow the existing source failure
+  contract. Texture release and variant clearing are idempotent and never
+  release the shared encoded source.
+
+## Plan of Work
+
+### Milestone 1 — Defer color mutations
+
+Add node kinds and deferred dispatch for all five color mutations. Extract or
+reuse eager helpers so materialized behavior is unchanged. Invalidate affected
+leaf variants, preserve operation order, and cover multi-frame reset/current
+frame quirks. Add focused Java tests and the dedicated macOS smoke fixture,
+including Gradle compile, deploy, and pass/fail checks.
+
+Acceptance requires construction to remain lazy, each mutation to remain
+deferred, equivalent eager/deferred pixels to match within the established
+contract, cached variants to be invalidated, and conservative JPEG eligibility
+to remain unchanged by color nodes.
+
+### Milestone 2 — Defer crop and frame extraction
+
+Add crop and explicit frame-selection nodes. Capture source pixels and frame
+metadata at the operation boundary, preserve current-frame semantics, and
+resolve physical crop bounds for natural, HiDPI, and fractional scales. Add
+focused tests for snapshot isolation, metadata, deterministic pixels, frame
+selection, legacy presentation fields, and source changes after the call. Add
+and register the crop/frame macOS smoke.
+
+Acceptance requires lazy crop and extraction, source isolation, eager-baseline
+equivalence at tested scales, correct destination-scale behavior, and no
+regression of the materialized path.
+
+### Milestone 3 — Defer frame state and layout
+
+Add deferred presentation updates, full-strip synchronization, canonical
+selected-frame adoption, and the scale-neutral `FRAME_LAYOUT` node. Cover fade
+ordering, cached variant switching, allocation retry, zero-width compatibility,
+crop-to-layout composition, and exact fractional scale cases whose physical
+bounds require ceiling.
+
+Acceptance requires stable metadata and visible pixels before and after
+canonical barriers, correct full-strip reuse, no stale cache synchronization,
+and identical eager/deferred frame behavior within the documented tolerance.
+
+## Validation and Acceptance
+
+Use the smallest validation that proves each slice, then run the final Image
+family and distribution checks. The focused SDK selectors must cover the three
+deferred test classes plus the existing Image deferred suites. The final SDK
+validation includes the relevant `totalcross.ui.image.*Image*` tests and
+`./gradlew-agent dist -x test` from `TotalCrossSDK`.
+
+Build a fresh macOS Release `tcvm` with CMake/Ninja from the final functional
+tree. Run the color, crop/frame, frame-state, encoded-source, lazy-materialize,
+and Image ABI smokes against that exact dylib. Each smoke must emit its
+machine-readable required fields and `overallPass=true`; the ABI smoke must
+continue to prove field/bridge ordering.
+
+Run `python3 scripts/validate-copyright-headers.sh --files` for changed
+first-party files and `git diff --check`. Do not claim Android, iOS, Linux,
+Windows, packaging, or a full platform matrix without running those builds.
+Those validations are deferred when the local environment or milestone scope
+does not include them.
+
+## Risks and Open Questions
+
+Do not broaden public API, change native descriptors, teach native Graphics to
+walk pipeline nodes, add asynchronous or global caching, or reorder operations
+to improve optimization. Do not apply reduced-resolution decode to a path whose
+operation ordering changes semantics. If a platform exposes a conflict between
+legacy presentation fields and direct deferred geometry, preserve the eager
+compatibility path and record the limitation rather than changing the public
+contract.
+
+The accepted reduced-JPEG similarity rule, if exercised by the existing lazy
+pipeline, is tolerance-based rather than byte equality. Sampling policy and
+other unrelated rendering changes remain outside this feature.

--- a/.agent/reports/image-deferred-operations-report.md
+++ b/.agent/reports/image-deferred-operations-report.md
@@ -1,0 +1,133 @@
+<!--
+Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+
+SPDX-License-Identifier: LGPL-2.1-only
+-->
+
+# Deferred Image operations report
+
+## Result
+
+The deferred Image operation families are complete. Encoded sources continue
+to be captured and structurally validated eagerly, while deferred receivers
+represent color mutations, cropping, explicit frame extraction, frame state,
+and frame layout as immutable pipeline operations until a pixel barrier or
+destination draw requires materialization.
+
+The public Image API, field layout, native bridge ABI, eager behavior of
+materialized Images, and established exception and alias contracts remain
+compatible. The implementation is limited to the existing lazy-image
+pipeline and does not add a public deferred-operation API.
+
+## Delivered architecture
+
+`ImagePipeline` is an immutable linked chain rooted in an encoded or detached
+raster source. Nodes contain only operation kinds, primitive parameters, and
+metadata for logical dimensions, physical dimensions, content scale, frame
+count, and full-strip width. Derived Images share immutable source objects and
+never retain a path, stream, caller array, mutable Image, or borrowed native
+buffer.
+
+Canonical barriers resolve at scale one and adopt an ordinary materialized
+Image. Destination drawing may resolve a separate variant at the destination
+content scale without mutating the original deferred Image. Geometric nodes
+use checked ceiling arithmetic for physical bounds; color-only nodes preserve
+their input scale and exact operation order. Hardware presentation scale and
+alpha state remain presentation metadata rather than raster density.
+
+Resolved variants are bounded to two exact-scale entries per pipeline leaf,
+with LRU replacement and texture-only release on eviction. Failed resolutions
+are not cached, and the shared encoded source remains usable after cache
+eviction or retryable allocation/resource failures.
+
+## Functional behavior
+
+Deferred `applyColor`, `applyColor2`, `changeColors`, `applyFade`, and
+`setTransparentColor` append scale-neutral nodes. Resolution reuses the
+existing eager JavaSE or native kernels on detached materialized variants and
+invalidates stale cached variants. Materialized receivers still execute their
+historical eager paths.
+
+Deferred multi-frame color operations preserve the established quirks:
+`applyColor`, `applyColor2`, and `changeColors` reset to frame zero, while fade
+and transparent-color operations preserve their current-frame contract. Fade
+nodes capture call-time frame ordering, including chains with multiple fade
+operations. Color and fade nodes never move across geometric nodes.
+
+`getClippedInstance` and `getFrameInstance` append immutable crop and explicit
+frame-selection nodes. Materialized sources are detached at the operation
+boundary, and deferred sources retain the existing immutable chain. Later
+source pixel changes, frame changes, mutations, and metadata changes cannot
+alter the derived result. Crop geometry preserves eager-baseline behavior at
+natural, HiDPI, and fractional content scales, including compatibility paths
+for alpha and hardware presentation fields.
+
+Deferred `setCurrentFrame`, `nextFrame`, and `prevFrame` update presentation
+state without adding nodes or cache keys. Resolved full-strip variants update
+the visible frame at use time, and canonical barriers adopt the selected frame.
+Deferred `setFrameCount` appends a scale-neutral `FRAME_LAYOUT` node that
+preserves legacy metadata, integer truncation, logical dimensions, physical
+frame widths, full-strip data, and retryable allocation behavior. The
+zero-width frame-count case remains representable. `CROP` followed by
+`FRAME_LAYOUT` retains physical full-strip width and correct frame pixels at
+HiDPI and fractional scales.
+
+## Problems addressed
+
+- Eager mutation and crop paths allocated intermediate rasters for deferred
+  receivers; they now use immutable nodes while preserving eager behavior for
+  materialized receivers.
+- Cached full-strip variants could expose stale visible-frame pixels after a
+  frame change; presentation state is now synchronized when a variant is used.
+- Frame layout could derive physical widths from rounded values and lose
+  logical or full-strip metadata; layout retains both representations and uses
+  checked ceiling bounds.
+- Crop followed by frame layout could lose the preceding physical full-strip
+  width; the composition now carries that width through resolution.
+- Fade resolution could observe a later frame instead of the frame visible at
+  the call site; each fade node preserves call-time frame ordering.
+- Fractional destination scales exposed ceil-sensitive errors; the coverage
+  includes exact 1.1, 1.25, and 1.75 cases for frame and cropped paths.
+
+## Decisions and alternatives
+
+The design keeps source capture eager and pixel decode lazy, uses immutable
+nodes rather than mutable command objects, and keeps caches local and bounded.
+Current-frame state is presentation state rather than a pipeline node or cache
+key. Canonical barriers remain scale-one adoption points, and native rendering
+continues to receive only ordinary materialized Images.
+
+The following alternatives were rejected because they would change semantics
+or lifetime guarantees: eager drawing for every crop or mutation, mutable or
+globally shared pipeline nodes, a global decoded-raster cache, native traversal
+of Java pipeline nodes, frame state embedded in cache keys, operation
+reordering/fusion, and broad reduced-resolution decoding. Sampling-policy
+changes, regional JPEG crop decode, selective GIF decode, GPU command
+buffering, and arbitrary Graphics deferral remain separate work.
+
+## Validation
+
+The consolidated tree passed the following gates:
+
+- focused Java tests for deferred color mutation, crop, explicit frame
+  extraction, and frame state/layout;
+- final `totalcross.ui.image.*Image*` tests;
+- SDK `dist -x test` distribution build;
+- fresh macOS Release CMake/Ninja `tcvm` build;
+- encoded-source, lazy-materialization, color-mutation, crop/frame,
+  frame-state, and Image ABI macOS smokes against the exact native build;
+- copyright-header validation for changed first-party files;
+- `git diff --check`;
+- exact fractional-scale coverage for frame selection and crop-to-layout,
+  including ceil-sensitive physical bounds.
+
+All required smoke fields passed with `overallPass=true`. The functional SDK,
+tests, smoke applications, and build wiring are preserved; only the planning
+and handoff material is consolidated into the final plan and this report.
+
+## Limitations
+
+Android, iOS, Linux, Windows, packaging, and a complete platform matrix were
+not rerun as part of this local acceptance gate. The supported behavior is the
+existing JavaSE and macOS-validated lazy pipeline contract; cross-platform
+release claims require the corresponding platform builds and packaging jobs.

--- a/TotalCrossSDK/build.gradle
+++ b/TotalCrossSDK/build.gradle
@@ -1051,6 +1051,113 @@ tasks.register('runImageDeferredColorMutationSmokeMacOS', Exec) {
     }
 }
 
+def imageDeferredCropFrameSmokeClassesDir = layout.buildDirectory.dir('image-deferred-crop-frame-smoke/classes')
+
+tasks.register('compileImageDeferredCropFrameSmoke', Sync) {
+    group = 'verification'
+    description = 'Compiles and stages the deferred Image crop/frame smoke app.'
+    dependsOn sourceSets.smokeTest.classesTaskName
+
+    from(smokeTestClassesDir) {
+        include 'totalcross/ui/image/ImageDeferredCropFrameSmokeApp.class'
+    }
+    into imageDeferredCropFrameSmokeClassesDir
+}
+
+tasks.register('jarImageDeferredCropFrameSmoke', Jar) {
+    group = 'verification'
+    description = 'Packages the deferred Image crop/frame smoke app for deployment.'
+    dependsOn 'compileImageDeferredCropFrameSmoke'
+    archiveFileName = 'ImageDeferredCropFrameSmokeApp.jar'
+    destinationDirectory = imageDeferredCropFrameSmokeClassesDir
+    from(imageDeferredCropFrameSmokeClassesDir)
+}
+
+tasks.register('deployImageDeferredCropFrameSmokeMacOS', JavaExec) {
+    group = 'verification'
+    description = 'Deploys the deferred Image crop/frame smoke app for macOS.'
+    dependsOn 'copySdkDependencies', 'jarImageDeferredCropFrameSmoke'
+
+    mainClass = 'tc.Deploy'
+    classpath = files(smokeTestSdkJar) + fileTree('dist/libs') {
+        include '*.jar'
+    }
+    workingDir imageDeferredCropFrameSmokeClassesDir.get().asFile
+    args = [
+        'ImageDeferredCropFrameSmokeApp.jar',
+        '-macos'
+    ]
+}
+
+tasks.register('runImageDeferredCropFrameSmokeMacOS', Exec) {
+    group = 'verification'
+    description = 'Runs the deferred Image crop/frame smoke app with the exact macOS dylib.'
+    dependsOn 'deployImageDeferredCropFrameSmokeMacOS'
+    ignoreExitValue = true
+    def smokeOutput = new ByteArrayOutputStream()
+
+    doFirst {
+        def nativeRuntime = project.findProperty('tcvmDylib')
+        if (!nativeRuntime) {
+            throw new GradleException('runImageDeferredCropFrameSmokeMacOS requires -PtcvmDylib=<absolute path>')
+        }
+        def nativeRuntimeFile = file(nativeRuntime).absoluteFile
+        if (!nativeRuntimeFile.isFile()) {
+            throw new GradleException("Native runtime not found: ${nativeRuntimeFile}")
+        }
+        def installDir = imageDeferredCropFrameSmokeClassesDir.get().dir('install/macos').asFile
+        def deployedRuntime = new File(installDir, 'libtcvm.dylib')
+        copy {
+            from nativeRuntimeFile
+            into installDir
+            rename { 'libtcvm.dylib' }
+        }
+        def sourceHash = java.security.MessageDigest.getInstance('SHA-256')
+            .digest(nativeRuntimeFile.bytes).encodeHex().toString()
+        def deployedHash = java.security.MessageDigest.getInstance('SHA-256')
+            .digest(deployedRuntime.bytes).encodeHex().toString()
+        if (sourceHash != deployedHash) {
+            throw new GradleException("Deployed native runtime hash differs: source=${sourceHash}, deployed=${deployedHash}")
+        }
+        def executable = new File(installDir, 'ImageDeferredCropFrameSmokeApp')
+        if (!executable.isFile()) {
+            throw new GradleException("Native smoke executable not found: ${executable}")
+        }
+        commandLine executable.absolutePath
+        smokeOutput.reset()
+        standardOutput = smokeOutput
+        errorOutput = smokeOutput
+    }
+    workingDir imageDeferredCropFrameSmokeClassesDir.map { it.dir('install/macos').asFile }
+
+    doLast {
+        def output = smokeOutput.toString('UTF-8')
+        logger.lifecycle(output.trim())
+        def exitCode = executionResult.get().exitValue
+        def requiredFields = [
+            'fixture=ImageDeferredCropFrameSmokeApp',
+            'frameExtractionLazy=true',
+            'frameNormalization=true',
+            'getCopyLazy=true',
+            'cropLazy=true',
+            'cropPixels=true',
+            'cropCapturesCurrentFrame=true',
+            'cropMetadataCompatibility=true',
+            'rasterSnapshotIsolation=true',
+            'naturalScaleCrop=true',
+            'scaledCrop=true',
+            'targetedAfterSmooth=true',
+            'fallbackBeforeSmooth=true',
+            'overallPass=true'
+        ]
+        def missing = requiredFields.findAll { !output.contains(it) }
+        if (exitCode != 0 || !missing.isEmpty()) {
+            throw new GradleException('Deferred Image crop/frame native macOS smoke failed: exitCode=' + exitCode
+                + ', missing=' + missing)
+        }
+    }
+}
+
 tasks.register('deployModernJavaFeatureSmoke', JavaExec) {
     group = 'verification'
     description = 'Deploys the aggregate modern Java feature smoke app with the generated SDK.'

--- a/TotalCrossSDK/build.gradle
+++ b/TotalCrossSDK/build.gradle
@@ -435,6 +435,7 @@ def logicalUiScalingSmokeSources = fileTree('src/test/resources/logical-ui-scali
 	include '*.java'
 }
 def imageAbiSmokeClassesDir = layout.buildDirectory.dir('image-abi-smoke/classes')
+def imageDeferredFrameStateSmokeClassesDir = layout.buildDirectory.dir('image-deferred-frame-state-smoke/classes')
 
 tasks.named('processSmokeTestResources') {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
@@ -1153,6 +1154,124 @@ tasks.register('runImageDeferredCropFrameSmokeMacOS', Exec) {
         def missing = requiredFields.findAll { !output.contains(it) }
         if (exitCode != 0 || !missing.isEmpty()) {
             throw new GradleException('Deferred Image crop/frame native macOS smoke failed: exitCode=' + exitCode
+                + ', missing=' + missing)
+        }
+    }
+}
+
+tasks.register('compileImageDeferredFrameStateSmoke', Sync) {
+    group = 'verification'
+    description = 'Compiles and stages the deferred Image frame-state smoke app.'
+    dependsOn sourceSets.smokeTest.classesTaskName
+
+    from(smokeTestClassesDir) {
+        include 'totalcross/ui/image/ImageDeferredFrameStateSmokeApp.class'
+    }
+    into imageDeferredFrameStateSmokeClassesDir
+}
+
+tasks.register('jarImageDeferredFrameStateSmoke', Jar) {
+    group = 'verification'
+    description = 'Packages the deferred Image frame-state smoke app for deployment.'
+    dependsOn 'compileImageDeferredFrameStateSmoke'
+    archiveFileName = 'ImageDeferredFrameStateSmokeApp.jar'
+    destinationDirectory = imageDeferredFrameStateSmokeClassesDir
+    from(imageDeferredFrameStateSmokeClassesDir)
+}
+
+tasks.register('deployImageDeferredFrameStateSmokeMacOS', JavaExec) {
+    group = 'verification'
+    description = 'Deploys the deferred Image frame-state smoke app for macOS.'
+    dependsOn 'copySdkDependencies', 'jarImageDeferredFrameStateSmoke'
+
+    mainClass = 'tc.Deploy'
+    classpath = files(smokeTestSdkJar) + fileTree('dist/libs') {
+        include '*.jar'
+    }
+    workingDir imageDeferredFrameStateSmokeClassesDir.get().asFile
+    args = [
+        'ImageDeferredFrameStateSmokeApp.jar',
+        '-macos'
+    ]
+}
+
+tasks.register('runImageDeferredFrameStateSmokeMacOS', Exec) {
+    group = 'verification'
+    description = 'Runs the deferred Image frame-state smoke app with the exact macOS dylib.'
+    dependsOn 'deployImageDeferredFrameStateSmokeMacOS'
+    ignoreExitValue = true
+    def smokeOutput = new ByteArrayOutputStream()
+
+    doFirst {
+        def nativeRuntime = project.findProperty('tcvmDylib')
+        if (!nativeRuntime) {
+            throw new GradleException('runImageDeferredFrameStateSmokeMacOS requires -PtcvmDylib=<absolute path>')
+        }
+        def nativeRuntimeFile = file(nativeRuntime).absoluteFile
+        if (!nativeRuntimeFile.isFile()) {
+            throw new GradleException("Native runtime not found: ${nativeRuntimeFile}")
+        }
+        def installDir = imageDeferredFrameStateSmokeClassesDir.get().dir('install/macos').asFile
+        def deployedRuntime = new File(installDir, 'libtcvm.dylib')
+        copy {
+            from nativeRuntimeFile
+            into installDir
+            rename { 'libtcvm.dylib' }
+        }
+        def sourceHash = java.security.MessageDigest.getInstance('SHA-256')
+            .digest(nativeRuntimeFile.bytes).encodeHex().toString()
+        def deployedHash = java.security.MessageDigest.getInstance('SHA-256')
+            .digest(deployedRuntime.bytes).encodeHex().toString()
+        if (sourceHash != deployedHash) {
+            throw new GradleException("Deployed native runtime hash differs: source=${sourceHash}, deployed=${deployedHash}")
+        }
+        def executable = new File(installDir, 'ImageDeferredFrameStateSmokeApp')
+        if (!executable.isFile()) {
+            throw new GradleException("Native smoke executable not found: ${executable}")
+        }
+        commandLine executable.absolutePath
+        smokeOutput.reset()
+        standardOutput = smokeOutput
+        errorOutput = smokeOutput
+    }
+    workingDir imageDeferredFrameStateSmokeClassesDir.map { it.dir('install/macos').asFile }
+
+    doLast {
+        def output = smokeOutput.toString('UTF-8')
+        logger.lifecycle(output.trim())
+        def exitCode = executionResult.get().exitValue
+        def requiredFields = [
+            'fixture=ImageDeferredFrameStateSmokeApp',
+            'currentFrameDeferred=true',
+            'currentFrameWrap=true',
+            'cachedVariantReused=true',
+            'cachedVariantFrameUpdated=true',
+            'canonicalSelectedFrame=true',
+            'cropCapturesSelectedFrame=true',
+            'explicitFrameExtraction=true',
+            'colorFrameSemantics=true',
+            'fadeCallTimeFrame=true',
+            'fadeOrdering=true',
+            'fadeVisibleFrameOrdering=true',
+            'hidpiFrameLayout=true',
+            'croppedHidpiFrameLayout=true',
+            'croppedFractionalFrameLayout=true',
+            'exactFractionalScale11=true',
+            'exactFractionalScale125=true',
+            'exactFractionalScale175=true',
+            'croppedExactFractionalScale=true',
+            'frameSelectedExactFractionalScale=true',
+            'zeroWidthFrameCompatibility=true',
+            'frameLayoutDeferred=true',
+            'frameLayoutMetadata=true',
+            'frameLayoutPixels=true',
+            'frameLayoutRoundTrip=true',
+            'frameLayoutRetryable=true',
+            'overallPass=true'
+        ]
+        def missing = requiredFields.findAll { !output.contains(it) }
+        if (exitCode != 0 || !missing.isEmpty()) {
+            throw new GradleException('Deferred Image frame-state native macOS smoke failed: exitCode=' + exitCode
                 + ', missing=' + missing)
         }
     }

--- a/TotalCrossSDK/build.gradle
+++ b/TotalCrossSDK/build.gradle
@@ -941,6 +941,116 @@ tasks.register('runImageLazyMaterializationSmokeMacOS', Exec) {
     }
 }
 
+def imageDeferredColorMutationSmokeClassesDir = layout.buildDirectory.dir('image-deferred-color-mutation-smoke/classes')
+
+tasks.register('compileImageDeferredColorMutationSmoke', Sync) {
+    group = 'verification'
+    description = 'Compiles and stages the deferred Image color-mutation smoke app.'
+    dependsOn sourceSets.smokeTest.classesTaskName
+
+    from(smokeTestClassesDir) {
+        include 'totalcross/ui/image/ImageDeferredColorMutationSmokeApp.class'
+    }
+    from(smokeTestResourcesDir) {
+        include 'image-abi/**'
+    }
+    into imageDeferredColorMutationSmokeClassesDir
+}
+
+tasks.register('jarImageDeferredColorMutationSmoke', Jar) {
+    group = 'verification'
+    description = 'Packages the deferred Image color-mutation smoke app for deployment.'
+    dependsOn 'compileImageDeferredColorMutationSmoke'
+    archiveFileName = 'ImageDeferredColorMutationSmokeApp.jar'
+    destinationDirectory = imageDeferredColorMutationSmokeClassesDir
+    from(imageDeferredColorMutationSmokeClassesDir)
+}
+
+tasks.register('deployImageDeferredColorMutationSmokeMacOS', JavaExec) {
+    group = 'verification'
+    description = 'Deploys the deferred Image color-mutation smoke app for macOS.'
+    dependsOn 'copySdkDependencies', 'jarImageDeferredColorMutationSmoke'
+
+    mainClass = 'tc.Deploy'
+    classpath = files(smokeTestSdkJar) + fileTree('dist/libs') {
+        include '*.jar'
+    }
+    workingDir imageDeferredColorMutationSmokeClassesDir.get().asFile
+    args = [
+        'ImageDeferredColorMutationSmokeApp.jar',
+        '-macos'
+    ]
+}
+
+tasks.register('runImageDeferredColorMutationSmokeMacOS', Exec) {
+    group = 'verification'
+    description = 'Runs the deferred Image color-mutation smoke app with the exact macOS dylib.'
+    dependsOn 'deployImageDeferredColorMutationSmokeMacOS'
+    ignoreExitValue = true
+    def smokeOutput = new ByteArrayOutputStream()
+
+    doFirst {
+        def nativeRuntime = project.findProperty('tcvmDylib')
+        if (!nativeRuntime) {
+            throw new GradleException('runImageDeferredColorMutationSmokeMacOS requires -PtcvmDylib=<absolute path>')
+        }
+        def nativeRuntimeFile = file(nativeRuntime).absoluteFile
+        if (!nativeRuntimeFile.isFile()) {
+            throw new GradleException("Native runtime not found: ${nativeRuntimeFile}")
+        }
+        def installDir = imageDeferredColorMutationSmokeClassesDir.get().dir('install/macos').asFile
+        def deployedRuntime = new File(installDir, 'libtcvm.dylib')
+        copy {
+            from nativeRuntimeFile
+            into installDir
+            rename { 'libtcvm.dylib' }
+        }
+        def sourceHash = java.security.MessageDigest.getInstance('SHA-256')
+            .digest(nativeRuntimeFile.bytes).encodeHex().toString()
+        def deployedHash = java.security.MessageDigest.getInstance('SHA-256')
+            .digest(deployedRuntime.bytes).encodeHex().toString()
+        if (sourceHash != deployedHash) {
+            throw new GradleException("Deployed native runtime hash differs: source=${sourceHash}, deployed=${deployedHash}")
+        }
+        def executable = new File(installDir, 'ImageDeferredColorMutationSmokeApp')
+        if (!executable.isFile()) {
+            throw new GradleException("Native smoke executable not found: ${executable}")
+        }
+        commandLine executable.absolutePath
+        smokeOutput.reset()
+        standardOutput = smokeOutput
+        errorOutput = smokeOutput
+    }
+    workingDir imageDeferredColorMutationSmokeClassesDir.map { it.dir('install/macos').asFile }
+
+    doLast {
+        def output = smokeOutput.toString('UTF-8')
+        logger.lifecycle(output.trim())
+        def exitCode = executionResult.get().exitValue
+        def requiredFields = [
+            'fixture=ImageDeferredColorMutationSmokeApp',
+            'constructionLazy=true',
+            'applyColorDeferred=true',
+            'applyColor2Deferred=true',
+            'applyFadeDeferred=true',
+            'changeColorsDeferred=true',
+            'transparentColorDeferred=true',
+            'chainEquivalence=true',
+            'multiFrameCompatibility=true',
+            'cacheInvalidated=true',
+            'eagerAliasCompatibility=true',
+            'targetedAfterSmooth=true',
+            'fallbackBeforeSmooth=true',
+            'overallPass=true'
+        ]
+        def missing = requiredFields.findAll { !output.contains(it) }
+        if (exitCode != 0 || !missing.isEmpty()) {
+            throw new GradleException('Deferred Image color-mutation native macOS smoke failed: exitCode=' + exitCode
+                + ', missing=' + missing)
+        }
+    }
+}
+
 tasks.register('deployModernJavaFeatureSmoke', JavaExec) {
     group = 'verification'
     description = 'Deploys the aggregate modern Java feature smoke app with the generated SDK.'

--- a/TotalCrossSDK/src/main/java/totalcross/ui/image/EncodedImageSource.java
+++ b/TotalCrossSDK/src/main/java/totalcross/ui/image/EncodedImageSource.java
@@ -151,6 +151,11 @@ final class EncodedImageSource extends ImageSource {
     return intrinsicWidth;
   }
 
+  @Override
+  double contentScale() {
+    return 1;
+  }
+
   String getComment() {
     return comment;
   }

--- a/TotalCrossSDK/src/main/java/totalcross/ui/image/Image.java
+++ b/TotalCrossSDK/src/main/java/totalcross/ui/image/Image.java
@@ -537,12 +537,12 @@ public class Image extends GfxSurface {
     transparentColor = source.transparentColor;
     useAlpha = source.useAlpha;
     alphaMask = source.alphaMask;
-    contentScale = 1;
+    contentScale = deferred.hasGeometricNode() ? 1 : deferred.contentScale();
     hwScaleW = source.hwScaleW;
     hwScaleH = source.hwScaleH;
     textureId = -1;
     gfx = new Graphics(this);
-    gfx.setScales(1, 1);
+    gfx.setScales(contentScale, 1);
     gfx.refresh(0, 0, logicalWidth, logicalHeight, 0, 0, null);
   }
 
@@ -566,8 +566,9 @@ public class Image extends GfxSurface {
 
   private RasterImageSource snapshotRasterSource() {
     int[] allFrames = frameCount > 1 ? (int[]) pixelsOfAllFrames : null;
+    int fullWidth = frameCount > 1 ? widthOfAllFrames : width;
     return new RasterImageSource(width, height, logicalWidth, logicalHeight, contentScale, frameCount,
-        currentFrame, widthOfAllFrames, pixels == null ? null : pixels.clone(),
+        currentFrame, fullWidth, pixels == null ? null : pixels.clone(),
         allFrames == null ? null : allFrames.clone(), comment, path, surfaceType, transparentColor, useAlpha,
         alphaMask, hwScaleW, hwScaleH);
   }
@@ -647,7 +648,7 @@ public class Image extends GfxSurface {
     frameCount = 1;
     currentFrame = -1;
     path = source.path;
-    contentScale = source.contentScale;
+    contentScale = deferred.hasGeometricNode() ? 1 : deferred.contentScale();
     hwScaleW = source.hwScaleW;
     hwScaleH = source.hwScaleH;
     textureId = -1;
@@ -665,9 +666,10 @@ public class Image extends GfxSurface {
     widthOfAllFrames = width;
     frameCount = 1;
     currentFrame = -1;
+    contentScale = deferred.hasGeometricNode() ? 1 : deferred.contentScale();
     textureId = -1;
     gfx = new Graphics(this);
-    gfx.setScales(1, 1);
+    gfx.setScales(contentScale, 1);
     gfx.refresh(0, 0, logicalWidth, logicalHeight, 0, 0, null);
   }
 
@@ -769,6 +771,7 @@ public class Image extends GfxSurface {
       return;
     }
     Image resolved = resolvePipeline(deferred, 1);
+    synchronizePresentationState(resolved);
     pixels = resolved.pixels;
     pixelsOfAllFrames = resolved.pixelsOfAllFrames;
     width = resolved.width;
@@ -816,6 +819,26 @@ public class Image extends GfxSurface {
     resolved.alphaMask = alphaMask;
     resolved.hwScaleW = hwScaleW;
     resolved.hwScaleH = hwScaleH;
+    if (resolved.frameCount > 1) {
+      selectCurrentFrameEager(resolved, currentFrame);
+    }
+  }
+
+  /** Selects a frame on an already materialized variant without crossing the deferred barrier. */
+  private static void selectCurrentFrameEager(Image image, int frame) {
+    if (image.frameCount <= 1) {
+      return;
+    }
+    int normalized = frame < 0 ? image.frameCount - 1 : frame >= image.frameCount ? 0 : frame;
+    if (normalized == image.currentFrame) {
+      return;
+    }
+    image.currentFrame = normalized;
+    int[] allFrames = (int[]) image.pixelsOfAllFrames;
+    for (int y = image.height - 1; y >= 0; y--) {
+      Vm.arrayCopy(allFrames, normalized * image.width + y * image.widthOfAllFrames,
+          image.pixels, y * image.width, image.width);
+    }
   }
 
   private Image resolvePipeline(ImagePipeline deferred, double destinationScale) throws ImageException {
@@ -835,7 +858,7 @@ public class Image extends GfxSurface {
       Image decoded = new Image();
       decoded.initializeDecodeTarget(source);
       ImagePipeline firstNode = nodes.isEmpty() ? null : nodes.get(nodes.size() - 1);
-      int targetWidth = firstNode == null ? 0 : scaledDimension(firstNode.logicalWidth(), destinationScale);
+      int targetWidth = firstNode == null ? 0 : scaledDimensionAllowingZero(firstNode.logicalWidth(), destinationScale);
       int targetHeight = firstNode == null ? 0 : scaledDimension(firstNode.logicalHeight(), destinationScale);
       boolean targeted = isEligibleJpegTargetDecode(source, firstNode, targetWidth, targetHeight);
       try {
@@ -868,6 +891,9 @@ public class Image extends GfxSurface {
     }
 
     for (int i = nodes.size() - 1; i >= 0; i--) {
+      if (nodes.get(i).operationType() == ImagePipeline.APPLY_FADE && current.frameCount > 1) {
+        selectCurrentFrameEager(current, nodes.get(i).parameter2());
+      }
       current = applyEagerTransform(current, nodes.get(i), destinationScale);
     }
     return current;
@@ -889,12 +915,18 @@ public class Image extends GfxSurface {
     boolean geometric = node.operationType() == ImagePipeline.SCALE
         || node.operationType() == ImagePipeline.SMOOTH_SCALE
         || node.operationType() == ImagePipeline.ROTATE_SCALE;
-    int targetWidth = scaledDimension(node.logicalWidth(), destinationScale);
+    int targetWidth = node.operationType() == ImagePipeline.FRAME_LAYOUT && node.logicalWidth() == 0
+        ? 0 : scaledDimension(node.logicalWidth(), destinationScale);
     int targetHeight = scaledDimension(node.logicalHeight(), destinationScale);
     Image result;
     switch (node.operationType()) {
     case ImagePipeline.FRAME_SELECT:
       result = source.eagerFrameSelection(node.parameter1());
+      break;
+    case ImagePipeline.FRAME_LAYOUT:
+      int physicalFrameWidth = node.previous().hasGeometricNode()
+          ? targetWidth : node.parameter2();
+      result = source.eagerFrameLayout(node.parameter1(), node.logicalWidth(), physicalFrameWidth);
       break;
     case ImagePipeline.CROP:
       result = source.eagerCrop(node.parameter1(), node.parameter2(), node.parameter3(), node.parameter4());
@@ -948,7 +980,50 @@ public class Image extends GfxSurface {
     result.logicalWidth = node.logicalWidth();
     result.logicalHeight = node.logicalHeight();
     result.contentScale = geometric ? destinationScale : source.contentScale;
-    result.widthOfAllFrames = result.frameCount > 1 ? result.width * result.frameCount : result.width;
+    if (node.operationType() != ImagePipeline.FRAME_LAYOUT) {
+      result.widthOfAllFrames = result.frameCount > 1 ? result.width * result.frameCount : result.width;
+    }
+    return result;
+  }
+
+  private Image eagerFrameLayout(int outputFrameCount, int logicalFrameWidth, int visibleWidth) throws ImageException {
+    if (visibleWidth < 0) {
+      throw new ImageException("Image dimensions are too large.");
+    }
+    long visibleLength = (long) visibleWidth * height;
+    if (visibleLength > Integer.MAX_VALUE) {
+      throw new ImageException("Image dimensions are too large.");
+    }
+    if (consumeMaterializedFrameBufferAllocationFailureForTest()) {
+      throw new TransientImageMaterializationException("Simulated multi-frame buffer allocation failure");
+    }
+
+    Image result = new Image();
+    result.width = visibleWidth;
+    result.height = height;
+    result.logicalWidth = logicalFrameWidth;
+    result.logicalHeight = logicalHeight;
+    result.contentScale = contentScale;
+    result.frameCount = outputFrameCount;
+    result.currentFrame = -1;
+    result.widthOfAllFrames = width;
+    result.pixelsOfAllFrames = pixels;
+    try {
+      result.pixels = new int[(int) visibleLength];
+    } catch (OutOfMemoryError oome) {
+      throw new TransientImageMaterializationException(oome);
+    }
+    result.comment = "FC=" + outputFrameCount;
+    result.path = path;
+    result.surfaceType = surfaceType;
+    result.transparentColor = transparentColor;
+    result.useAlpha = useAlpha;
+    result.alphaMask = alphaMask;
+    result.hwScaleW = hwScaleW;
+    result.hwScaleH = hwScaleH;
+    result.textureId = -1;
+    selectCurrentFrameEager(result, 0);
+    result.init();
     return result;
   }
 
@@ -1005,6 +1080,10 @@ public class Image extends GfxSurface {
       throw new ImageException("Image dimensions are too large.");
     }
     return (int) physical;
+  }
+
+  private static int scaledDimensionAllowingZero(int logicalDimension, double scale) throws ImageException {
+    return logicalDimension == 0 ? 0 : scaledDimension(logicalDimension, scale);
   }
 
   private static int checkedFrameWidth(int width, int frameCount) throws ImageException {
@@ -1234,13 +1313,37 @@ public class Image extends GfxSurface {
 
   private void setFrameCount(int n, boolean materializingEncodedSource)
       throws IllegalArgumentException, IllegalStateException, ImageException {
-    materializeCanonicalChecked();
-    if (frameCount > 1 && n != frameCount) {
-      throw new IllegalStateException("The frame count can only be set once.");
-    }
     if (n < 1) {
       throw new IllegalArgumentException("Argument 'n' must have a positive value");
     }
+    if (frameCount > 1 && n != frameCount) {
+      throw new IllegalStateException("The frame count can only be set once.");
+    }
+    if (n == frameCount) {
+      return;
+    }
+
+    if (pipeline != null) {
+      int oldFullWidth = pipeline.widthOfAllFrames();
+      int physicalFrameWidth = oldFullWidth / n;
+      double canonicalScale = pipeline.hasGeometricNode() ? 1 : pipeline.contentScale();
+      int logicalFrameWidth = (int) Math.ceil(physicalFrameWidth / canonicalScale);
+      pipeline.clearCachedVariants();
+      pipeline = pipeline.append(ImagePipeline.FRAME_LAYOUT, n, physicalFrameWidth, 0, 0,
+          physicalFrameWidth, height, logicalFrameWidth, logicalHeight, n, oldFullWidth);
+      width = physicalFrameWidth;
+      widthOfAllFrames = oldFullWidth;
+      logicalWidth = logicalFrameWidth;
+      frameCount = n;
+      currentFrame = 0;
+      comment = "FC=" + n;
+      hashCode = 0;
+      pixels = null;
+      pixelsOfAllFrames = null;
+      return;
+    }
+
+    materializeCanonicalChecked();
 
     if (n != frameCount && n > 1 && frameCount <= 1) {
       try {
@@ -1276,6 +1379,16 @@ public class Image extends GfxSurface {
    * @since TotalCross 1.0
    */
   final public void setCurrentFrame(int nr) {
+    if (pipeline != null) {
+      if (frameCount <= 1) {
+        return;
+      }
+      int normalized = normalizedFrame(nr);
+      if (normalized != currentFrame) {
+        currentFrame = normalized;
+      }
+      return;
+    }
     materializeCanonicalUnchecked();
     if (!Settings.onJavaSE) {
       setCurrentFrameNative(nr);
@@ -1289,10 +1402,7 @@ public class Image extends GfxSurface {
     } else if (nr >= frameCount) {
       nr = 0;
     }
-    currentFrame = nr;
-    for (int y = height - 1; y >= 0; y--) {
-      Vm.arrayCopy(pixelsOfAllFrames, nr * width + y * widthOfAllFrames, pixels, y * width, width);
-    }
+    selectCurrentFrameEager(this, nr);
   }
 
   @ReplacedByNativeOnDeploy
@@ -3498,7 +3608,8 @@ public class Image extends GfxSurface {
   /** Applies the given fade value to r,g,b of this image while preserving the alpha value. */
   public void applyFade(int fadeValue) {
     if (pipeline != null) {
-      deferInPlaceMutation(ImagePipeline.APPLY_FADE, fadeValue, 0, 0, 0);
+      deferInPlaceMutation(ImagePipeline.APPLY_FADE, fadeValue,
+          frameCount > 1 ? normalizedFrame(currentFrame) : 0, 0, 0);
       return;
     }
     materializeCanonicalUnchecked();
@@ -3586,7 +3697,12 @@ public class Image extends GfxSurface {
           previous.width(), previous.height(), previous.logicalWidth(), previous.logicalHeight(), 1,
           previous.width());
     }
-    ImagePipeline deferred = previous.append(ImagePipeline.CROP, x, y, w, h, w, h, w, h, 1, w);
+    boolean destinationAware = previous.hasGeometricNode();
+    double canonicalScale = destinationAware ? 1 : previous.contentScale();
+    int physicalWidth = destinationAware ? w : scaledDimension(w, canonicalScale);
+    int physicalHeight = destinationAware ? h : scaledDimension(h, canonicalScale);
+    ImagePipeline deferred = previous.append(ImagePipeline.CROP, x, y, w, h, physicalWidth, physicalHeight, w, h, 1,
+        physicalWidth);
     Image result = new Image();
     result.initializeDeferredCrop(deferred);
     return result;

--- a/TotalCrossSDK/src/main/java/totalcross/ui/image/Image.java
+++ b/TotalCrossSDK/src/main/java/totalcross/ui/image/Image.java
@@ -406,17 +406,25 @@ public class Image extends GfxSurface {
    */
   @Deprecated
   public Image setTransparentColor(int color) {
+    if (pipeline != null) {
+      deferInPlaceMutation(ImagePipeline.SET_TRANSPARENT_COLOR, color, 0, 0, 0);
+      return this;
+    }
     materializeCanonicalUnchecked();
+    setTransparentColorEager(color);
+    return this;
+  }
+
+  private void setTransparentColorEager(int color) {
     if (!Settings.onJavaSE) {
       setTransparentColorNative(color);
-      return this;
+      return;
     }
     int[] pixels = (int[]) ((frameCount == 1) ? this.pixels : this.pixelsOfAllFrames); // guich@tc100b5_40
     for (int i = pixels.length; --i >= 0;) {
       int p = pixels[i] & 0xFFFFFF;
       pixels[i] = (p == color) ? color : p | 0xFF000000; // if is the transparent color, set the alpha to 0, otherwise, set to full bright
     }
-    return this;
   }
 
   @ReplacedByNativeOnDeploy
@@ -536,6 +544,24 @@ public class Image extends GfxSurface {
     gfx = new Graphics(this);
     gfx.setScales(1, 1);
     gfx.refresh(0, 0, logicalWidth, logicalHeight, 0, 0, null);
+  }
+
+  private void deferInPlaceMutation(int operationType, int parameter1, int parameter2, int parameter3,
+      int parameter4) {
+    ImagePipeline previous = pipeline;
+    if (previous == null) {
+      throw new IllegalStateException("Deferred image pipeline is missing");
+    }
+    previous.clearCachedVariants();
+    pipeline = previous.append(operationType, parameter1, parameter2, parameter3, parameter4,
+        width, height, logicalWidth, logicalHeight, frameCount, widthOfAllFrames);
+    hashCode = 0;
+    pixels = null;
+    pixelsOfAllFrames = null;
+    if (frameCount > 1 && (operationType == ImagePipeline.APPLY_COLOR
+        || operationType == ImagePipeline.APPLY_COLOR2 || operationType == ImagePipeline.CHANGE_COLORS)) {
+      currentFrame = 0;
+    }
   }
 
   private RasterImageSource snapshotRasterSource() {
@@ -832,6 +858,26 @@ public class Image extends GfxSurface {
       break;
     case ImagePipeline.ALPHA:
       result = source.eagerAlphaInstance(node.parameter1());
+      break;
+    case ImagePipeline.APPLY_COLOR:
+      source.applyColorEager(node.parameter1());
+      result = source;
+      break;
+    case ImagePipeline.APPLY_COLOR2:
+      source.applyColor2Eager(node.parameter1());
+      result = source;
+      break;
+    case ImagePipeline.APPLY_FADE:
+      source.applyFadeEager(node.parameter1());
+      result = source;
+      break;
+    case ImagePipeline.CHANGE_COLORS:
+      source.changeColorsEager(node.parameter1(), node.parameter2());
+      result = source;
+      break;
+    case ImagePipeline.SET_TRANSPARENT_COLOR:
+      source.setTransparentColorEager(node.parameter1());
+      result = source;
       break;
     default:
       throw new IllegalStateException("Unknown image pipeline operation: " + node.operationType());
@@ -1288,7 +1334,15 @@ public class Image extends GfxSurface {
    * @see #applyColor2(int)
    */
   final public void changeColors(int from, int to) {
+    if (pipeline != null) {
+      deferInPlaceMutation(ImagePipeline.CHANGE_COLORS, from, to, 0, 0);
+      return;
+    }
     materializeCanonicalUnchecked();
+    changeColorsEager(from, to);
+  }
+
+  private void changeColorsEager(int from, int to) {
     if (!Settings.onJavaSE) {
       changeColorsNative(from, to);
       return;
@@ -3097,7 +3151,16 @@ public class Image extends GfxSurface {
    */
   final public void applyColor(int color) // guich@tc112_24
   {
+    if (pipeline != null) {
+      deferInPlaceMutation(ImagePipeline.APPLY_COLOR, color, 0, 0, 0);
+      return;
+    }
     materializeCanonicalUnchecked();
+    applyColorEager(color);
+  }
+
+  private void applyColorEager(int color)
+  {
     if (!Settings.onJavaSE) {
       applyColorNative(color);
       return;
@@ -3210,7 +3273,15 @@ public class Image extends GfxSurface {
    * @since TotalCross 1.3
    */
   final public void applyColor2(int color) {
+    if (pipeline != null) {
+      deferInPlaceMutation(ImagePipeline.APPLY_COLOR2, color, 0, 0, 0);
+      return;
+    }
     materializeCanonicalUnchecked();
+    applyColor2Eager(color);
+  }
+
+  private void applyColor2Eager(int color) {
     if (!Settings.onJavaSE) {
       applyColor2Native(color);
       return;
@@ -3324,7 +3395,15 @@ public class Image extends GfxSurface {
 
   /** Applies the given fade value to r,g,b of this image while preserving the alpha value. */
   public void applyFade(int fadeValue) {
+    if (pipeline != null) {
+      deferInPlaceMutation(ImagePipeline.APPLY_FADE, fadeValue, 0, 0, 0);
+      return;
+    }
     materializeCanonicalUnchecked();
+    applyFadeEager(fadeValue);
+  }
+
+  private void applyFadeEager(int fadeValue) {
     if (!Settings.onJavaSE) {
       applyFadeNative(fadeValue);
       return;

--- a/TotalCrossSDK/src/main/java/totalcross/ui/image/Image.java
+++ b/TotalCrossSDK/src/main/java/totalcross/ui/image/Image.java
@@ -614,6 +614,63 @@ public class Image extends GfxSurface {
     return result;
   }
 
+  private int normalizedFrame(int frame) {
+    if (frameCount <= 1) {
+      return 0;
+    }
+    if (frame < 0) {
+      return frameCount - 1;
+    }
+    return frame >= frameCount ? 0 : frame;
+  }
+
+  private Image deferFrameSelection(int frame) {
+    ImagePipeline previous = pipeline;
+    if (previous == null) {
+      previous = new ImagePipeline(snapshotRasterSource());
+    }
+    ImagePipeline deferred = previous.append(ImagePipeline.FRAME_SELECT, frame, 0, 0, 0,
+        previous.width(), previous.height(), previous.logicalWidth(), previous.logicalHeight(), 1,
+        previous.width());
+    Image result = new Image();
+    result.initializeDeferredFrameSelection(deferred, this);
+    return result;
+  }
+
+  private void initializeDeferredFrameSelection(ImagePipeline deferred, Image source) {
+    pipeline = deferred;
+    width = deferred.width();
+    height = deferred.height();
+    logicalWidth = deferred.logicalWidth();
+    logicalHeight = deferred.logicalHeight();
+    widthOfAllFrames = width;
+    frameCount = 1;
+    currentFrame = -1;
+    path = source.path;
+    contentScale = source.contentScale;
+    hwScaleW = source.hwScaleW;
+    hwScaleH = source.hwScaleH;
+    textureId = -1;
+    gfx = new Graphics(this);
+    gfx.setScales(contentScale, 1);
+    gfx.refresh(0, 0, logicalWidth, logicalHeight, 0, 0, null);
+  }
+
+  private void initializeDeferredCrop(ImagePipeline deferred) {
+    pipeline = deferred;
+    width = deferred.width();
+    height = deferred.height();
+    logicalWidth = deferred.logicalWidth();
+    logicalHeight = deferred.logicalHeight();
+    widthOfAllFrames = width;
+    frameCount = 1;
+    currentFrame = -1;
+    textureId = -1;
+    gfx = new Graphics(this);
+    gfx.setScales(1, 1);
+    gfx.refresh(0, 0, logicalWidth, logicalHeight, 0, 0, null);
+  }
+
   private static int[] rotatedDimensions(int inputWidth, int inputHeight, int scale, int angle) {
     if (scale <= 0) {
       scale = 1;
@@ -836,6 +893,12 @@ public class Image extends GfxSurface {
     int targetHeight = scaledDimension(node.logicalHeight(), destinationScale);
     Image result;
     switch (node.operationType()) {
+    case ImagePipeline.FRAME_SELECT:
+      result = source.eagerFrameSelection(node.parameter1());
+      break;
+    case ImagePipeline.CROP:
+      result = source.eagerCrop(node.parameter1(), node.parameter2(), node.parameter3(), node.parameter4());
+      break;
     case ImagePipeline.SCALE:
       result = source.eagerScaledInstance(targetWidth, targetHeight);
       break;
@@ -887,6 +950,53 @@ public class Image extends GfxSurface {
     result.contentScale = geometric ? destinationScale : source.contentScale;
     result.widthOfAllFrames = result.frameCount > 1 ? result.width * result.frameCount : result.width;
     return result;
+  }
+
+  private Image eagerFrameSelection(int frame) throws ImageException {
+    materializeCanonicalChecked();
+    if (frameCount > 1) {
+      setCurrentFrame(frame);
+    }
+    Image result = new Image(logicalWidth, logicalHeight, contentScale);
+    Vm.arrayCopy(pixels, 0, result.pixels, 0, pixels.length);
+    return result;
+  }
+
+  private Image eagerCrop(int x, int y, int w, int h) throws ImageException {
+    materializeCanonicalChecked();
+    Image result = new Image(w, h, contentScale);
+    if (contentScale != 1 && x >= 0 && y >= 0 && x + w <= logicalWidth && y + h <= logicalHeight) {
+      int sourceX = scaledCropEdge(x, contentScale);
+      int sourceY = scaledCropEdge(y, contentScale);
+      int sourceRight = sourceX + result.width;
+      int sourceBottom = sourceY + result.height;
+      if (sourceRight <= width && sourceBottom <= height && canCopyCropDirect(sourceX, sourceY, sourceRight, sourceBottom)) {
+        for (int row = sourceY; row < sourceBottom; row++) {
+          Vm.arrayCopy(pixels, row * width + sourceX, result.pixels, (row - sourceY) * result.width, result.width);
+        }
+        return result;
+      }
+    }
+    result.gfx.copyImageRect(this, x, y, w, h, true);
+    return result;
+  }
+
+  private boolean canCopyCropDirect(int sourceX, int sourceY, int sourceRight, int sourceBottom) {
+    if (alphaMask != 255 || hwScaleW != 1 || hwScaleH != 1) {
+      return false;
+    }
+    for (int row = sourceY; row < sourceBottom; row++) {
+      for (int column = sourceX; column < sourceRight; column++) {
+        if ((pixels[row * width + column] >>> 24) != 255) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  private static int scaledCropEdge(int logicalEdge, double contentScale) {
+    return (int) Math.round(logicalEdge * contentScale);
   }
 
   private static int scaledDimension(int logicalDimension, double scale) throws ImageException {
@@ -3133,15 +3243,7 @@ public class Image extends GfxSurface {
    * @since TotalCross 1.12 
    */
   final public Image getFrameInstance(int frame) throws ImageException {
-    materializeCanonicalChecked();
-    Image img = getCopy(width, height);
-    int old = currentFrame;
-    setCurrentFrame(frame);
-    int[] from = (int[]) this.pixels;
-    int[] to = (int[]) img.pixels;
-    Vm.arrayCopy(from, 0, to, 0, from.length);
-    setCurrentFrame(old);
-    return img;
+    return deferFrameSelection(normalizedFrame(frame));
   }
 
   /** Applies the given color r,g,b values to all pixels of this image, 
@@ -3469,10 +3571,25 @@ public class Image extends GfxSurface {
    * an exception will be thrown
    */
   public Image getClippedInstance(int x, int y, int w, int h) throws ImageException {
-    Image img = new Image(w, h);
-    Graphics g = img.getGraphics();
-    g.copyImageRect(this, x, y, w, h, true);
-    return img;
+    if (w <= 0 || h <= 0) {
+      throw new ImageException("Image dimensions and content scale must be positive.");
+    }
+    if ((long) w * h > Integer.MAX_VALUE) {
+      throw new ImageException("Image dimensions are too large.");
+    }
+    ImagePipeline previous = pipeline;
+    if (previous == null) {
+      previous = new ImagePipeline(snapshotRasterSource());
+    }
+    if (frameCount > 1) {
+      previous = previous.append(ImagePipeline.FRAME_SELECT, normalizedFrame(currentFrame), 0, 0, 0,
+          previous.width(), previous.height(), previous.logicalWidth(), previous.logicalHeight(), 1,
+          previous.width());
+    }
+    ImagePipeline deferred = previous.append(ImagePipeline.CROP, x, y, w, h, w, h, w, h, 1, w);
+    Image result = new Image();
+    result.initializeDeferredCrop(deferred);
+    return result;
   }
 
   public static void resizeJpeg(String inputPath, String outputPath, int maxPixelSize) {

--- a/TotalCrossSDK/src/main/java/totalcross/ui/image/ImagePipeline.java
+++ b/TotalCrossSDK/src/main/java/totalcross/ui/image/ImagePipeline.java
@@ -19,6 +19,7 @@ final class ImagePipeline {
   static final int SET_TRANSPARENT_COLOR = 10;
   static final int FRAME_SELECT = 11;
   static final int CROP = 12;
+  static final int FRAME_LAYOUT = 13;
 
   private final ImageSource root;
   private final ImagePipeline previous;
@@ -33,6 +34,7 @@ final class ImagePipeline {
   private final int logicalHeight;
   private final int frameCount;
   private final int widthOfAllFrames;
+  private final double contentScale;
 
   // The cache belongs to this pipeline leaf. It is deliberately not shared by
   // roots or images so encoded sources remain authoritative after eviction.
@@ -58,6 +60,7 @@ final class ImagePipeline {
     logicalHeight = root.logicalHeight();
     frameCount = root.frameCount();
     widthOfAllFrames = root.widthOfAllFrames();
+    contentScale = root.contentScale();
   }
 
   private ImagePipeline(ImagePipeline previous, int operationType, int parameter1, int parameter2,
@@ -76,6 +79,7 @@ final class ImagePipeline {
     this.logicalHeight = logicalHeight;
     this.frameCount = frameCount;
     this.widthOfAllFrames = widthOfAllFrames;
+    this.contentScale = previous.contentScale;
   }
 
   ImageSource root() {
@@ -128,6 +132,10 @@ final class ImagePipeline {
 
   int widthOfAllFrames() {
     return widthOfAllFrames;
+  }
+
+  double contentScale() {
+    return contentScale;
   }
 
   ImagePipeline append(int operationType, int parameter1, int parameter2, int parameter3, int parameter4,

--- a/TotalCrossSDK/src/main/java/totalcross/ui/image/ImagePipeline.java
+++ b/TotalCrossSDK/src/main/java/totalcross/ui/image/ImagePipeline.java
@@ -12,6 +12,11 @@ final class ImagePipeline {
   static final int TOUCH_UP = 3;
   static final int FADE = 4;
   static final int ALPHA = 5;
+  static final int APPLY_COLOR = 6;
+  static final int APPLY_COLOR2 = 7;
+  static final int APPLY_FADE = 8;
+  static final int CHANGE_COLORS = 9;
+  static final int SET_TRANSPARENT_COLOR = 10;
 
   private final ImageSource root;
   private final ImagePipeline previous;

--- a/TotalCrossSDK/src/main/java/totalcross/ui/image/ImagePipeline.java
+++ b/TotalCrossSDK/src/main/java/totalcross/ui/image/ImagePipeline.java
@@ -17,6 +17,8 @@ final class ImagePipeline {
   static final int APPLY_FADE = 8;
   static final int CHANGE_COLORS = 9;
   static final int SET_TRANSPARENT_COLOR = 10;
+  static final int FRAME_SELECT = 11;
+  static final int CROP = 12;
 
   private final ImageSource root;
   private final ImagePipeline previous;

--- a/TotalCrossSDK/src/main/java/totalcross/ui/image/ImageSource.java
+++ b/TotalCrossSDK/src/main/java/totalcross/ui/image/ImageSource.java
@@ -20,4 +20,6 @@ abstract class ImageSource {
   abstract int frameCount();
 
   abstract int widthOfAllFrames();
+
+  abstract double contentScale();
 }

--- a/TotalCrossSDK/src/main/java/totalcross/ui/image/RasterImageSource.java
+++ b/TotalCrossSDK/src/main/java/totalcross/ui/image/RasterImageSource.java
@@ -79,6 +79,11 @@ final class RasterImageSource extends ImageSource {
     return widthOfAllFrames;
   }
 
+  @Override
+  double contentScale() {
+    return contentScale;
+  }
+
   Image materialize() throws ImageException {
     return Image.materializeRasterSource(this);
   }

--- a/TotalCrossSDK/src/smokeTest/java/totalcross/ui/image/ImageDeferredColorMutationSmokeApp.java
+++ b/TotalCrossSDK/src/smokeTest/java/totalcross/ui/image/ImageDeferredColorMutationSmokeApp.java
@@ -1,0 +1,237 @@
+// Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+package totalcross.ui.image;
+
+import totalcross.io.ByteArrayStream;
+import totalcross.sys.Vm;
+import totalcross.ui.MainWindow;
+
+/** Deployed macOS smoke for deferred in-place Image color mutations. */
+public class ImageDeferredColorMutationSmokeApp extends MainWindow {
+  private static final int COLOR = 0xFF804020;
+  private static final int COLOR2 = 0xFF4080C0;
+  private static final int FADE = 137;
+  private static final int TRANSPARENT = 0;
+  private static final int CHANGE_FROM = 0xFF000000;
+  private static final int CHANGE_TO = 0xFF20A040;
+
+  @Override
+  public void initUI() {
+    boolean constructionLazy = false;
+    boolean applyColorDeferred = false;
+    boolean applyColor2Deferred = false;
+    boolean applyFadeDeferred = false;
+    boolean changeColorsDeferred = false;
+    boolean transparentColorDeferred = false;
+    boolean chainEquivalence = false;
+    boolean multiFrameCompatibility = false;
+    boolean cacheInvalidated = false;
+    boolean eagerAliasCompatibility = false;
+    boolean targetedAfterSmooth = false;
+    boolean fallbackBeforeSmooth = false;
+    String error = "";
+
+    try {
+      byte[] png = Vm.getFile("image-abi/tiny.png");
+      require(png != null && png.length > 0, "tiny PNG resource");
+      Image constructed = new Image(png);
+      constructionLazy = constructed.pipelineForSmoke() != null && constructed.pixels == null
+          && constructed.getPixelWidth() == 36 && constructed.getPixelHeight() == 36;
+      require(constructionLazy, "deferred construction");
+
+      applyColorDeferred = matchesEager(png, 1);
+      applyColor2Deferred = matchesEager(png, 2);
+      applyFadeDeferred = matchesEager(png, 3);
+      changeColorsDeferred = matchesEager(png, 4);
+      transparentColorDeferred = matchesEager(png, 5);
+      require(applyColorDeferred && applyColor2Deferred && applyFadeDeferred && changeColorsDeferred
+          && transparentColorDeferred, "deferred mutation equivalence");
+
+      Image expectedChain = new Image(png);
+      expectedChain.getPixels();
+      expectedChain.applyFade(FADE);
+      expectedChain.applyColor(COLOR);
+      expectedChain.changeColors(CHANGE_FROM, CHANGE_TO);
+      expectedChain.setTransparentColor(TRANSPARENT);
+      expectedChain.applyColor2(COLOR2);
+      Image actualChain = new Image(png);
+      actualChain.applyFade(FADE);
+      actualChain.applyColor(COLOR);
+      actualChain.changeColors(CHANGE_FROM, CHANGE_TO);
+      actualChain.setTransparentColor(TRANSPARENT);
+      actualChain.applyColor2(COLOR2);
+      chainEquivalence = actualChain.pipelineForSmoke() != null
+          && samePixels(expectedChain, actualChain);
+      require(chainEquivalence, "mutation order");
+
+      Image cachedSource = new Image(24, 20);
+      fill(cachedSource, 0xFF204060);
+      Image cached = cachedSource.getSmoothScaledInstance(18, 18);
+      Image oldVariant = cached.resolveForDrawing(1);
+      int[] oldPixels = oldVariant.getPixels().clone();
+      cached.applyColor(0xFFFFFFFF);
+      Image newVariant = cached.resolveForDrawing(1);
+      cacheInvalidated = cached.pipelineForSmoke().cachedVariantCountForSmoke() == 1
+          && oldVariant != newVariant && sameArray(oldPixels, oldVariant.getPixels())
+          && !sameArray(oldPixels, newVariant.getPixels());
+      require(cacheInvalidated, "mutation cache invalidation");
+
+      Image eagerAlias = new Image(4, 2);
+      int[] alias = eagerAlias.getPixels();
+      eagerAlias.applyColor(COLOR);
+      eagerAliasCompatibility = eagerAlias.pipelineForSmoke() == null && alias == eagerAlias.getPixels();
+      require(eagerAliasCompatibility, "materialized alias compatibility");
+
+      multiFrameCompatibility = multiFrameMatches(1) && multiFrameMatches(2) && multiFrameMatches(3)
+          && multiFrameMatches(4) && multiFrameMatches(5);
+      require(multiFrameCompatibility, "multi-frame compatibility");
+
+      byte[] jpeg = createJpeg(1024, 768);
+      Image.resetTargetedDecodeInvocationCountForTest();
+      Image smoothThenColor = new Image(jpeg).getSmoothScaledInstance(64, 48);
+      smoothThenColor.applyColor(COLOR);
+      Image smoothResult = smoothThenColor.resolveForDrawing(1);
+      targetedAfterSmooth = Image.targetedDecodeInvocationCountForTest() == 1
+          && smoothResult.getPixelWidth() == 64 && smoothResult.getPixelHeight() == 48;
+      require(targetedAfterSmooth, "JPEG targeted decode after smooth scale");
+
+      Image.resetTargetedDecodeInvocationCountForTest();
+      Image colorThenSmooth = new Image(jpeg);
+      colorThenSmooth.applyColor(COLOR);
+      Image fallbackResult = colorThenSmooth.getSmoothScaledInstance(64, 48).resolveForDrawing(1);
+      fallbackBeforeSmooth = Image.targetedDecodeInvocationCountForTest() == 0
+          && fallbackResult.getPixelWidth() == 64 && fallbackResult.getPixelHeight() == 48;
+      require(fallbackBeforeSmooth, "JPEG full decode before smooth scale");
+    } catch (Throwable failure) {
+      error = failure.getClass().getName() + ":" + String.valueOf(failure.getMessage()).replace(' ', '_');
+    }
+
+    boolean overallPass = constructionLazy && applyColorDeferred && applyColor2Deferred && applyFadeDeferred
+        && changeColorsDeferred && transparentColorDeferred && chainEquivalence && multiFrameCompatibility
+        && cacheInvalidated && eagerAliasCompatibility && targetedAfterSmooth && fallbackBeforeSmooth;
+    System.out.println("fixture=ImageDeferredColorMutationSmokeApp,constructionLazy=" + constructionLazy
+        + ",applyColorDeferred=" + applyColorDeferred + ",applyColor2Deferred=" + applyColor2Deferred
+        + ",applyFadeDeferred=" + applyFadeDeferred + ",changeColorsDeferred=" + changeColorsDeferred
+        + ",transparentColorDeferred=" + transparentColorDeferred + ",chainEquivalence=" + chainEquivalence
+        + ",multiFrameCompatibility=" + multiFrameCompatibility + ",cacheInvalidated=" + cacheInvalidated
+        + ",eagerAliasCompatibility=" + eagerAliasCompatibility + ",targetedAfterSmooth="
+        + targetedAfterSmooth + ",fallbackBeforeSmooth=" + fallbackBeforeSmooth + ",overallPass=" + overallPass
+        + (error.length() == 0 ? "" : ",error=" + error));
+    exit(overallPass ? 0 : 1);
+  }
+
+  private static boolean matchesEager(byte[] encoded, int operation) throws Exception {
+    Image expected = new Image(encoded);
+    expected.getPixels();
+    apply(expected, operation);
+    Image actual = new Image(encoded);
+    apply(actual, operation);
+    boolean deferred = actual.pipelineForSmoke() != null && actual.pixels == null;
+    return deferred && samePixels(expected, actual);
+  }
+
+  private static boolean multiFrameMatches(int operation) throws Exception {
+    Image expected = framed().getSmoothScaledInstance(2, 1);
+    expected.getPixels();
+    apply(expected, operation);
+    Image actual = framed().getSmoothScaledInstance(2, 1);
+    apply(actual, operation);
+    return actual.pipelineForSmoke() != null && actual.getCurrentFrame() == 0
+        && sameFrames(expected, actual);
+  }
+
+  private static void apply(Image image, int operation) {
+    switch (operation) {
+    case 1:
+      image.applyColor(COLOR);
+      break;
+    case 2:
+      image.applyColor2(COLOR2);
+      break;
+    case 3:
+      image.applyFade(FADE);
+      break;
+    case 4:
+      image.changeColors(CHANGE_FROM, CHANGE_TO);
+      break;
+    case 5:
+      image.setTransparentColor(TRANSPARENT);
+      break;
+    default:
+      throw new IllegalArgumentException("operation=" + operation);
+    }
+  }
+
+  private static Image framed() throws Exception {
+    Image image = new Image(8, 2);
+    int[] first = image.getPixels();
+    for (int i = 0; i < first.length; i++) {
+      first[i] = 0xFF000000;
+    }
+    image.setFrameCount(2);
+    image.setCurrentFrame(1);
+    int[] second = image.getPixels();
+    for (int i = 0; i < second.length; i++) {
+      second[i] = 0xFF0000FF;
+    }
+    image.setCurrentFrame(0);
+    return image;
+  }
+
+  private static boolean sameFrames(Image expected, Image actual) throws Exception {
+    if (expected.getFrameCount() != actual.getFrameCount()) {
+      return false;
+    }
+    for (int frame = 0; frame < expected.getFrameCount(); frame++) {
+      expected.setCurrentFrame(frame);
+      actual.setCurrentFrame(frame);
+      if (!samePixels(expected, actual)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean samePixels(Image expected, Image actual) throws Exception {
+    return expected.getPixelWidth() == actual.getPixelWidth()
+        && expected.getPixelHeight() == actual.getPixelHeight()
+        && sameArray(expected.getPixels(), actual.getPixels());
+  }
+
+  private static boolean sameArray(int[] first, int[] second) {
+    if (first == null || second == null || first.length != second.length) {
+      return false;
+    }
+    for (int i = 0; i < first.length; i++) {
+      if (first[i] != second[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static void require(boolean condition, String message) {
+    if (!condition) {
+      throw new IllegalStateException(message);
+    }
+  }
+
+  private static void fill(Image image, int pixel) {
+    int[] pixels = image.getPixels();
+    for (int i = 0; i < pixels.length; i++) {
+      pixels[i] = pixel;
+    }
+  }
+
+  private static byte[] createJpeg(int width, int height) throws Exception {
+    Image image = new Image(width, height);
+    fill(image, 0xFF204060);
+    ByteArrayStream stream = new ByteArrayStream(width * height);
+    image.createJpg(stream, 80);
+    byte[] jpeg = new byte[stream.getPos()];
+    Vm.arrayCopy(stream.getBuffer(), 0, jpeg, 0, jpeg.length);
+    return jpeg;
+  }
+}

--- a/TotalCrossSDK/src/smokeTest/java/totalcross/ui/image/ImageDeferredCropFrameSmokeApp.java
+++ b/TotalCrossSDK/src/smokeTest/java/totalcross/ui/image/ImageDeferredCropFrameSmokeApp.java
@@ -1,0 +1,313 @@
+// Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+package totalcross.ui.image;
+
+import totalcross.io.ByteArrayStream;
+import totalcross.net.Base64;
+import totalcross.sys.Vm;
+import totalcross.ui.MainWindow;
+import totalcross.ui.gfx.Graphics;
+
+/** Deployed macOS smoke for deferred Image frame extraction and clipping. */
+public class ImageDeferredCropFrameSmokeApp extends MainWindow {
+  private static final int FRAME_A = 0xFF102030;
+  private static final int FRAME_B = 0xFF405060;
+
+  @Override
+  public void initUI() {
+    boolean frameExtractionLazy = false;
+    boolean frameNormalization = false;
+    boolean getCopyLazy = false;
+    boolean cropLazy = false;
+    boolean cropPixels = false;
+    boolean cropCapturesCurrentFrame = false;
+    boolean cropMetadataCompatibility = false;
+    boolean rasterSnapshotIsolation = false;
+    boolean naturalScaleCrop = false;
+    boolean scaledCrop = false;
+    boolean fractionalScale15 = false;
+    boolean fractionalScale25 = false;
+    boolean alphaMaskCompatibility = false;
+    boolean hwScaleCompatibility = false;
+    boolean targetedAfterSmooth = false;
+    boolean fallbackBeforeSmooth = false;
+    String error = "";
+
+    try {
+      byte[] fixture = encodedFrames();
+      Image source = new Image(fixture);
+      Image selected = source.getFrameInstance(-1);
+      frameExtractionLazy = source.pipelineForSmoke() != null && source.pixels == null
+          && selected.pipelineForSmoke() != null && selected.pixels == null;
+      require(frameExtractionLazy, "lazy frame extraction");
+      int lastPixel = selected.getPixels()[0];
+      int firstPixel = new Image(fixture).getFrameInstance(99).getPixels()[0];
+      frameNormalization = lastPixel != firstPixel;
+      require(frameNormalization, "frame normalization");
+
+      Image copy = new Image(fixture).getCopy();
+      getCopyLazy = copy.pipelineForSmoke() != null && copy.pixels == null;
+      Image expectedCopy = new Image(fixture).getFrameInstance(0);
+      getCopyLazy = getCopyLazy && copy.getPixels()[0] == expectedCopy.getPixels()[0];
+      require(getCopyLazy, "lazy getCopy");
+
+      Image actualCrop = new Image(fixture).getClippedInstance(1, 0, 2, 2);
+      cropLazy = actualCrop.pipelineForSmoke() != null && actualCrop.pixels == null;
+      require(cropLazy, "lazy crop");
+      Image expectedCrop = eagerCrop(new Image(fixture), 1, 0, 2, 2);
+      cropPixels = samePixels(expectedCrop, actualCrop);
+      require(cropPixels, "crop pixels");
+
+      Image currentFrameSource = new Image(fixture);
+      currentFrameSource.setCurrentFrame(1);
+      Image currentFrameCrop = currentFrameSource.getClippedInstance(0, 0, 2, 2);
+      currentFrameSource.setCurrentFrame(0);
+      Image expectedCurrentFrameCrop = eagerCrop(new Image(fixture).getFrameInstance(1), 0, 0, 2, 2);
+      cropCapturesCurrentFrame = samePixels(expectedCurrentFrameCrop, currentFrameCrop)
+          && currentFrameCrop.getFrameCount() == 1;
+      require(cropCapturesCurrentFrame, "crop current frame snapshot");
+
+      Image metadataSource = new Image(fixture);
+      metadataSource.hwScaleW = 0.5;
+      metadataSource.hwScaleH = 0.75;
+      metadataSource.alphaMask = 73;
+      metadataSource.transparentColor = 0x123456;
+      metadataSource.useAlpha = true;
+      Image metadataCrop = metadataSource.getClippedInstance(0, 0, 2, 1);
+      cropMetadataCompatibility = metadataCrop.getPath() == null && metadataCrop.hwScaleW == 1
+          && metadataCrop.hwScaleH == 1 && metadataCrop.alphaMask == 255
+          && metadataCrop.transparentColor == 0xFFFFFF && !metadataCrop.useAlpha;
+      require(cropMetadataCompatibility, "crop metadata defaults");
+
+      Image raster = new Image(4, 3);
+      fill(raster, 0xFF203040);
+      int callTimePixel = raster.getPixels()[0];
+      Image rasterCopy = raster.getFrameInstance(0);
+      raster.getPixels()[0] = 0xFFFFFFFF;
+      rasterSnapshotIsolation = rasterCopy.pixels == null && callTimePixel == rasterCopy.getPixels()[0];
+      require(rasterSnapshotIsolation, "raster snapshot isolation");
+
+      Image logical = Image.createLogical(3, 2, 2);
+      fillPattern(logical);
+      Image natural = logical.getClippedInstance(1, 0, 2, 1).resolveForDrawing(3);
+      naturalScaleCrop = natural.getContentScale() == 2 && natural.getPixelWidth() == 4
+          && natural.getPixelHeight() == 2
+          && sameArray(natural.getPixels(), croppedPattern(2, 0, 4));
+      require(naturalScaleCrop, "natural crop scale actual=" + values(natural.getPixels()) + " expected="
+          + values(croppedPattern(2, 0, 4)) + " dimensions=" + natural.getPixelWidth() + "x"
+          + natural.getPixelHeight() + " scale=" + natural.getContentScale());
+
+      Image scaledSource = Image.createLogical(4, 4, 2);
+      fillQuadrants(scaledSource);
+      Image scaled = scaledSource.getSmoothScaledInstance(6, 6).getClippedInstance(1, 1, 1, 1);
+      Image scaledResult = scaled.resolveForDrawing(2);
+      scaledCrop = scaledResult.getContentScale() == 2 && scaledResult.getPixelWidth() == 2
+          && scaledResult.getPixelHeight() == 2 && scaledResult.getWidth() == 1
+          && scaledResult.getHeight() == 1 && allPixelsEqual(scaledResult.getPixels(), FRAME_A);
+      require(scaledCrop, "scaled crop bounds actual=" + values(scaledResult.getPixels()) + " dimensions="
+          + scaledResult.getPixelWidth() + "x" + scaledResult.getPixelHeight() + " logical="
+          + scaledResult.getWidth() + "x" + scaledResult.getHeight() + " scale="
+          + scaledResult.getContentScale());
+
+      fractionalScale15 = fractionalScaleCrop(1.5);
+      require(fractionalScale15, "fractional scale 1.5");
+      fractionalScale25 = fractionalScaleCrop(2.5);
+      require(fractionalScale25, "fractional scale 2.5");
+
+      Image alphaSource = Image.createLogical(3, 2, 2);
+      fillPattern(alphaSource);
+      alphaSource.alphaMask = 127;
+      Image alphaActual = alphaSource.getClippedInstance(1, 0, 2, 1).resolveForDrawing(1);
+      Image alphaExpected = eagerCropWithScale(alphaSource, 1, 0, 2, 1, 2);
+      alphaMaskCompatibility = samePixels(alphaExpected, alphaActual);
+      require(alphaMaskCompatibility, "alpha mask compatibility");
+
+      Image hwSource = Image.createLogical(3, 2, 2);
+      fillPattern(hwSource);
+      hwSource.hwScaleW = 0.5;
+      hwSource.hwScaleH = 0.75;
+      Image hwActual = hwSource.getClippedInstance(1, 0, 2, 1).resolveForDrawing(1);
+      Image hwExpected = eagerCropWithScale(hwSource, 1, 0, 2, 1, 2);
+      hwScaleCompatibility = samePixels(hwExpected, hwActual);
+      require(hwScaleCompatibility, "hardware scale compatibility");
+
+      byte[] jpeg = createJpeg(1024, 768);
+      Image.resetTargetedDecodeInvocationCountForTest();
+      Image smoothThenCrop = new Image(jpeg).getSmoothScaledInstance(64, 48).getClippedInstance(0, 0, 32, 24);
+      Image smoothCropResult = smoothThenCrop.resolveForDrawing(1);
+      targetedAfterSmooth = Image.targetedDecodeInvocationCountForTest() == 1
+          && smoothCropResult.getPixelWidth() == 32 && smoothCropResult.getPixelHeight() == 24;
+      require(targetedAfterSmooth, "JPEG targeted decode after smooth scale");
+
+      Image.resetTargetedDecodeInvocationCountForTest();
+      Image cropThenSmooth = new Image(jpeg).getClippedInstance(0, 0, 128, 96).getSmoothScaledInstance(64, 48);
+      Image fallbackResult = cropThenSmooth.resolveForDrawing(1);
+      fallbackBeforeSmooth = Image.targetedDecodeInvocationCountForTest() == 0
+          && fallbackResult.getPixelWidth() == 64 && fallbackResult.getPixelHeight() == 48;
+      require(fallbackBeforeSmooth, "JPEG fallback before smooth scale");
+    } catch (Throwable failure) {
+      error = failure.getClass().getName() + ":" + String.valueOf(failure.getMessage()).replace(' ', '_');
+    }
+
+    boolean overallPass = frameExtractionLazy && frameNormalization && getCopyLazy && cropLazy && cropPixels
+        && cropCapturesCurrentFrame && cropMetadataCompatibility && rasterSnapshotIsolation && naturalScaleCrop
+        && scaledCrop && fractionalScale15 && fractionalScale25 && alphaMaskCompatibility && hwScaleCompatibility
+        && targetedAfterSmooth && fallbackBeforeSmooth;
+    System.out.println("fixture=ImageDeferredCropFrameSmokeApp,frameExtractionLazy=" + frameExtractionLazy
+        + ",frameNormalization=" + frameNormalization + ",getCopyLazy=" + getCopyLazy + ",cropLazy=" + cropLazy
+        + ",cropPixels=" + cropPixels + ",cropCapturesCurrentFrame=" + cropCapturesCurrentFrame
+        + ",cropMetadataCompatibility=" + cropMetadataCompatibility + ",rasterSnapshotIsolation="
+        + rasterSnapshotIsolation + ",naturalScaleCrop=" + naturalScaleCrop + ",scaledCrop=" + scaledCrop
+        + ",fractionalScale15=" + fractionalScale15 + ",fractionalScale25=" + fractionalScale25
+        + ",alphaMaskCompatibility=" + alphaMaskCompatibility + ",hwScaleCompatibility="
+        + hwScaleCompatibility
+        + ",targetedAfterSmooth=" + targetedAfterSmooth + ",fallbackBeforeSmooth=" + fallbackBeforeSmooth
+        + ",overallPass=" + overallPass + (error.length() == 0 ? "" : ",error=" + error));
+    exit(overallPass ? 0 : 1);
+  }
+
+  private static byte[] encodedFrames() throws Exception {
+    return Base64.decode("iVBORw0KGgoAAAANSUhEUgAAAAgAAAACCAYAAABllJ3tAAAADHRFWHRDb21tZW50AEZDPTLAxqe/AAAAFklEQVR4nGMQUDD4j4wdAhJQMAMhBQAwNxpx1IOH/QAAAABJRU5ErkJggg==");
+  }
+
+  private static boolean samePixels(Image expected, Image actual) throws Exception {
+    int[] first = expected.getPixels();
+    int[] second = actual.getPixels();
+    if (first.length != second.length) {
+      return false;
+    }
+    for (int i = 0; i < first.length; i++) {
+      if (first[i] != second[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static Image eagerCrop(Image source, int x, int y, int w, int h) throws Exception {
+    source.getPixels();
+    Image result = new Image(w, h);
+    new Graphics(result).copyImageRect(source, x, y, w, h, true);
+    return result;
+  }
+
+  private static Image eagerCropWithScale(Image source, int x, int y, int w, int h, double contentScale)
+      throws Exception {
+    source.getPixels();
+    Image result = Image.createLogical(w, h, contentScale);
+    new Graphics(result).copyImageRect(source, x, y, w, h, true);
+    return result;
+  }
+
+  private static boolean fractionalScaleCrop(double contentScale) throws Exception {
+    Image source = Image.createLogical(3, 2, contentScale);
+    fillPattern(source);
+    int sourceX = (int) Math.round(contentScale);
+    int physicalWidth = (int) Math.ceil(contentScale);
+    int physicalHeight = (int) Math.ceil(contentScale);
+    Image actual = source.getClippedInstance(1, 0, 1, 1).resolveForDrawing(1);
+    int[] expected = new int[physicalWidth * physicalHeight];
+    int[] sourcePixels = source.getPixels();
+    for (int row = 0; row < physicalHeight; row++) {
+      Vm.arrayCopy(sourcePixels, row * source.getPixelWidth() + sourceX, expected, row * physicalWidth,
+          physicalWidth);
+    }
+    return actual.getPixelWidth() == physicalWidth && actual.getPixelHeight() == physicalHeight
+        && sameArray(actual.getPixels(), expected);
+  }
+
+  private static boolean sameArray(int[] first, int[] second) {
+    if (first.length != second.length) {
+      return false;
+    }
+    for (int i = 0; i < first.length; i++) {
+      if (first[i] != second[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static String values(int[] pixels) {
+    String result = "[";
+    for (int i = 0; i < pixels.length; i++) {
+      if (i > 0) {
+        result += ",";
+      }
+      result += Integer.toHexString(pixels[i]);
+    }
+    return result + "]";
+  }
+
+  private static boolean allPixelsEqual(int[] pixels, int expected) {
+    for (int pixel : pixels) {
+      if (pixel != expected) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static void fillPattern(Image image) {
+    int width = image.getPixelWidth();
+    int height = image.getPixelHeight();
+    int[] pixels = image.getPixels();
+    for (int y = 0; y < height; y++) {
+      for (int x = 0; x < width; x++) {
+        pixels[y * width + x] = patternPixel(x, y);
+      }
+    }
+  }
+
+  private static int[] croppedPattern(int x, int y, int physicalWidth) {
+    int[] result = new int[physicalWidth * 2];
+    for (int row = 0; row < 2; row++) {
+      for (int column = 0; column < physicalWidth; column++) {
+        result[row * physicalWidth + column] = patternPixel(x + column, y + row);
+      }
+    }
+    return result;
+  }
+
+  private static int patternPixel(int x, int y) {
+    return 0xFF000000 | ((x + 1) << 16) | ((y + 1) << 8) | (x + y + 1);
+  }
+
+  private static void fillQuadrants(Image image) {
+    int[] pixels = image.getPixels();
+    int width = image.getPixelWidth();
+    int halfWidth = width / 2;
+    int halfHeight = image.getPixelHeight() / 2;
+    for (int y = 0; y < image.getPixelHeight(); y++) {
+      for (int x = 0; x < width; x++) {
+        pixels[y * width + x] = x < halfWidth && y < halfHeight ? FRAME_A
+            : x >= halfWidth && y < halfHeight ? FRAME_B : 0xFF708090;
+      }
+    }
+  }
+
+  private static void fill(Image image, int pixel) {
+    int[] pixels = image.getPixels();
+    for (int i = 0; i < pixels.length; i++) {
+      pixels[i] = pixel;
+    }
+  }
+
+  private static void require(boolean condition, String message) {
+    if (!condition) {
+      throw new IllegalStateException(message);
+    }
+  }
+
+  private static byte[] createJpeg(int width, int height) throws Exception {
+    Image image = new Image(width, height);
+    fill(image, 0xFF204060);
+    ByteArrayStream stream = new ByteArrayStream(width * height);
+    image.createJpg(stream, 80);
+    byte[] result = new byte[stream.getPos()];
+    Vm.arrayCopy(stream.getBuffer(), 0, result, 0, result.length);
+    return result;
+  }
+}

--- a/TotalCrossSDK/src/smokeTest/java/totalcross/ui/image/ImageDeferredFrameStateSmokeApp.java
+++ b/TotalCrossSDK/src/smokeTest/java/totalcross/ui/image/ImageDeferredFrameStateSmokeApp.java
@@ -1,0 +1,375 @@
+// Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+package totalcross.ui.image;
+
+import totalcross.io.ByteArrayStream;
+import totalcross.net.Base64;
+import totalcross.sys.Vm;
+import totalcross.ui.MainWindow;
+
+/** Deployed macOS smoke for deferred Image frame state and frame layout. */
+public class ImageDeferredFrameStateSmokeApp extends MainWindow {
+  private static final int FRAME_A = 0xFF102030;
+  private static final int FRAME_B = 0xFF405060;
+
+  @Override
+  public void initUI() {
+    boolean currentFrameDeferred = false;
+    boolean currentFrameWrap = false;
+    boolean cachedVariantReused = false;
+    boolean cachedVariantFrameUpdated = false;
+    boolean canonicalSelectedFrame = false;
+    boolean cropCapturesSelectedFrame = false;
+    boolean explicitFrameExtraction = false;
+    boolean colorFrameSemantics = false;
+    boolean fadeCallTimeFrame = false;
+    boolean fadeOrdering = false;
+    boolean fadeVisibleFrameOrdering = false;
+    boolean hidpiFrameLayout = false;
+    boolean croppedHidpiFrameLayout = false;
+    boolean croppedFractionalFrameLayout = false;
+    boolean exactFractionalScale11 = false;
+    boolean exactFractionalScale125 = false;
+    boolean exactFractionalScale175 = false;
+    boolean croppedExactFractionalScale = false;
+    boolean frameSelectedExactFractionalScale = false;
+    boolean zeroWidthFrameCompatibility = false;
+    boolean frameLayoutDeferred = false;
+    boolean frameLayoutMetadata = false;
+    boolean frameLayoutPixels = false;
+    boolean frameLayoutRoundTrip = false;
+    boolean frameLayoutRetryable = false;
+    String error = "";
+
+    try {
+      byte[] frames = encodedFrames();
+      Image source = new Image(frames);
+      source.setCurrentFrame(-1);
+      currentFrameDeferred = source.pipelineForSmoke() != null && source.pixels == null
+          && source.getCurrentFrame() == 1;
+      source.nextFrame();
+      source.prevFrame();
+      currentFrameWrap = source.getCurrentFrame() == 1;
+
+      Image scaled = new Image(frames).getSmoothScaledInstance(4, 2);
+      Image oneX = scaled.resolveForDrawing(1);
+      Image twoX = scaled.resolveForDrawing(2);
+      int firstFramePixel = oneX.getPixels()[0];
+      Image selectedOneX = oneX;
+      Image selectedTwoX = twoX;
+      scaled.setCurrentFrame(1);
+      cachedVariantReused = selectedOneX == scaled.resolveForDrawing(1)
+          && selectedTwoX == scaled.resolveForDrawing(2);
+      int oneFramePixel = oneX.getPixels()[0];
+      int twoFramePixel = twoX.getPixels()[0];
+      cachedVariantFrameUpdated = firstFramePixel != oneFramePixel && firstFramePixel != twoFramePixel;
+      require(cachedVariantReused && cachedVariantFrameUpdated, "cached frame synchronization");
+
+      Image canonical = new Image(frames);
+      canonical.setCurrentFrame(1);
+      Image expectedCanonical = new Image(frames).getFrameInstance(1);
+      canonicalSelectedFrame = samePixels(expectedCanonical, canonical);
+      require(canonicalSelectedFrame, "canonical selected frame");
+
+      Image cropSource = new Image(frames);
+      cropSource.setCurrentFrame(1);
+      Image crop = cropSource.getClippedInstance(0, 0, 2, 1);
+      cropSource.setCurrentFrame(0);
+      Image expectedCrop = new Image(frames).getFrameInstance(1).getClippedInstance(0, 0, 2, 1);
+      cropCapturesSelectedFrame = samePixels(expectedCrop, crop);
+      explicitFrameExtraction = samePixels(new Image(frames).getFrameInstance(0),
+          new Image(frames).getFrameInstance(0));
+      require(cropCapturesSelectedFrame && explicitFrameExtraction, "frame extraction isolation");
+
+      Image color = new Image(frames);
+      color.setCurrentFrame(1);
+      color.applyColor(0xFF804020);
+      boolean colorReset = color.getCurrentFrame() == 0 && color.pipelineForSmoke() != null;
+      Image fadeExpected = new Image(frames);
+      fadeExpected.getPixels();
+      fadeExpected.applyFade(137);
+      Image fade = new Image(frames);
+      fade.applyFade(137);
+      boolean fadeSelected = samePixels(fadeExpected, fade) && fade.getCurrentFrame() == 0;
+      Image transparent = new Image(frames);
+      transparent.setCurrentFrame(1);
+      transparent.setTransparentColor(0x102030);
+      colorFrameSemantics = colorReset && fadeSelected && transparent.getCurrentFrame() == 1;
+      require(colorFrameSemantics, "color frame semantics");
+
+      Image fadeExpectedFirst = new Image(frames);
+      fadeExpectedFirst.getPixels();
+      fadeExpectedFirst.applyFade(137);
+      fadeExpectedFirst.setCurrentFrame(1);
+      Image fadeActualFirst = new Image(frames);
+      fadeActualFirst.applyFade(137);
+      fadeActualFirst.setCurrentFrame(1);
+      fadeCallTimeFrame = samePixels(fadeExpectedFirst, fadeActualFirst) && fadeActualFirst.getCurrentFrame() == 1;
+
+      Image fadeExpectedOrdering = new Image(frames);
+      fadeExpectedOrdering.getPixels();
+      fadeExpectedOrdering.setCurrentFrame(1);
+      fadeExpectedOrdering.applyFade(137);
+      fadeExpectedOrdering.setCurrentFrame(0);
+      fadeExpectedOrdering.applyFade(137);
+      fadeExpectedOrdering.setCurrentFrame(1);
+      Image fadeActualOrdering = new Image(frames);
+      fadeActualOrdering.setCurrentFrame(1);
+      fadeActualOrdering.applyFade(137);
+      fadeActualOrdering.setCurrentFrame(0);
+      fadeActualOrdering.applyFade(137);
+      fadeActualOrdering.setCurrentFrame(1);
+      fadeOrdering = samePixels(fadeExpectedOrdering, fadeActualOrdering)
+          && fadeActualOrdering.getCurrentFrame() == 1;
+      fadeVisibleFrameOrdering = fadeCallTimeFrame && fadeOrdering;
+      require(fadeVisibleFrameOrdering, "fade call-time ordering");
+
+      Image layout = new Image(encodedStrip());
+      layout.setFrameCount(2);
+      frameLayoutDeferred = layout.pipelineForSmoke() != null && layout.pixels == null;
+      frameLayoutMetadata = layout.getFrameCount() == 2 && layout.getWidth() == 2
+          && "FC=2".equals(layout.comment);
+      Image layoutVariant = layout.resolveForDrawing(1);
+      int[] first = layoutVariant.getPixels().clone();
+      layout.setCurrentFrame(1);
+      boolean secondFrame = layout.resolveForDrawing(1) == layoutVariant
+          && layoutVariant.getPixels()[0] != first[0];
+      frameLayoutPixels = layoutVariant.getPixelWidth() == 2 && secondFrame;
+      require(frameLayoutDeferred && frameLayoutMetadata && frameLayoutPixels, "frame layout");
+
+      Image scaledLayout = new Image(encodedStrip()).getSmoothScaledInstance(3, 2);
+      scaledLayout.setFrameCount(2);
+      Image scaledLayoutVariant = scaledLayout.resolveForDrawing(2);
+      frameLayoutMetadata = frameLayoutMetadata && scaledLayout.getWidth() == 1
+          && scaledLayoutVariant.getWidth() == 1 && scaledLayoutVariant.getPixelWidth() == 2;
+
+      Image roundTripSource = new Image(encodedStrip());
+      roundTripSource.setFrameCount(2);
+      ByteArrayStream output = new ByteArrayStream(256);
+      roundTripSource.createPng(output);
+      Image roundTrip = new Image(copy(output));
+      EncodedImageSource roundTripEncoded = (EncodedImageSource) roundTrip.pipelineForSmoke().root();
+      frameLayoutRoundTrip = roundTrip.getFrameCount() == 2 && roundTripEncoded.getIntrinsicWidth() == 5
+          && "FC=2".equals(roundTripEncoded.getComment());
+      require(frameLayoutRoundTrip, "frame layout round trip");
+
+      hidpiFrameLayout = highDensityFrameLayout(2.0) && highDensityFrameLayout(1.5);
+      require(hidpiFrameLayout, "high-density frame layout");
+      croppedHidpiFrameLayout = croppedHighDensityFrameLayout(2.0);
+      croppedFractionalFrameLayout = croppedHighDensityFrameLayout(1.5);
+      require(croppedHidpiFrameLayout && croppedFractionalFrameLayout, "cropped high-density frame layout");
+      exactFractionalScale11 = exactFractionalFrameLayout(1.1, 6, false);
+      exactFractionalScale125 = exactFractionalFrameLayout(1.25, 6, false);
+      exactFractionalScale175 = exactFractionalFrameLayout(1.75, 5, false);
+      frameSelectedExactFractionalScale = exactFractionalScale11 && exactFractionalScale125
+          && exactFractionalScale175;
+      croppedExactFractionalScale = exactFractionalFrameLayout(1.1, 6, true)
+          && exactFractionalFrameLayout(1.25, 6, true) && exactFractionalFrameLayout(1.75, 5, true);
+      require(frameSelectedExactFractionalScale && croppedExactFractionalScale,
+          "exact fractional frame layout");
+
+      Image zeroExpected = new Image(1, 2);
+      fill(zeroExpected, FRAME_A);
+      zeroExpected.setFrameCount(2);
+      Image zeroActual = new Image(encodedZeroStrip());
+      zeroActual.setFrameCount(2);
+      Image zeroResolved = zeroActual.resolveForDrawing(1);
+      zeroActual.setCurrentFrame(1);
+      zeroWidthFrameCompatibility = zeroActual.getWidth() == 0 && zeroActual.getPixelWidth() == 0
+          && zeroResolved.getPixels().length == 0 && sameRows(zeroExpected, zeroActual, 1);
+      require(zeroWidthFrameCompatibility, "zero-width frame compatibility");
+
+      Image retry = new Image(encodedStrip());
+      retry.setFrameCount(2);
+      EncodedImageSource retryEncoded = (EncodedImageSource) retry.pipelineForSmoke().root();
+      Image.failNextMaterializedFrameBufferAllocationForTest();
+      try {
+        retry.resolveForDrawing(1);
+      } catch (TransientImageMaterializationException expected) {
+        // The failed visible allocation must leave the deferred source retryable.
+      }
+      frameLayoutRetryable = retry.pipelineForSmoke() != null && retryEncoded.decodeFailure() == null
+          && retry.resolveForDrawing(1) != null;
+      require(frameLayoutRetryable, "retryable frame layout allocation");
+    } catch (Throwable failure) {
+      error = failure.getClass().getName() + ":" + String.valueOf(failure.getMessage()).replace(' ', '_');
+    }
+
+    boolean overallPass = currentFrameDeferred && currentFrameWrap && cachedVariantReused
+        && cachedVariantFrameUpdated && canonicalSelectedFrame && cropCapturesSelectedFrame
+        && explicitFrameExtraction && colorFrameSemantics && fadeCallTimeFrame && fadeOrdering
+        && fadeVisibleFrameOrdering && hidpiFrameLayout && croppedHidpiFrameLayout
+        && croppedFractionalFrameLayout && exactFractionalScale11 && exactFractionalScale125
+        && exactFractionalScale175 && croppedExactFractionalScale && frameSelectedExactFractionalScale
+        && zeroWidthFrameCompatibility && frameLayoutDeferred && frameLayoutMetadata
+        && frameLayoutPixels && frameLayoutRoundTrip && frameLayoutRetryable;
+    System.out.println("fixture=ImageDeferredFrameStateSmokeApp,currentFrameDeferred=" + currentFrameDeferred
+        + ",currentFrameWrap=" + currentFrameWrap + ",cachedVariantReused=" + cachedVariantReused
+        + ",cachedVariantFrameUpdated=" + cachedVariantFrameUpdated + ",canonicalSelectedFrame="
+        + canonicalSelectedFrame + ",cropCapturesSelectedFrame=" + cropCapturesSelectedFrame
+        + ",explicitFrameExtraction=" + explicitFrameExtraction + ",colorFrameSemantics=" + colorFrameSemantics
+        + ",fadeCallTimeFrame=" + fadeCallTimeFrame + ",fadeOrdering=" + fadeOrdering
+        + ",fadeVisibleFrameOrdering=" + fadeVisibleFrameOrdering + ",hidpiFrameLayout=" + hidpiFrameLayout
+        + ",croppedHidpiFrameLayout=" + croppedHidpiFrameLayout + ",croppedFractionalFrameLayout="
+        + croppedFractionalFrameLayout + ",exactFractionalScale11=" + exactFractionalScale11
+        + ",exactFractionalScale125=" + exactFractionalScale125 + ",exactFractionalScale175="
+        + exactFractionalScale175 + ",croppedExactFractionalScale=" + croppedExactFractionalScale
+        + ",frameSelectedExactFractionalScale=" + frameSelectedExactFractionalScale
+        + ",zeroWidthFrameCompatibility=" + zeroWidthFrameCompatibility
+        + ",frameLayoutDeferred=" + frameLayoutDeferred + ",frameLayoutMetadata=" + frameLayoutMetadata
+        + ",frameLayoutPixels=" + frameLayoutPixels + ",frameLayoutRoundTrip=" + frameLayoutRoundTrip
+        + ",frameLayoutRetryable=" + frameLayoutRetryable + ",overallPass=" + overallPass
+        + (error.length() == 0 ? "" : ",error=" + error));
+    exit(overallPass ? 0 : 1);
+  }
+
+  private static byte[] encodedFrames() throws Exception {
+    return Base64.decode("iVBORw0KGgoAAAANSUhEUgAAAAgAAAACCAYAAABllJ3tAAAADHRFWHRDb21tZW50AEZDPTLAxqe/AAAAFklEQVR4nGMQUDD4j4wdAhJQMAMhBQAwNxpx1IOH/QAAAABJRU5ErkJggg==");
+  }
+
+  private static byte[] encodedStrip() throws Exception {
+    return Base64.decode("iVBORw0KGgoAAAANSUhEUgAAAAUAAAACCAYAAACQahZdAAAAIElEQVR4nGP4z8jE/J+JmeU/MwvrfxZWtv+sbOwM2AQB6OEKbzVpD/sAAAAASUVORK5CYII=");
+  }
+
+  private static byte[] encodedZeroStrip() throws Exception {
+    return Base64.decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAACCAYAAACZgbYnAAAAD0lEQVR4nGP4L6BgwAAiABAdAr80JfcXAAAAAElFTkSuQmCC");
+  }
+
+  private static byte[] copy(ByteArrayStream stream) {
+    byte[] result = new byte[stream.getPos()];
+    Vm.arrayCopy(stream.getBuffer(), 0, result, 0, result.length);
+    return result;
+  }
+
+  private static boolean samePixels(Image expected, Image actual) throws Exception {
+    int[] first = expected.getPixels();
+    int[] second = actual.getPixels();
+    if (first.length != second.length) {
+      return false;
+    }
+    for (int i = 0; i < first.length; i++) {
+      if (first[i] != second[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean sameRows(Image expected, Image actual) throws Exception {
+    return sameRows(expected, actual, expected.getPixelWidth() * expected.getFrameCount());
+  }
+
+  private static boolean sameRows(Image expected, Image actual, int fullWidth) throws Exception {
+    byte[] first = new byte[fullWidth * 4];
+    byte[] second = new byte[fullWidth * 4];
+    for (int y = 0; y < expected.getPixelHeight(); y++) {
+      expected.getPixelRow(first, y);
+      actual.getPixelRow(second, y);
+      for (int i = 0; i < first.length; i++) {
+        if (first[i] != second[i]) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  private static boolean highDensityFrameLayout(double contentScale) throws Exception {
+    Image expected = Image.createLogical(4, 2, contentScale);
+    fillStrip(expected);
+    expected.setFrameCount(2);
+    Image source = Image.createLogical(4, 2, contentScale);
+    fillStrip(source);
+    Image actual = source.getFrameInstance(0);
+    actual.setFrameCount(2);
+    boolean metadata = actual.pipelineForSmoke() != null && actual.pixels == null
+        && actual.getPixelWidth() == expected.getPixelWidth()
+        && actual.getWidth() == expected.getWidth();
+    boolean first = samePixels(expected, actual);
+    expected.setCurrentFrame(1);
+    actual.setCurrentFrame(1);
+    boolean second = samePixels(expected, actual);
+    require(metadata && first && second, "high-density frame layout");
+    return true;
+  }
+
+  private static boolean croppedHighDensityFrameLayout(double contentScale) throws Exception {
+    Image expectedSource = Image.createLogical(4, 2, contentScale);
+    fillStrip(expectedSource);
+    Image expected = expectedSource.getClippedInstance(0, 0, 4, 2);
+    expected.getPixels();
+    expected.setFrameCount(2);
+
+    Image source = Image.createLogical(4, 2, contentScale);
+    fillStrip(source);
+    Image actual = source.getClippedInstance(0, 0, 4, 2);
+    actual.setFrameCount(2);
+    ImagePipeline layout = actual.pipelineForSmoke();
+    boolean metadata = layout != null && actual.pixels == null && actual.getPixelWidth() == expected.getPixelWidth()
+        && actual.getWidth() == expected.getWidth() && actual.getContentScale() == expected.getContentScale()
+        && layout.widthOfAllFrames() == expected.getPixelWidth() * 2;
+    boolean first = samePixels(expected, actual);
+    expected.setCurrentFrame(1);
+    actual.setCurrentFrame(1);
+    boolean second = samePixels(expected, actual);
+    boolean canonical = actual.pipelineForSmoke() == null;
+    require(metadata && first && second && canonical, "cropped high-density frame layout");
+    return true;
+  }
+
+  private static boolean exactFractionalFrameLayout(double contentScale, int logicalWidth, boolean cropped)
+      throws Exception {
+    int fullPhysicalWidth = (int) Math.ceil(logicalWidth * contentScale);
+    Image expectedSource = Image.createLogical(logicalWidth, 2, contentScale);
+    fillStrip(expectedSource);
+    Image expected = cropped ? expectedSource.getClippedInstance(0, 0, logicalWidth, 2)
+        : expectedSource.getFrameInstance(0);
+    boolean roundedSource = expectedSource.getPixelWidth() == fullPhysicalWidth;
+    int fullWidth = expected.getPixelWidth();
+    expected.getPixels();
+    expected.setFrameCount(2);
+
+    Image source = Image.createLogical(logicalWidth, 2, contentScale);
+    fillStrip(source);
+    boolean actualRoundedSource = source.getPixelWidth() == fullPhysicalWidth;
+    Image actual = cropped ? source.getClippedInstance(0, 0, logicalWidth, 2) : source.getFrameInstance(0);
+    actual.setFrameCount(2);
+    ImagePipeline layout = actual.pipelineForSmoke();
+    boolean metadata = layout != null && actual.pixels == null && actual.getFrameCount() == 2
+        && actual.getContentScale() == contentScale && actual.getPixelWidth() == fullWidth / 2
+        && actual.getWidth() == (int) Math.ceil(actual.getPixelWidth() / contentScale)
+        && layout.widthOfAllFrames() == fullWidth && roundedSource && actualRoundedSource;
+    boolean first = samePixels(expected, actual);
+    expected.setCurrentFrame(1);
+    actual.setCurrentFrame(1);
+    boolean second = samePixels(expected, actual);
+    boolean stable = actual.getContentScale() == contentScale && actual.getPixelWidth() == expected.getPixelWidth()
+        && actual.getWidth() == expected.getWidth();
+    return metadata && first && second && stable && actual.pipelineForSmoke() == null;
+  }
+
+  private static void fillStrip(Image image) {
+    int width = image.getPixelWidth();
+    int[] pixels = image.getPixels();
+    for (int y = 0; y < image.getPixelHeight(); y++) {
+      for (int x = 0; x < width; x++) {
+        pixels[y * width + x] = 0xFF000000 | ((x + 1) << 16) | ((y + 2) << 8) | x + 3;
+      }
+    }
+  }
+
+  private static void fill(Image image, int pixel) {
+    int[] pixels = image.getPixels();
+    for (int i = 0; i < pixels.length; i++) {
+      pixels[i] = pixel;
+    }
+  }
+
+  private static void require(boolean condition, String message) {
+    if (!condition) {
+      throw new IllegalStateException(message);
+    }
+  }
+}

--- a/TotalCrossSDK/src/test/java/totalcross/ui/image/ImageDeferredColorMutationTest.java
+++ b/TotalCrossSDK/src/test/java/totalcross/ui/image/ImageDeferredColorMutationTest.java
@@ -1,0 +1,329 @@
+// Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+package totalcross.ui.image;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.zip.CRC32;
+
+import javax.imageio.ImageIO;
+
+import org.junit.jupiter.api.Test;
+
+class ImageDeferredColorMutationTest {
+  private static final int APPLY_COLOR = 0xFF804020;
+  private static final int APPLY_COLOR2 = 0xFF4080C0;
+  private static final int FADE = 137;
+  private static final int TRANSPARENT = 0x000000;
+  private static final int CHANGE_FROM = 0xFF000000;
+  private static final int CHANGE_TO = 0xFF20A040;
+
+  @Test
+  void everyInPlaceMutationStaysDeferredAndMatchesAnEagerEncodedBaseline() throws Exception {
+    assertDeferredAndEquivalent(Operation.APPLY_COLOR);
+    assertDeferredAndEquivalent(Operation.APPLY_COLOR2);
+    assertDeferredAndEquivalent(Operation.APPLY_FADE);
+    assertDeferredAndEquivalent(Operation.CHANGE_COLORS);
+    assertDeferredAndEquivalent(Operation.SET_TRANSPARENT_COLOR);
+  }
+
+  @Test
+  void transparentColorReturnsTheSameReceiverAndPublicSignaturesRemainStable() throws Exception {
+    Image image = new Image(png(6, 4));
+    assertSame(image, image.setTransparentColor(TRANSPARENT));
+    assertNotNullPipeline(image);
+
+    assertEquals(void.class, Image.class.getMethod("applyColor", int.class).getReturnType());
+    assertEquals(void.class, Image.class.getMethod("applyColor2", int.class).getReturnType());
+    assertEquals(void.class, Image.class.getMethod("applyFade", int.class).getReturnType());
+    assertEquals(void.class, Image.class.getMethod("changeColors", int.class, int.class).getReturnType());
+    assertEquals(Image.class, Image.class.getMethod("setTransparentColor", int.class).getReturnType());
+  }
+
+  @Test
+  void chainedMutationsPreserveCallOrderExactly() throws Exception {
+    byte[] encoded = png(7, 5);
+    Image expected = new Image(encoded);
+    expected.getPixels();
+    expected.applyFade(FADE);
+    expected.applyColor(APPLY_COLOR);
+    expected.changeColors(CHANGE_FROM, CHANGE_TO);
+    expected.setTransparentColor(TRANSPARENT);
+    expected.applyColor2(APPLY_COLOR2);
+
+    Image actual = new Image(encoded);
+    actual.applyFade(FADE);
+    actual.applyColor(APPLY_COLOR);
+    actual.changeColors(CHANGE_FROM, CHANGE_TO);
+    actual.setTransparentColor(TRANSPARENT);
+    actual.applyColor2(APPLY_COLOR2);
+
+    assertEquals(Arrays.asList(ImagePipeline.APPLY_FADE, ImagePipeline.APPLY_COLOR,
+        ImagePipeline.CHANGE_COLORS, ImagePipeline.SET_TRANSPARENT_COLOR, ImagePipeline.APPLY_COLOR2),
+        operationTypes(pipeline(actual)));
+    assertArrayEquals(expected.getPixels(), actual.getPixels());
+  }
+
+  @Test
+  void deferredMutationInvalidatesCachedVariantsWithoutMutatingTheOldVariant() throws Exception {
+    Image image = new Image(png(24, 20)).getSmoothScaledInstance(12, 10);
+    Image oldVariant = image.resolveForDrawing(1);
+    int[] oldPixels = oldVariant.getPixels().clone();
+    assertEquals(1, pipeline(image).cachedVariantCountForSmoke());
+
+    image.applyColor(0xFFFFFFFF);
+
+    assertEquals(0, pipeline(image).cachedVariantCountForSmoke());
+    assertArrayEquals(oldPixels, oldVariant.getPixels());
+    Image newVariant = image.resolveForDrawing(1);
+    assertNotSame(oldVariant, newVariant);
+    assertFalse(Arrays.equals(oldPixels, newVariant.getPixels()));
+  }
+
+  @Test
+  void materializedImagesKeepTheirPixelArrayAndEagerBehavior() throws Exception {
+    for (Operation operation : Operation.values()) {
+      Image image = raster(6, 4);
+      int[] pixels = image.getPixels();
+      apply(operation, image);
+      assertNull(pipeline(image));
+      assertSame(pixels, image.getPixels());
+    }
+  }
+
+  @Test
+  void multiFrameColorOperationsMatchHistoricalAllFrameAndVisibleFrameRules() throws Exception {
+    byte[] encoded = twoFramePng();
+
+    for (Operation operation : new Operation[] { Operation.APPLY_COLOR, Operation.APPLY_COLOR2,
+        Operation.CHANGE_COLORS }) {
+      Image expected = new Image(encoded);
+      expected.getPixels();
+      apply(operation, expected);
+
+      Image actual = new Image(encoded);
+      assertEquals(0, actual.getCurrentFrame());
+      apply(operation, actual);
+      assertEquals(0, actual.getCurrentFrame());
+      assertNotNullPipeline(actual);
+      assertFrameArraysEqual(expected, actual);
+    }
+
+    Image expectedFade = new Image(encoded);
+    expectedFade.getPixels();
+    expectedFade.applyFade(FADE);
+    int[] expectedFadeFrame0 = expectedFade.getPixels().clone();
+    expectedFade.setCurrentFrame(1);
+    int[] expectedFadeFrame1 = expectedFade.getPixels().clone();
+
+    Image actualFade = new Image(encoded);
+    actualFade.applyFade(FADE);
+    assertEquals(0, actualFade.getCurrentFrame());
+    assertNotNullPipeline(actualFade);
+    assertArrayEquals(expectedFadeFrame0, actualFade.getPixels());
+    actualFade.setCurrentFrame(1);
+    assertArrayEquals(expectedFadeFrame1, actualFade.getPixels());
+
+    Image expectedTransparent = new Image(encoded);
+    int[] originalVisible = expectedTransparent.getPixels().clone();
+    expectedTransparent.setTransparentColor(TRANSPARENT);
+    assertArrayEquals(originalVisible, expectedTransparent.getPixels());
+    expectedTransparent.setCurrentFrame(1);
+    int[] expectedTransparentFrame1 = expectedTransparent.getPixels().clone();
+
+    Image actualTransparent = new Image(encoded);
+    assertSame(actualTransparent, actualTransparent.setTransparentColor(TRANSPARENT));
+    assertEquals(0, actualTransparent.getCurrentFrame());
+    assertArrayEquals(originalVisible, actualTransparent.getPixels());
+    actualTransparent.setCurrentFrame(1);
+    assertArrayEquals(expectedTransparentFrame1, actualTransparent.getPixels());
+  }
+
+  @Test
+  void colorAfterSmoothKeepsJpegTargetedDecodeEligibleButColorBeforeSmoothDoesNot() throws Exception {
+    Image.resetTargetedDecodeInvocationCountForTest();
+    Image afterSmooth = new Image(jpeg(1024, 768)).getSmoothScaledInstance(64, 48);
+    afterSmooth.applyColor(APPLY_COLOR);
+    assertEquals(0, Image.targetedDecodeInvocationCountForTest());
+    assertEquals(64, afterSmooth.resolveForDrawing(1).getPixelWidth());
+    assertEquals(1, Image.targetedDecodeInvocationCountForTest());
+
+    Image.resetTargetedDecodeInvocationCountForTest();
+    Image beforeSmooth = new Image(jpeg(1024, 768));
+    beforeSmooth.applyColor(APPLY_COLOR);
+    Image scaledAfterColor = beforeSmooth.getSmoothScaledInstance(64, 48);
+    assertEquals(0, Image.targetedDecodeInvocationCountForTest());
+    assertEquals(64, scaledAfterColor.resolveForDrawing(1).getPixelWidth());
+    assertEquals(0, Image.targetedDecodeInvocationCountForTest());
+  }
+
+  @Test
+  void colorNodesAreScaleNeutralAndKeepResolvedContentScale() throws Exception {
+    Image image = new Image(png(24, 20)).getSmoothScaledInstance(12, 10);
+    image.applyColor(APPLY_COLOR);
+    Image resolved = image.resolveForDrawing(2);
+    assertEquals(24, resolved.getPixelWidth());
+    assertEquals(20, resolved.getPixelHeight());
+    assertEquals(2, resolved.getContentScale());
+    assertEquals(1, image.getContentScale());
+    assertNull(image.pixels);
+  }
+
+  private void assertDeferredAndEquivalent(Operation operation) throws Exception {
+    byte[] encoded = png(6, 4);
+    Image expected = new Image(encoded);
+    expected.getPixels();
+    apply(operation, expected);
+
+    Image actual = new Image(encoded);
+    assertNull(actual.pixels);
+    apply(operation, actual);
+    assertNotNullPipeline(actual);
+    assertNull(actual.pixels);
+    assertArrayEquals(expected.getPixels(), actual.getPixels());
+  }
+
+  private static void apply(Operation operation, Image image) {
+    switch (operation) {
+    case APPLY_COLOR:
+      image.applyColor(APPLY_COLOR);
+      break;
+    case APPLY_COLOR2:
+      image.applyColor2(APPLY_COLOR2);
+      break;
+    case APPLY_FADE:
+      image.applyFade(FADE);
+      break;
+    case CHANGE_COLORS:
+      image.changeColors(CHANGE_FROM, CHANGE_TO);
+      break;
+    case SET_TRANSPARENT_COLOR:
+      image.setTransparentColor(TRANSPARENT);
+      break;
+    default:
+      throw new AssertionError(operation);
+    }
+  }
+
+  private static void assertFrameArraysEqual(Image expected, Image actual) {
+    assertEquals(expected.getFrameCount(), actual.getFrameCount());
+    for (int frame = 0; frame < expected.getFrameCount(); frame++) {
+      expected.setCurrentFrame(frame);
+      actual.setCurrentFrame(frame);
+      assertArrayEquals(expected.getPixels(), actual.getPixels());
+    }
+  }
+
+  private static List<Integer> operationTypes(ImagePipeline leaf) {
+    List<Integer> result = new ArrayList<Integer>();
+    for (ImagePipeline node = leaf; node != null && node.previous() != null; node = node.previous()) {
+      result.add(0, node.operationType());
+    }
+    return result;
+  }
+
+  private static ImagePipeline pipeline(Image image) throws Exception {
+    Field field = Image.class.getDeclaredField("pipeline");
+    field.setAccessible(true);
+    return (ImagePipeline) field.get(image);
+  }
+
+  private static void assertNotNullPipeline(Image image) throws Exception {
+    assertTrue(pipeline(image) != null);
+  }
+
+  private static Image raster(int width, int height) throws Exception {
+    Image image = new Image(width, height);
+    for (int i = 0; i < image.pixels.length; i++) {
+      image.pixels[i] = 0xFF000000 | ((i * 37) & 0xFF) << 16 | ((i * 19) & 0xFF) << 8 | (i * 11) & 0xFF;
+    }
+    return image;
+  }
+
+  private static byte[] png(int width, int height) throws Exception {
+    BufferedImage source = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+    for (int y = 0; y < height; y++) {
+      for (int x = 0; x < width; x++) {
+        source.setRGB(x, y, 0xFF000000 | ((x * 29) & 0xFF) << 16 | ((y * 41) & 0xFF) << 8 | (x + y));
+      }
+    }
+    return writePng(source, null);
+  }
+
+  private static byte[] twoFramePng() throws Exception {
+    BufferedImage source = new BufferedImage(8, 3, BufferedImage.TYPE_INT_ARGB);
+    for (int y = 0; y < source.getHeight(); y++) {
+      for (int x = 0; x < source.getWidth(); x++) {
+        int color = x < 4 ? 0xFF000000 | (x * 20) << 16 | (y * 30) << 8 : 0xFF000000 | 0x00004000
+            | ((x - 4) * 25) | (y * 15);
+        source.setRGB(x, y, color);
+      }
+    }
+    return writePng(source, "FC=2");
+  }
+
+  private static byte[] writePng(BufferedImage source, String comment) throws Exception {
+    ByteArrayOutputStream encoded = new ByteArrayOutputStream();
+    assertTrue(ImageIO.write(source, "png", encoded));
+    if (comment == null) {
+      return encoded.toByteArray();
+    }
+    byte[] original = encoded.toByteArray();
+    int iend = original.length - 12;
+    ByteArrayOutputStream withComment = new ByteArrayOutputStream(original.length + comment.length() + 32);
+    withComment.write(original, 0, iend);
+    byte[] text = ("Comment\0" + comment).getBytes();
+    writeChunk(withComment, "tEXt", text);
+    withComment.write(original, iend, 12);
+    return withComment.toByteArray();
+  }
+
+  private static void writeChunk(ByteArrayOutputStream output, String type, byte[] data) {
+    writeInt(output, data.length);
+    byte[] typeBytes = type.getBytes();
+    output.write(typeBytes, 0, typeBytes.length);
+    output.write(data, 0, data.length);
+    CRC32 crc = new CRC32();
+    crc.update(typeBytes);
+    crc.update(data);
+    writeInt(output, (int) crc.getValue());
+  }
+
+  private static void writeInt(ByteArrayOutputStream output, int value) {
+    output.write(value >> 24);
+    output.write(value >> 16);
+    output.write(value >> 8);
+    output.write(value);
+  }
+
+  private static byte[] jpeg(int width, int height) throws Exception {
+    BufferedImage source = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+    for (int y = 0; y < height; y++) {
+      for (int x = 0; x < width; x++) {
+        source.setRGB(x, y, ((x * 3) & 0xFF) << 16 | ((y * 3) & 0xFF) << 8 | ((x + y) * 2) & 0xFF);
+      }
+    }
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    assertTrue(ImageIO.write(source, "jpg", output));
+    return output.toByteArray();
+  }
+
+  private enum Operation {
+    APPLY_COLOR, APPLY_COLOR2, APPLY_FADE, CHANGE_COLORS, SET_TRANSPARENT_COLOR
+  }
+}

--- a/TotalCrossSDK/src/test/java/totalcross/ui/image/ImageDeferredCropTest.java
+++ b/TotalCrossSDK/src/test/java/totalcross/ui/image/ImageDeferredCropTest.java
@@ -1,0 +1,277 @@
+// Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+package totalcross.ui.image;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+import javax.imageio.ImageIO;
+
+import org.junit.jupiter.api.Test;
+
+class ImageDeferredCropTest {
+  @Test
+  void encodedCropIsLazyAndMatchesMaterializedCopyImageRect() throws Exception {
+    byte[] encoded = png(7, 5);
+    Image expectedSource = new Image(encoded);
+    Image expected = eagerCrop(expectedSource, 1, 2, 4, 2);
+    Image actual = new Image(encoded).getClippedInstance(1, 2, 4, 2);
+
+    assertNull(actual.pixels);
+    assertEquals(Arrays.asList(ImagePipeline.CROP), operationTypes(pipeline(actual)));
+    assertEquals(1, actual.getFrameCount());
+    assertEquals(4, actual.getWidth());
+    assertEquals(2, actual.getHeight());
+    assertArrayEquals(expected.getPixels(), actual.getPixels());
+  }
+
+  @Test
+  void multiFrameCropCapturesCurrentFrameAndReturnsOneFrame() throws Exception {
+    byte[] encoded = twoFramePng();
+    Image source = new Image(encoded);
+    source.setCurrentFrame(1);
+    Image expected = eagerCrop(source, 0, 0, 3, 2);
+    Image actual = source.getClippedInstance(0, 0, 3, 2);
+
+    source.setCurrentFrame(0);
+    assertEquals(1, actual.getFrameCount());
+    assertEquals(Arrays.asList(ImagePipeline.FRAME_SELECT, ImagePipeline.CROP),
+        operationTypes(pipeline(actual)));
+    assertArrayEquals(expected.getPixels(), actual.getPixels());
+  }
+
+  @Test
+  void cropUsesNewImagePresentationDefaultsAndSnapshotsMaterializedPixels() throws Exception {
+    Image source = materialized(6, 4);
+    setField(source, "path", "source.png");
+    source.hwScaleW = 0.5;
+    source.hwScaleH = 0.75;
+    source.alphaMask = 83;
+    source.transparentColor = 0x123456;
+    source.useAlpha = true;
+
+    Image actual = source.getClippedInstance(1, 1, 3, 2);
+    int[] expected = eagerCrop(source, 1, 1, 3, 2).getPixels().clone();
+    source.getPixels()[0] = 0xFFFFFFFF;
+
+    assertArrayEquals(expected, actual.getPixels());
+    assertNull(actual.getPath());
+    assertEquals(1, actual.hwScaleW);
+    assertEquals(1, actual.hwScaleH);
+    assertEquals(255, actual.alphaMask);
+    assertEquals(0xFFFFFF, actual.transparentColor);
+    assertEquals(false, actual.useAlpha);
+    assertEquals(3, actual.getWidth());
+    assertEquals(2, actual.getHeight());
+  }
+
+  @Test
+  void invalidDimensionsFailImmediatelyAndCoordinatesKeepExistingClipping() throws Exception {
+    Image source = new Image(png(5, 4));
+    assertThrows(ImageException.class, () -> source.getClippedInstance(0, 0, 0, 2));
+    assertThrows(ImageException.class, () -> source.getClippedInstance(0, 0, 2, -1));
+
+    Image expected = eagerCrop(source, -1, 1, 4, 3);
+    Image actual = source.getClippedInstance(-1, 1, 4, 3);
+    assertArrayEquals(expected.getPixels(), actual.getPixels());
+  }
+
+  @Test
+  void cropAloneKeepsNaturalScaleWhileScaleNodesRemainDestinationAware() throws Exception {
+    Image logical = Image.createLogical(3, 2, 2);
+    fillLogicalPixels(logical);
+
+    Image naturalCrop = logical.getClippedInstance(1, 0, 2, 1);
+    Image naturalResolved = naturalCrop.resolveForDrawing(3);
+    assertEquals(2, naturalResolved.getContentScale());
+    assertEquals(4, naturalResolved.getPixelWidth());
+    assertEquals(2, naturalResolved.getPixelHeight());
+
+    Image scaledCrop = new Image(png(8, 6)).getSmoothScaledInstance(4, 3).getClippedInstance(1, 1, 2, 1);
+    Image scaledResolved = scaledCrop.resolveForDrawing(2);
+    assertEquals(2, scaledResolved.getContentScale());
+    assertEquals(4, scaledResolved.getPixelWidth());
+    assertEquals(2, scaledResolved.getPixelHeight());
+    assertEquals(2, scaledResolved.getWidth());
+    assertEquals(1, scaledResolved.getHeight());
+    assertTrue(scaledResolved.getPixels().length > 0);
+  }
+
+  @Test
+  void fractionalContentScaleCropCopiesTheCompletePhysicalRectangle() throws Exception {
+    assertFractionalCrop(1.5);
+    assertFractionalCrop(2.5);
+  }
+
+  @Test
+  void highDensityCropKeepsLegacyPresentationBehavior() throws Exception {
+    Image source = Image.createLogical(3, 2, 2);
+    fillLogicalPixels(source);
+    source.alphaMask = 127;
+    source.hwScaleW = 0.5;
+    source.hwScaleH = 0.75;
+
+    Image expected = eagerCrop(source, 1, 0, 2, 1, 2);
+    Image actual = source.getClippedInstance(1, 0, 2, 1).resolveForDrawing(1);
+
+    assertArrayEquals(expected.getPixels(), actual.getPixels());
+  }
+
+  private static void assertFractionalCrop(double contentScale) throws Exception {
+    Image source = Image.createLogical(3, 2, contentScale);
+    fillPhysicalPattern(source);
+    int sourceX = (int) Math.round(contentScale);
+    int expectedWidth = (int) Math.ceil(contentScale);
+    int expectedHeight = (int) Math.ceil(contentScale);
+    int[] expected = new int[expectedWidth * expectedHeight];
+    for (int row = 0; row < expectedHeight; row++) {
+      System.arraycopy(source.getPixels(), row * source.getPixelWidth() + sourceX, expected,
+          row * expectedWidth, expectedWidth);
+    }
+
+    Image actual = source.getClippedInstance(1, 0, 1, 1).resolveForDrawing(1);
+    assertEquals(expectedWidth, actual.getPixelWidth());
+    assertEquals(expectedHeight, actual.getPixelHeight());
+    assertArrayEquals(expected, actual.getPixels());
+  }
+
+  private static void fillPhysicalPattern(Image image) {
+    int[] pixels = image.getPixels();
+    int width = image.getPixelWidth();
+    for (int y = 0; y < image.getPixelHeight(); y++) {
+      for (int x = 0; x < width; x++) {
+        pixels[y * width + x] = 0xFF000000 | ((x + 1) << 16) | ((y + 1) << 8) | (x + y + 1);
+      }
+    }
+  }
+
+  @Test
+  void jpegEligibilityFollowsTheFirstRootOperation() throws Exception {
+    byte[] encoded = jpeg(1024, 768);
+
+    Image.resetTargetedDecodeInvocationCountForTest();
+    Image smoothThenCrop = new Image(encoded).getSmoothScaledInstance(64, 48).getClippedInstance(0, 0, 32, 24);
+    assertEquals(0, Image.targetedDecodeInvocationCountForTest());
+    smoothThenCrop.resolveForDrawing(1);
+    assertEquals(1, Image.targetedDecodeInvocationCountForTest());
+
+    Image.resetTargetedDecodeInvocationCountForTest();
+    Image cropThenSmooth = new Image(encoded).getClippedInstance(0, 0, 128, 96).getSmoothScaledInstance(64, 48);
+    cropThenSmooth.resolveForDrawing(1);
+    assertEquals(0, Image.targetedDecodeInvocationCountForTest());
+  }
+
+  private static Image eagerCrop(Image source, int x, int y, int w, int h) throws Exception {
+    return eagerCrop(source, x, y, w, h, 1);
+  }
+
+  private static Image eagerCrop(Image source, int x, int y, int w, int h, double contentScale) throws Exception {
+    source.getPixels();
+    Image result = Image.createLogical(w, h, contentScale);
+    result.getGraphics().copyImageRect(source, x, y, w, h, true);
+    return result;
+  }
+
+  private static Image materialized(int width, int height) throws Exception {
+    Image image = new Image(width, height);
+    for (int y = 0; y < height; y++) {
+      for (int x = 0; x < width; x++) {
+        image.pixels[y * width + x] = 0xFF000000 | (x * 30) << 16 | (y * 40) << 8 | x + y;
+      }
+    }
+    return image;
+  }
+
+  private static void fillLogicalPixels(Image image) {
+    for (int i = 0; i < image.pixels.length; i++) {
+      image.pixels[i] = 0xFF000000 | (i * 13) << 8 | i;
+    }
+  }
+
+  private static ImagePipeline pipeline(Image image) throws Exception {
+    Field field = Image.class.getDeclaredField("pipeline");
+    field.setAccessible(true);
+    return (ImagePipeline) field.get(image);
+  }
+
+  private static java.util.List<Integer> operationTypes(ImagePipeline leaf) {
+    java.util.List<Integer> result = new java.util.ArrayList<Integer>();
+    for (ImagePipeline node = leaf; node != null && node.previous() != null; node = node.previous()) {
+      result.add(0, node.operationType());
+    }
+    return result;
+  }
+
+  private static void setField(Object object, String name, Object value) throws Exception {
+    Field field = object.getClass().getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(object, value);
+  }
+
+  private static byte[] png(int width, int height) throws Exception {
+    BufferedImage source = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+    for (int y = 0; y < height; y++) {
+      for (int x = 0; x < width; x++) {
+        source.setRGB(x, y, 0xFF000000 | ((x * 29) & 0xFF) << 16 | ((y * 41) & 0xFF) << 8 | x + y);
+      }
+    }
+    return write(source, "png");
+  }
+
+  private static byte[] twoFramePng() throws Exception {
+    BufferedImage source = new BufferedImage(8, 3, BufferedImage.TYPE_INT_ARGB);
+    for (int y = 0; y < source.getHeight(); y++) {
+      for (int x = 0; x < source.getWidth(); x++) {
+        source.setRGB(x, y, x < 4 ? 0xFF102030 : 0xFF406070);
+      }
+    }
+    byte[] bytes = write(source, "png");
+    int iend = bytes.length - 12;
+    ByteArrayOutputStream output = new ByteArrayOutputStream(bytes.length + 32);
+    output.write(bytes, 0, iend);
+    byte[] text = "Comment\0FC=2".getBytes("ISO-8859-1");
+    byte[] type = "tEXt".getBytes("ISO-8859-1");
+    writeInt(output, text.length);
+    output.write(type);
+    output.write(text);
+    java.util.zip.CRC32 crc = new java.util.zip.CRC32();
+    crc.update(type);
+    crc.update(text);
+    writeInt(output, (int) crc.getValue());
+    output.write(bytes, iend, 12);
+    return output.toByteArray();
+  }
+
+  private static byte[] jpeg(int width, int height) throws Exception {
+    BufferedImage source = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+    for (int y = 0; y < height; y++) {
+      for (int x = 0; x < width; x++) {
+        source.setRGB(x, y, (x * 0x330000) | (y * 0x003300));
+      }
+    }
+    return write(source, "jpg");
+  }
+
+  private static byte[] write(BufferedImage source, String format) throws Exception {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    assertTrue(ImageIO.write(source, format, output));
+    return output.toByteArray();
+  }
+
+  private static void writeInt(ByteArrayOutputStream output, int value) {
+    output.write(value >> 24);
+    output.write(value >> 16);
+    output.write(value >> 8);
+    output.write(value);
+  }
+}

--- a/TotalCrossSDK/src/test/java/totalcross/ui/image/ImageDeferredFrameExtractionTest.java
+++ b/TotalCrossSDK/src/test/java/totalcross/ui/image/ImageDeferredFrameExtractionTest.java
@@ -1,0 +1,229 @@
+// Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+package totalcross.ui.image;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.imageio.ImageIO;
+
+import org.junit.jupiter.api.Test;
+
+class ImageDeferredFrameExtractionTest {
+  private static final int COLOR = 0xFF204060;
+
+  @Test
+  void encodedFrameSelectionStaysLazyAndUsesKnownSingleFrameMetadata() throws Exception {
+    Image source = new Image(twoFramePng());
+
+    Image result = source.getFrameInstance(1);
+
+    assertNull(source.pixels);
+    assertNull(result.pixels);
+    assertEquals(1, result.getFrameCount());
+    assertEquals(4, result.getWidth());
+    assertEquals(4, result.getPixelWidth());
+    assertEquals(-1, result.getCurrentFrame());
+    assertEquals(Arrays.asList(ImagePipeline.FRAME_SELECT), operationTypes(pipeline(result)));
+    assertNotNull(pipeline(result));
+  }
+
+  @Test
+  void frameNormalizationMatchesSetCurrentFrameAndSingleFrameIgnoresArgument() throws Exception {
+    byte[] encoded = twoFramePng();
+    Image expectedLast = new Image(encoded);
+    expectedLast.getPixels();
+    expectedLast.setCurrentFrame(-1);
+    Image expectedFirst = new Image(encoded);
+    expectedFirst.getPixels();
+    expectedFirst.setCurrentFrame(0);
+
+    assertArrayEquals(expectedLast.getPixels(), new Image(encoded).getFrameInstance(-1).getPixels());
+    assertArrayEquals(expectedFirst.getPixels(), new Image(encoded).getFrameInstance(2).getPixels());
+
+    Image single = new Image(png(5, 3));
+    assertArrayEquals(single.getPixels(), single.getFrameInstance(-1).getPixels());
+    assertArrayEquals(single.getPixels(), single.getFrameInstance(99).getPixels());
+  }
+
+  @Test
+  void selectedFrameIsIndependentOfLaterSourceStateChanges() throws Exception {
+    byte[] encoded = twoFramePng();
+    Image source = new Image(encoded);
+    Image selected = source.getFrameInstance(1);
+    int[] expected = new Image(encoded).getFrameInstance(1).getPixels().clone();
+
+    source.setCurrentFrame(0);
+    assertArrayEquals(expected, selected.getPixels());
+    assertEquals(0, source.getCurrentFrame());
+  }
+
+  @Test
+  void materializedSourceIsDeepSnapshottedAndFrameResultKeepsLegacyMetadata() throws Exception {
+    Image source = materializedMultiFrame();
+    setField(source, "path", "frame-fixture.png");
+    source.hwScaleW = 0.75;
+    source.hwScaleH = 0.5;
+    source.alphaMask = 91;
+    source.transparentColor = 0x123456;
+    source.useAlpha = true;
+    int[] expected = source.getFrameInstance(1).getPixels().clone();
+    Image result = source.getFrameInstance(1);
+
+    source.setCurrentFrame(0);
+    source.getPixels()[0] = 0xFFFFFFFF;
+
+    assertArrayEquals(expected, result.getPixels());
+    assertEquals("frame-fixture.png", result.getPath());
+    assertEquals(0.75, result.hwScaleW);
+    assertEquals(0.5, result.hwScaleH);
+    assertEquals(255, result.alphaMask);
+    assertEquals(ColorDefaults.WHITE, result.transparentColor);
+    assertFalse(result.useAlpha);
+  }
+
+  @Test
+  void getCopySelectsFrameZeroAndRemainsDeferred() throws Exception {
+    Image source = new Image(twoFramePng());
+    Image copy = source.getCopy();
+
+    assertNull(copy.pixels);
+    assertEquals(1, copy.getFrameCount());
+    assertEquals(Arrays.asList(ImagePipeline.FRAME_SELECT), operationTypes(pipeline(copy)));
+    Image expected = new Image(twoFramePng());
+    expected.getPixels();
+    assertArrayEquals(expected.getPixels(), copy.getPixels());
+  }
+
+  @Test
+  void frameSelectionComposesInCallOrderWithColorAndScaleNodes() throws Exception {
+    byte[] encoded = twoFramePng();
+
+    Image colorThenFrame = new Image(encoded);
+    colorThenFrame.applyColor(COLOR);
+    Image colorThenFrameResult = colorThenFrame.getFrameInstance(1);
+    assertEquals(Arrays.asList(ImagePipeline.APPLY_COLOR, ImagePipeline.FRAME_SELECT),
+        operationTypes(pipeline(colorThenFrameResult)));
+
+    Image frameThenColor = new Image(encoded).getFrameInstance(1);
+    frameThenColor.applyColor(COLOR);
+    assertEquals(Arrays.asList(ImagePipeline.FRAME_SELECT, ImagePipeline.APPLY_COLOR),
+        operationTypes(pipeline(frameThenColor)));
+
+    Image expectedColorThenFrame = new Image(encoded);
+    expectedColorThenFrame.getPixels();
+    expectedColorThenFrame.applyColor(COLOR);
+    expectedColorThenFrame.setCurrentFrame(1);
+    assertArrayEquals(expectedColorThenFrame.getPixels(), colorThenFrameResult.getPixels());
+
+    Image expectedFrameThenColor = new Image(encoded).getFrameInstance(1);
+    expectedFrameThenColor.getPixels();
+    expectedFrameThenColor.applyColor(COLOR);
+    assertArrayEquals(expectedFrameThenColor.getPixels(), frameThenColor.getPixels());
+
+    Image scaled = new Image(encoded).getSmoothScaledInstance(2, 2).getFrameInstance(1);
+    assertEquals(Arrays.asList(ImagePipeline.SMOOTH_SCALE, ImagePipeline.FRAME_SELECT),
+        operationTypes(pipeline(scaled)));
+    assertEquals(2, scaled.getWidth());
+    assertTrue(scaled.getPixels().length > 0);
+  }
+
+  private static Image materializedMultiFrame() throws Exception {
+    Image image = new Image(8, 2);
+    for (int i = 0; i < image.pixels.length; i++) {
+      image.pixels[i] = i < 8 ? 0xFF102030 : 0xFF405060;
+    }
+    image.setFrameCount(2);
+    image.setCurrentFrame(1);
+    return image;
+  }
+
+  private static List<Integer> operationTypes(ImagePipeline leaf) {
+    List<Integer> result = new ArrayList<Integer>();
+    for (ImagePipeline node = leaf; node != null && node.previous() != null; node = node.previous()) {
+      result.add(0, node.operationType());
+    }
+    return result;
+  }
+
+  private static ImagePipeline pipeline(Image image) throws Exception {
+    Field field = Image.class.getDeclaredField("pipeline");
+    field.setAccessible(true);
+    return (ImagePipeline) field.get(image);
+  }
+
+  private static void setField(Object object, String name, Object value) throws Exception {
+    Field field = object.getClass().getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(object, value);
+  }
+
+  private static byte[] png(int width, int height) throws Exception {
+    BufferedImage source = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+    for (int y = 0; y < height; y++) {
+      for (int x = 0; x < width; x++) {
+        source.setRGB(x, y, 0xFF000000 | ((x * 29) & 0xFF) << 16 | ((y * 41) & 0xFF) << 8 | (x + y));
+      }
+    }
+    return writePng(source, null);
+  }
+
+  private static byte[] twoFramePng() throws Exception {
+    BufferedImage source = new BufferedImage(8, 3, BufferedImage.TYPE_INT_ARGB);
+    for (int y = 0; y < source.getHeight(); y++) {
+      for (int x = 0; x < source.getWidth(); x++) {
+        int color = x < 4 ? 0xFF000000 | (x * 20) << 16 | (y * 30) << 8
+            : 0xFF004000 | ((x - 4) * 25) | (y * 15);
+        source.setRGB(x, y, color);
+      }
+    }
+    return writePng(source, "FC=2");
+  }
+
+  private static byte[] writePng(BufferedImage source, String comment) throws Exception {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    assertTrue(ImageIO.write(source, "png", output));
+    byte[] bytes = output.toByteArray();
+    if (comment == null) {
+      return bytes;
+    }
+    int iend = bytes.length - 12;
+    ByteArrayOutputStream withComment = new ByteArrayOutputStream(bytes.length + comment.length() + 32);
+    withComment.write(bytes, 0, iend);
+    byte[] text = ("Comment\0" + comment).getBytes("ISO-8859-1");
+    writeInt(withComment, text.length);
+    byte[] type = "tEXt".getBytes("ISO-8859-1");
+    withComment.write(type);
+    withComment.write(text);
+    java.util.zip.CRC32 crc = new java.util.zip.CRC32();
+    crc.update(type);
+    crc.update(text);
+    writeInt(withComment, (int) crc.getValue());
+    withComment.write(bytes, iend, 12);
+    return withComment.toByteArray();
+  }
+
+  private static void writeInt(ByteArrayOutputStream output, int value) {
+    output.write(value >> 24);
+    output.write(value >> 16);
+    output.write(value >> 8);
+    output.write(value);
+  }
+
+  private static final class ColorDefaults {
+    static final int WHITE = 0xFFFFFF;
+  }
+}

--- a/TotalCrossSDK/src/test/java/totalcross/ui/image/ImageDeferredFrameStateTest.java
+++ b/TotalCrossSDK/src/test/java/totalcross/ui/image/ImageDeferredFrameStateTest.java
@@ -1,0 +1,495 @@
+// Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+package totalcross.ui.image;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+import javax.imageio.ImageIO;
+
+import org.junit.jupiter.api.Test;
+
+import totalcross.io.ByteArrayStream;
+import totalcross.io.DataStream;
+
+class ImageDeferredFrameStateTest {
+  private static final int FRAME_ZERO = 0xFF204060;
+  private static final int FRAME_ONE = 0xFFB06020;
+
+  @Test
+  void currentFrameNavigationIsMetadataOnlyAndReusesCachedVariants() throws Exception {
+    Image image = new Image(twoFramePng()).getSmoothScaledInstance(4, 2);
+    assertNull(image.pixels);
+    assertEquals(0, image.getCurrentFrame());
+
+    Image oneX = image.resolveForDrawing(1);
+    Image twoX = image.resolveForDrawing(2);
+    int[] oneFrameZero = oneX.getPixels().clone();
+    int[] twoFrameZero = twoX.getPixels().clone();
+
+    image.setCurrentFrame(-1);
+    assertEquals(1, image.getCurrentFrame());
+    assertNull(image.pixels);
+    assertSame(oneX, image.resolveForDrawing(1));
+    assertSame(twoX, image.resolveForDrawing(2));
+    assertFalse(Arrays.equals(oneFrameZero, oneX.getPixels()));
+    assertFalse(Arrays.equals(twoFrameZero, twoX.getPixels()));
+
+    image.nextFrame();
+    assertEquals(0, image.getCurrentFrame());
+    image.prevFrame();
+    assertEquals(1, image.getCurrentFrame());
+    image.setCurrentFrame(99);
+    assertEquals(0, image.getCurrentFrame());
+    image.setCurrentFrame(-99);
+    assertEquals(1, image.getCurrentFrame());
+  }
+
+  @Test
+  void canonicalBarrierAdoptsTheSelectedFrame() throws Exception {
+    Image actual = new Image(twoFramePng());
+    actual.setCurrentFrame(1);
+    assertNull(actual.pixels);
+    int[] expected = new Image(twoFramePng()).getFrameInstance(1).getPixels();
+
+    assertArrayEquals(expected, actual.getPixels());
+    assertNull(pipeline(actual));
+    assertEquals(1, actual.getCurrentFrame());
+  }
+
+  @Test
+  void explicitFrameExtractionAndCropCaptureAreIndependentOfLaterState() throws Exception {
+    Image source = new Image(twoFramePng());
+    source.setCurrentFrame(1);
+    Image explicitFirst = source.getFrameInstance(0);
+    Image cropOfSecond = source.getClippedInstance(0, 0, 2, 2);
+    source.setCurrentFrame(0);
+
+    assertArrayEquals(new Image(twoFramePng()).getFrameInstance(0).getPixels(), explicitFirst.getPixels());
+    Image expectedCrop = new Image(twoFramePng()).getFrameInstance(1).getClippedInstance(0, 0, 2, 2);
+    assertArrayEquals(expectedCrop.getPixels(), cropOfSecond.getPixels());
+    assertEquals(0, source.getCurrentFrame());
+  }
+
+  @Test
+  void deferredColorMutationFrameSideEffectsRemainCompatible() throws Exception {
+    Image color = new Image(twoFramePng());
+    color.setCurrentFrame(1);
+    color.applyColor(0xFF804020);
+    assertEquals(0, color.getCurrentFrame());
+    assertNotNull(pipeline(color));
+
+    Image fade = new Image(twoFramePng());
+    fade.setCurrentFrame(1);
+    fade.applyFade(137);
+    assertEquals(1, fade.getCurrentFrame());
+    Image expectedFade = new Image(twoFramePng());
+    expectedFade.getPixels();
+    expectedFade.setCurrentFrame(1);
+    expectedFade.applyFade(137);
+    assertArrayEquals(expectedFade.getPixels(), fade.getPixels());
+
+    Image transparent = new Image(twoFramePng());
+    transparent.setCurrentFrame(1);
+    transparent.setTransparentColor(0x204060);
+    assertEquals(1, transparent.getCurrentFrame());
+    assertNotNull(pipeline(transparent));
+  }
+
+  @Test
+  void deferredFadeUsesTheCallTimeFrameBeforeFinalPresentationSync() throws Exception {
+    assertFadeOrdering(0, 1);
+    assertFadeOrdering(1, 0);
+
+    Image expected = new Image(twoFramePng());
+    expected.getPixels();
+    expected.setCurrentFrame(1);
+    expected.applyFade(137);
+    expected.setCurrentFrame(0);
+    expected.applyFade(137);
+    expected.setCurrentFrame(1);
+
+    Image actual = new Image(twoFramePng());
+    actual.setCurrentFrame(1);
+    actual.applyFade(137);
+    actual.setCurrentFrame(0);
+    actual.applyFade(137);
+    actual.setCurrentFrame(1);
+
+    assertArrayEquals(allFramePixels(expected), allFramePixels(actual));
+    assertArrayEquals(expected.getPixels(), actual.getPixels());
+    assertEquals(1, actual.getCurrentFrame());
+  }
+
+  private static void assertFadeOrdering(int applyFrame, int finalFrame) throws Exception {
+    Image expected = new Image(twoFramePng());
+    expected.getPixels();
+    expected.setCurrentFrame(applyFrame);
+    expected.applyFade(137);
+    expected.setCurrentFrame(finalFrame);
+
+    Image actual = new Image(twoFramePng());
+    actual.setCurrentFrame(applyFrame);
+    actual.applyFade(137);
+    actual.setCurrentFrame(finalFrame);
+
+    assertArrayEquals(allFramePixels(expected), allFramePixels(actual));
+    assertArrayEquals(expected.getPixels(), actual.getPixels());
+  }
+
+  @Test
+  void deferredFrameLayoutUpdatesMetadataAndPreservesNonDivisibleStrip() throws Exception {
+    Image image = new Image(stripPng(5, 2));
+    image.setFrameCount(2);
+
+    assertNull(image.pixels);
+    assertEquals(2, image.getFrameCount());
+    assertEquals(2, image.getWidth());
+    assertEquals(2, intField(image, "logicalWidth"));
+    assertEquals("FC=2", image.comment);
+    assertEquals(0, image.getCurrentFrame());
+    assertEquals(ImagePipeline.FRAME_LAYOUT, pipeline(image).operationType());
+
+    Image resolved = image.resolveForDrawing(1);
+    assertEquals(2, resolved.getPixelWidth());
+    assertEquals(5, intField(resolved, "widthOfAllFrames"));
+    assertArrayEquals(new int[] { stripPixel(0), stripPixel(1), stripPixel(0), stripPixel(1), }, resolved.getPixels());
+    image.setCurrentFrame(1);
+    assertSame(resolved, image.resolveForDrawing(1));
+    assertArrayEquals(new int[] { stripPixel(2), stripPixel(3), stripPixel(2), stripPixel(3), }, resolved.getPixels());
+  }
+
+  @Test
+  void pngAndJpegSingleFrameSourcesStayDeferredUntilFrameLayoutResolution() throws Exception {
+    for (byte[] encoded : new byte[][] { stripPng(6, 2), jpeg(6, 2) }) {
+      Image actual = new Image(encoded);
+      Image expected = new Image(encoded);
+      expected.getPixels();
+      expected.setFrameCount(2);
+
+      actual.setFrameCount(2);
+      assertNull(actual.pixels);
+      assertEquals(2, actual.getFrameCount());
+      assertArrayEquals(expected.getPixels(), actual.getPixels());
+    }
+  }
+
+  @Test
+  void deferredFrameLayoutKeepsLogicalWidthAtDestinationScaleAndRoundTripsFullStrip() throws Exception {
+    Image image = new Image(stripPng(5, 2)).getSmoothScaledInstance(3, 2);
+    image.setFrameCount(2);
+    assertEquals(1, image.getWidth());
+    assertEquals(1, intField(image, "logicalWidth"));
+    assertEquals(2, image.resolveForDrawing(2).getPixelWidth());
+    assertEquals(1, image.resolveForDrawing(2).getWidth());
+
+    Image roundTripSource = new Image(stripPng(5, 2));
+    roundTripSource.setFrameCount(2);
+    ByteArrayStream output = new ByteArrayStream(256);
+    roundTripSource.createPng(new DataStream(output));
+    ImageEncodedStructure.Inspection inspection = ImageEncodedStructure.inspect(output.getBuffer(), output.getPos());
+    assertEquals(5, inspection.width);
+    assertEquals(2, inspection.frameCount);
+    assertEquals("FC=2", inspection.comment);
+  }
+
+  @Test
+  void deferredFrameLayoutPreservesHighDensityPhysicalAndLogicalDimensions() throws Exception {
+    assertHighDensityFrameLayout(2.0);
+    assertHighDensityFrameLayout(1.5);
+  }
+
+  @Test
+  void deferredFrameSelectionPreservesExactFractionalContentScale() throws Exception {
+    assertExactFractionalFrameLayout(1.1, 6);
+    assertExactFractionalFrameLayout(1.25, 6);
+    assertExactFractionalFrameLayout(1.75, 5);
+  }
+
+  private static void assertExactFractionalFrameLayout(double contentScale, int logicalWidth) throws Exception {
+    int fullPhysicalWidth = (int) Math.ceil(logicalWidth * contentScale);
+    Image expectedSource = Image.createLogical(logicalWidth, 2, contentScale);
+    fillPhysicalStrip(expectedSource);
+    assertEquals(fullPhysicalWidth, expectedSource.getPixelWidth());
+    Image expected = expectedSource.getFrameInstance(0);
+    expected.getPixels();
+    expected.setFrameCount(2);
+
+    Image actualSource = Image.createLogical(logicalWidth, 2, contentScale);
+    fillPhysicalStrip(actualSource);
+    assertEquals(fullPhysicalWidth, actualSource.getPixelWidth());
+    Image actual = actualSource.getFrameInstance(0);
+    actual.setFrameCount(2);
+    assertFrameLayoutMetadataBeforeBarrier(expected, actual, fullPhysicalWidth, contentScale);
+    assertArrayEquals(expected.getPixels(), actual.getPixels());
+    actual.setCurrentFrame(1);
+    expected.setCurrentFrame(1);
+    assertArrayEquals(expected.getPixels(), actual.getPixels());
+    assertFrameLayoutMetadataAfterBarrier(expected, actual, fullPhysicalWidth, contentScale);
+    assertNull(pipeline(actual));
+  }
+
+  @Test
+  void deferredCroppedFrameLayoutPreservesExactFractionalContentScale() throws Exception {
+    assertExactFractionalCroppedFrameLayout(1.1, 6);
+    assertExactFractionalCroppedFrameLayout(1.25, 6);
+    assertExactFractionalCroppedFrameLayout(1.75, 5);
+  }
+
+  private static void assertExactFractionalCroppedFrameLayout(double contentScale, int logicalWidth) throws Exception {
+    int fullPhysicalWidth = (int) Math.ceil(logicalWidth * contentScale);
+    Image expectedSource = Image.createLogical(logicalWidth, 2, contentScale);
+    fillPhysicalStrip(expectedSource);
+    assertEquals(fullPhysicalWidth, expectedSource.getPixelWidth());
+    Image expected = expectedSource.getClippedInstance(0, 0, logicalWidth, 2);
+    expected.getPixels();
+    expected.setFrameCount(2);
+
+    Image actualSource = Image.createLogical(logicalWidth, 2, contentScale);
+    fillPhysicalStrip(actualSource);
+    assertEquals(fullPhysicalWidth, actualSource.getPixelWidth());
+    Image actual = actualSource.getClippedInstance(0, 0, logicalWidth, 2);
+    actual.setFrameCount(2);
+    assertFrameLayoutMetadataBeforeBarrier(expected, actual, fullPhysicalWidth, contentScale);
+    assertArrayEquals(expected.getPixels(), actual.getPixels());
+    actual.setCurrentFrame(1);
+    expected.setCurrentFrame(1);
+    assertArrayEquals(expected.getPixels(), actual.getPixels());
+    assertFrameLayoutMetadataAfterBarrier(expected, actual, fullPhysicalWidth, contentScale);
+    assertNull(pipeline(actual));
+  }
+
+  private static void assertFrameLayoutMetadataBeforeBarrier(Image expected, Image actual, int fullPhysicalWidth,
+      double contentScale) throws Exception {
+    assertEquals(2, actual.getFrameCount());
+    assertEquals(contentScale, actual.getContentScale());
+    assertEquals(expected.getPixelWidth(), actual.getPixelWidth());
+    assertEquals(expected.getWidth(), actual.getWidth());
+    assertEquals(fullPhysicalWidth / 2, actual.getPixelWidth());
+    assertEquals((int) Math.ceil(actual.getPixelWidth() / contentScale), actual.getWidth());
+    assertEquals(intField(expected, "widthOfAllFrames"), intField(actual, "widthOfAllFrames"));
+    assertEquals(fullPhysicalWidth, intField(actual, "widthOfAllFrames"));
+  }
+
+  private static void assertFrameLayoutMetadataAfterBarrier(Image expected, Image actual, int fullPhysicalWidth,
+      double contentScale) throws Exception {
+    assertEquals(2, actual.getFrameCount());
+    assertEquals(contentScale, actual.getContentScale());
+    assertEquals(expected.getPixelWidth(), actual.getPixelWidth());
+    assertEquals(expected.getWidth(), actual.getWidth());
+    assertEquals(fullPhysicalWidth / 2, actual.getPixelWidth());
+    assertEquals((int) Math.ceil(actual.getPixelWidth() / contentScale), actual.getWidth());
+    assertEquals(intField(expected, "widthOfAllFrames"), intField(actual, "widthOfAllFrames"));
+    assertEquals(fullPhysicalWidth, intField(actual, "widthOfAllFrames"));
+  }
+
+  @Test
+  void deferredCroppedFrameLayoutPreservesHighDensityRasterSemantics() throws Exception {
+    assertCroppedHighDensityFrameLayout(2.0);
+    assertCroppedHighDensityFrameLayout(1.5);
+  }
+
+  private static void assertCroppedHighDensityFrameLayout(double contentScale) throws Exception {
+    Image eagerSource = highDensityStrip(contentScale);
+    Image expected = eagerSource.getClippedInstance(0, 0, 4, 2);
+    expected.getPixels();
+    expected.setFrameCount(2);
+
+    Image actual = highDensityStrip(contentScale).getClippedInstance(0, 0, 4, 2);
+    actual.setFrameCount(2);
+    assertNull(actual.pixels);
+    assertEquals(expected.getPixelWidth(), actual.getPixelWidth());
+    assertEquals(expected.getWidth(), actual.getWidth());
+    assertEquals(expected.getContentScale(), actual.getContentScale());
+    assertEquals(intField(expected, "widthOfAllFrames"), intField(actual, "widthOfAllFrames"));
+
+    assertArrayEquals(expected.getPixels(), actual.getPixels());
+    actual.setCurrentFrame(1);
+    expected.setCurrentFrame(1);
+    assertArrayEquals(expected.getPixels(), actual.getPixels());
+    assertNull(pipeline(actual));
+  }
+
+  private static void assertHighDensityFrameLayout(double contentScale) throws Exception {
+    Image expected = highDensityStrip(contentScale);
+    int fullPhysicalWidth = expected.getPixelWidth();
+    int physicalFrameWidth = fullPhysicalWidth / 2;
+    int logicalFrameWidth = (int) Math.ceil(physicalFrameWidth / contentScale);
+    expected.setFrameCount(2);
+
+    Image actual = highDensityStrip(contentScale).getFrameInstance(0);
+    actual.setFrameCount(2);
+    assertNull(actual.pixels);
+    assertEquals(physicalFrameWidth, actual.getPixelWidth());
+    assertEquals(logicalFrameWidth, actual.getWidth());
+    assertEquals(logicalFrameWidth, intField(actual, "logicalWidth"));
+
+    assertArrayEquals(expected.getPixels(), actual.getPixels());
+    expected.setCurrentFrame(1);
+    actual.setCurrentFrame(1);
+    assertArrayEquals(expected.getPixels(), actual.getPixels());
+  }
+
+  @Test
+  void deferredFrameLayoutPreservesLegacyZeroWidthFrameBehavior() throws Exception {
+    Image expected = new Image(1, 2);
+    fillPhysicalStrip(expected);
+    expected.setFrameCount(2);
+
+    Image actual = new Image(stripPng(1, 2));
+    actual.setFrameCount(2);
+    assertEquals(0, actual.getPixelWidth());
+    assertEquals(0, actual.getWidth());
+    assertEquals(0, intField(actual, "logicalWidth"));
+    assertEquals(2, actual.getFrameCount());
+    assertEquals(0, actual.resolveForDrawing(1).getPixels().length);
+
+    actual.setCurrentFrame(1);
+    assertEquals(0, actual.getPixels().length);
+    assertArrayEquals(allFramePixels(expected), allFramePixels(actual));
+  }
+
+  @Test
+  void frameLayoutValidationIsImmediateAndSameCountIsNoOp() throws Exception {
+    Image image = new Image(stripPng(5, 2));
+    assertThrows(IllegalArgumentException.class, () -> image.setFrameCount(0));
+    assertNull(image.pixels);
+    image.setFrameCount(2);
+    ImagePipeline layout = pipeline(image);
+    image.setFrameCount(2);
+    assertSame(layout, pipeline(image));
+    assertThrows(IllegalStateException.class, () -> image.setFrameCount(3));
+    assertNull(image.pixels);
+
+    Image multi = new Image(twoFramePng());
+    assertThrows(IllegalStateException.class, () -> multi.setFrameCount(3));
+    assertNull(multi.pixels);
+  }
+
+  @Test
+  void frameLayoutAllocationFailureIsRetryableAndDoesNotPoisonEncodedSource() throws Exception {
+    Image image = new Image(stripPng(5, 2));
+    image.setFrameCount(2);
+    EncodedImageSource source = (EncodedImageSource) pipeline(image).root();
+    Image.failNextMaterializedFrameBufferAllocationForTest();
+    assertThrows(TransientImageMaterializationException.class, () -> image.resolveForDrawing(1));
+    assertNull(source.decodeFailure());
+    assertNotNull(pipeline(image));
+    assertNotNull(image.resolveForDrawing(1));
+  }
+
+  private static ImagePipeline pipeline(Image image) throws Exception {
+    Field field = Image.class.getDeclaredField("pipeline");
+    field.setAccessible(true);
+    return (ImagePipeline) field.get(image);
+  }
+
+  private static int intField(Image image, String name) throws Exception {
+    Field field = Image.class.getDeclaredField(name);
+    field.setAccessible(true);
+    return field.getInt(image);
+  }
+
+  private static int stripPixel(int x) {
+    return 0xFF000000 | (x + 1) << 16 | (x + 2) << 8 | x + 3;
+  }
+
+  private static Image highDensityStrip(double contentScale) throws Exception {
+    Image image = Image.createLogical(4, 2, contentScale);
+    fillPhysicalStrip(image);
+    return image;
+  }
+
+  private static void fillPhysicalStrip(Image image) {
+    int width = image.getPixelWidth();
+    int[] pixels = image.getPixels();
+    for (int y = 0; y < image.getPixelHeight(); y++) {
+      for (int x = 0; x < width; x++) {
+        pixels[y * width + x] = stripPixel(x);
+      }
+    }
+  }
+
+  private static int[] allFramePixels(Image image) throws Exception {
+    image.getPixels();
+    Field field = Image.class.getDeclaredField("pixelsOfAllFrames");
+    field.setAccessible(true);
+    return ((int[]) field.get(image)).clone();
+  }
+
+  private static byte[] twoFramePng() throws Exception {
+    BufferedImage source = new BufferedImage(8, 2, BufferedImage.TYPE_INT_ARGB);
+    for (int y = 0; y < source.getHeight(); y++) {
+      for (int x = 0; x < source.getWidth(); x++) {
+        source.setRGB(x, y, x < 4 ? FRAME_ZERO : FRAME_ONE);
+      }
+    }
+    return writePng(source, "FC=2");
+  }
+
+  private static byte[] stripPng(int width, int height) throws Exception {
+    BufferedImage source = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+    for (int y = 0; y < height; y++) {
+      for (int x = 0; x < width; x++) {
+        source.setRGB(x, y, stripPixel(x));
+      }
+    }
+    return writePng(source, null);
+  }
+
+  private static byte[] jpeg(int width, int height) throws Exception {
+    BufferedImage source = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+    for (int y = 0; y < height; y++) {
+      for (int x = 0; x < width; x++) {
+        source.setRGB(x, y, (x * 0x220000) | (y * 0x003300));
+      }
+    }
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    assertTrue(ImageIO.write(source, "jpg", output));
+    return output.toByteArray();
+  }
+
+  private static byte[] writePng(BufferedImage source, String comment) throws Exception {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    assertTrue(ImageIO.write(source, "png", output));
+    byte[] bytes = output.toByteArray();
+    if (comment == null) {
+      return bytes;
+    }
+    int iend = bytes.length - 12;
+    ByteArrayOutputStream withComment = new ByteArrayOutputStream(bytes.length + 32);
+    withComment.write(bytes, 0, iend);
+    byte[] text = ("Comment\0" + comment).getBytes("ISO-8859-1");
+    byte[] type = "tEXt".getBytes("ISO-8859-1");
+    writeInt(withComment, text.length);
+    withComment.write(type);
+    withComment.write(text);
+    java.util.zip.CRC32 crc = new java.util.zip.CRC32();
+    crc.update(type);
+    crc.update(text);
+    writeInt(withComment, (int) crc.getValue());
+    withComment.write(bytes, iend, 12);
+    return withComment.toByteArray();
+  }
+
+  private static void writeInt(ByteArrayOutputStream output, int value) {
+    output.write(value >> 24);
+    output.write(value >> 16);
+    output.write(value >> 8);
+    output.write(value);
+  }
+}


### PR DESCRIPTION
### What changed
- Extends the lazy image pipeline so additional `Image` operations can remain deferred until pixels are actually required.
- Adds deferred color mutations, crop, frame extraction/navigation, and frame-layout operations instead of eagerly allocating intermediate rasters.
- Keeps already materialized images on the existing eager behavior for compatibility.

### Deferred semantics
- Preserves operation order through immutable pipeline nodes and resolves the chain only at rendering or pixel-access barriers.
- Snapshots the relevant source state for crop/frame extraction so later source mutations cannot affect previously derived images.
- Synchronizes frame selection across cached variants without turning the current frame into pipeline state or a cache key.

### Rendering and decode
- Keeps destination-aware resolution, including fractional HiDPI content scales.
- Retains reduced-resolution JPEG decode when the first eligible operation is a smooth downscale.
- Preserves encoded-source ownership, JPEG scaling semantics, public APIs, and the native `Image` ABI.

### Validation
- Adds focused Java and deployed macOS smoke coverage for deferred mutations, crop, frame behavior, caching, scaling, and compatibility.
- Together with lazy decode, reduces full-resolution intermediate images, decode/copy work, and peak memory pressure in common image-processing chains.