### PR TITLE
fix(sdk,vm): harden jpeg scaling factories

### DIFF
--- a/TotalCrossSDK/build.gradle
+++ b/TotalCrossSDK/build.gradle
@@ -683,6 +683,8 @@ tasks.register('runImageAbiSmokeMacOS', Exec) {
             'jpegBestFitPass=true',
             'jpegScaledPass=true',
             'jpegBestFitScalePass=true',
+            'jpegOddDimensionPass=true',
+            'jpegArgumentValidationPass=true',
             'overallPass=true'
         ]
         def missing = requiredFields.findAll { !output.contains(it) }

--- a/TotalCrossSDK/src/main/java/totalcross/ui/image/Image.java
+++ b/TotalCrossSDK/src/main/java/totalcross/ui/image/Image.java
@@ -2652,13 +2652,56 @@ public class Image extends GfxSurface {
   @ReplacedByNativeOnDeploy
   public static native void nativeResizeJpeg(String inputPath, String outputPath, int maxPixelSize);
   
-  private static final double F1_8 = 12.5;
-  private static final double F1_4 = 25;
-  private static final double F1_2 = 50;
+  private static final int JPEG_SCALE_1_8 = 8;
+  private static final int JPEG_SCALE_1_4 = 4;
+  private static final int JPEG_SCALE_1_2 = 2;
+
+  private static void validateJpegScaleArguments(int numerator, int denominator) throws ImageException {
+    if (numerator <= 0 || denominator <= 0) {
+      throw new ImageException(null);
+    }
+  }
+
+  private static int jpegScaledDimension(int sourceDimension, int scaleNumerator, int scaleDenominator)
+      throws ImageException {
+    long scaled = (long) sourceDimension * scaleNumerator;
+    long dimension = (scaled + scaleDenominator - 1) / scaleDenominator;
+    if (dimension <= 0 || dimension > Integer.MAX_VALUE) {
+      throw new ImageException("Image dimensions are too large.");
+    }
+    return (int) dimension;
+  }
+
+  private static boolean jpegBestFitFits(int sourceDimension, int scaleDenominator, int targetDimension) {
+    long decodedDimension = ((long) sourceDimension + scaleDenominator - 1) / scaleDenominator;
+    return decodedDimension >= targetDimension;
+  }
+
+  private static int jpegBestFitScaleDenominatorForDimension(int sourceDimension, int targetDimension) {
+    if (jpegBestFitFits(sourceDimension, JPEG_SCALE_1_8, targetDimension)) {
+      return JPEG_SCALE_1_8;
+    }
+    if (jpegBestFitFits(sourceDimension, JPEG_SCALE_1_4, targetDimension)) {
+      return JPEG_SCALE_1_4;
+    }
+    if (jpegBestFitFits(sourceDimension, JPEG_SCALE_1_2, targetDimension)) {
+      return JPEG_SCALE_1_2;
+    }
+    return 1;
+  }
+
+  private static int jpegBestFitScaleDenominator(int sourceWidth, int sourceHeight,
+      int targetWidth, int targetHeight) {
+    if ((long) targetWidth * sourceHeight <= (long) targetHeight * sourceWidth) {
+      return jpegBestFitScaleDenominatorForDimension(sourceWidth, targetWidth);
+    }
+    return jpegBestFitScaleDenominatorForDimension(sourceHeight, targetHeight);
+  }
   
   @ReplacedByNativeOnDeploy
   public static Image getJpegBestFit(String path, int targetWidth, int targetHeight)
       throws java.io.IOException, ImageException {
+    validateJpegScaleArguments(targetWidth, targetHeight);
     SimpleImageInfo sif = null;
 
     if (path != null) {
@@ -2683,28 +2726,17 @@ public class Image extends GfxSurface {
       throw new ImageException(null);
     }
 
-    final double p1 = targetWidth * 100.0 / sif.getWidth();
-    final double p2 = targetHeight * 100.0 / sif.getHeight();
-    final double p = Math.min(p1, p2);
-
-    int scale_denom;
-    if (p <= F1_8) {
-      scale_denom = 8; // 1/8
-    } else if (p <= F1_4) {
-      scale_denom = 4; // 1/4
-    } else if (p <= F1_2) {
-      scale_denom = 2; // 1/2
-    } else {
-      scale_denom = 1; // original size
-    }
-    
-    final double scale = 1.0 / scale_denom;
-    return new Image(path).smoothScaledBy(scale, scale);
+    final int scaleDenominator = jpegBestFitScaleDenominator(
+        sif.getWidth(), sif.getHeight(), targetWidth, targetHeight);
+    final int scaledWidth = jpegScaledDimension(sif.getWidth(), 1, scaleDenominator);
+    final int scaledHeight = jpegScaledDimension(sif.getHeight(), 1, scaleDenominator);
+    return new Image(path).getSmoothScaledInstance(scaledWidth, scaledHeight);
   }
 
   @ReplacedByNativeOnDeploy
   public static Image getJpegScaled(String path, int scaleNumerator, int scaleDenominator)
       throws java.io.IOException, ImageException {
+    validateJpegScaleArguments(scaleNumerator, scaleDenominator);
     SimpleImageInfo sif = null;
 
     if (path != null) {
@@ -2729,8 +2761,9 @@ public class Image extends GfxSurface {
       throw new ImageException(null);
     }
 
-    final double scale = (double) scaleNumerator / scaleDenominator;
-    return new Image(path).smoothScaledBy(scale, scale);
+    final int scaledWidth = jpegScaledDimension(sif.getWidth(), scaleNumerator, scaleDenominator);
+    final int scaledHeight = jpegScaledDimension(sif.getHeight(), scaleNumerator, scaleDenominator);
+    return new Image(path).getSmoothScaledInstance(scaledWidth, scaledHeight);
   }
 
   @Override

--- a/TotalCrossSDK/src/smokeTest/java/totalcross/ui/image/ImageAbiSmokeApp.java
+++ b/TotalCrossSDK/src/smokeTest/java/totalcross/ui/image/ImageAbiSmokeApp.java
@@ -11,6 +11,7 @@ import totalcross.sys.Vm;
 import totalcross.ui.MainWindow;
 import totalcross.ui.gfx.Graphics;
 import totalcross.ui.image.Image;
+import totalcross.ui.image.ImageException;
 
 /** Native macOS smoke fixture for the unified Image field ABI and lifecycle. */
 public class ImageAbiSmokeApp extends MainWindow {
@@ -46,6 +47,8 @@ public class ImageAbiSmokeApp extends MainWindow {
     boolean jpegBestFitPass = false;
     boolean jpegScaledPass = false;
     boolean jpegBestFitScalePass = false;
+    boolean jpegOddDimensionPass = false;
+    boolean jpegArgumentValidationPass = false;
     String error = "";
 
     try {
@@ -85,7 +88,9 @@ public class ImageAbiSmokeApp extends MainWindow {
 
       Image scaledTcz = Image.getJpegScaled("image-abi/back3.jpg", 1, 2);
       Image scaledFile = Image.getJpegScaled("back3-file.jpg", 1, 2);
-      jpegScaledPass = hasDimensions(scaledTcz, 800, 450) && hasDimensions(scaledFile, 800, 450);
+      Image scaledThreeQuarters = Image.getJpegScaled("image-abi/back3.jpg", 3, 4);
+      jpegScaledPass = hasDimensions(scaledTcz, 800, 450) && hasDimensions(scaledFile, 800, 450)
+          && hasDimensions(scaledThreeQuarters, 1200, 675);
       require(jpegScaledPass, "JPEG scaled logical/pixel dimensions");
 
       jpegBestFitScalePass = hasDimensions(Image.getJpegBestFit("image-abi/back3.jpg", 200, 113), 200, 113)
@@ -96,6 +101,26 @@ public class ImageAbiSmokeApp extends MainWindow {
           && hasDimensions(Image.getJpegBestFit("image-abi/back3.jpg", 401, 226), 800, 450)
           && hasDimensions(Image.getJpegBestFit("back3-file.jpg", 801, 451), 1600, 900);
       require(jpegBestFitScalePass, "JPEG best-fit libjpeg scale boundaries");
+
+      Image oddJpegSource = new Image(1601, 901);
+      File oddJpegFile = new File("odd-jpeg.jpg", File.CREATE_EMPTY);
+      oddJpegSource.createJpg(oddJpegFile, 90);
+      oddJpegFile.close();
+      jpegOddDimensionPass = hasDimensions(Image.getJpegBestFit("odd-jpeg.jpg", 201, 113), 201, 113)
+          && hasDimensions(Image.getJpegBestFit("odd-jpeg.jpg", 200, 200), 201, 113)
+          && hasDimensions(Image.getJpegBestFit("odd-jpeg.jpg", 402, 200), 401, 226)
+          && hasDimensions(Image.getJpegScaled("odd-jpeg.jpg", 1, 8), 201, 113)
+          && hasDimensions(Image.getJpegScaled("odd-jpeg.jpg", 3, 4), 1201, 676);
+      require(jpegOddDimensionPass, "JPEG odd dimensions use libjpeg ceiling");
+
+      jpegArgumentValidationPass = rejectsJpegBestFit("image-abi/back3.jpg", 0, 113)
+          && rejectsJpegBestFit("image-abi/back3.jpg", 200, -1)
+          && rejectsJpegScaled("image-abi/back3.jpg", 0, 1)
+          && rejectsJpegScaled("image-abi/back3.jpg", 1, 0)
+          && rejectsJpegScaled("image-abi/back3.jpg", -1, 1)
+          && rejectsJpegScaled("image-abi/back3.jpg", 1, -1)
+          && rejectsJpegScaled("image-abi/back3.jpg", Integer.MIN_VALUE, 1);
+      require(jpegArgumentValidationPass, "JPEG invalid arguments");
 
       Image mutable = new Image(2, 2);
       int[] mutablePixels = mutable.getPixels();
@@ -203,7 +228,7 @@ public class ImageAbiSmokeApp extends MainWindow {
         && framePass && colorMutationPass && resizePass && textureUploadPass && textureRecreatePass
         && pngRoundTripPass && replicateScalePass && smoothScalePass && rotationPass && touchUpPass
         && fadePass && alphaPass && hwScaleCopyPass && jpegBestFitPass && jpegScaledPass
-        && jpegBestFitScalePass;
+        && jpegBestFitScalePass && jpegOddDimensionPass && jpegArgumentValidationPass;
     byte[] commitBytes = Vm.getFile("image-abi/commit.txt");
     String commit = commitBytes == null ? "unknown" : new String(commitBytes).trim();
     System.out.println("fixture=ImageAbiSmokeApp,commit=" + commit + ",renderer="
@@ -217,6 +242,8 @@ public class ImageAbiSmokeApp extends MainWindow {
         + ",touchUpPass=" + touchUpPass + ",fadePass=" + fadePass + ",alphaPass=" + alphaPass
         + ",hwScaleCopyPass=" + hwScaleCopyPass + ",jpegBestFitPass=" + jpegBestFitPass
         + ",jpegScaledPass=" + jpegScaledPass + ",jpegBestFitScalePass=" + jpegBestFitScalePass
+        + ",jpegOddDimensionPass=" + jpegOddDimensionPass
+        + ",jpegArgumentValidationPass=" + jpegArgumentValidationPass
         + ",overallPass=" + overallPass
         + (error.length() == 0 ? "" : ",error=" + error));
     exit(overallPass ? 0 : 1);
@@ -232,6 +259,28 @@ public class ImageAbiSmokeApp extends MainWindow {
     return image != null && image.getWidth() == width && image.getHeight() == height
         && image.getPixelWidth() == width && image.getPixelHeight() == height
         && image.getContentScale() == 1;
+  }
+
+  private static boolean rejectsJpegBestFit(String path, int targetWidth, int targetHeight) {
+    try {
+      Image.getJpegBestFit(path, targetWidth, targetHeight);
+      return false;
+    } catch (ImageException expected) {
+      return true;
+    } catch (Exception unexpected) {
+      return false;
+    }
+  }
+
+  private static boolean rejectsJpegScaled(String path, int numerator, int denominator) {
+    try {
+      Image.getJpegScaled(path, numerator, denominator);
+      return false;
+    } catch (ImageException expected) {
+      return true;
+    } catch (Exception unexpected) {
+      return false;
+    }
   }
 
   private static void fill(Image image, int pixel) {

--- a/TotalCrossSDK/src/test/java/totalcross/ui/image/JpegBestFitTest.java
+++ b/TotalCrossSDK/src/test/java/totalcross/ui/image/JpegBestFitTest.java
@@ -5,6 +5,7 @@
 package totalcross.ui.image;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.image.BufferedImage;
@@ -19,8 +20,8 @@ import org.junit.jupiter.api.io.TempDir;
 import totalcross.Launcher;
 
 class JpegBestFitTest {
-  private static final int SOURCE_WIDTH = 1600;
-  private static final int SOURCE_HEIGHT = 800;
+  private static final int SOURCE_WIDTH = 1601;
+  private static final int SOURCE_HEIGHT = 901;
 
   @TempDir
   static Path tempDir;
@@ -37,31 +38,67 @@ class JpegBestFitTest {
 
   @Test
   void selectsExpectedScaleAtInclusiveBoundaries() throws Exception {
-    assertBestFit(200, 100, 200, 100); // 1/8
-    assertBestFit(400, 200, 400, 200); // 1/4
-    assertBestFit(800, 400, 800, 400); // 1/2
-    assertBestFit(1600, 800, 1600, 800); // 1/1
+    assertBestFit(201, 113, 201, 113); // 1/8, ceil(1601/8) x ceil(901/8)
+    assertBestFit(401, 226, 401, 226); // 1/4
+    assertBestFit(801, 451, 801, 451); // 1/2
+    assertBestFit(1601, 901, 1601, 901); // 1/1
   }
 
   @Test
   void selectsNextScaleImmediatelyAboveEachBoundary() throws Exception {
-    assertBestFit(201, 101, 400, 200); // above 1/8 -> 1/4
-    assertBestFit(401, 201, 800, 400); // above 1/4 -> 1/2
-    assertBestFit(801, 401, 1600, 800); // above 1/2 -> 1/1
+    assertBestFit(202, 114, 401, 226); // above 1/8 -> 1/4
+    assertBestFit(402, 227, 801, 451); // above 1/4 -> 1/2
+    assertBestFit(802, 452, 1601, 901); // above 1/2 -> 1/1
   }
 
   @Test
-  void scalesJpegByDoubleRatio() throws Exception {
-    Image image = Image.getJpegScaled(jpegPath.toString(), 1, 2);
-    assertEquals(SOURCE_WIDTH / 2, image.getWidth());
-    assertEquals(SOURCE_HEIGHT / 2, image.getHeight());
-    assertEquals(SOURCE_WIDTH / 2, image.getPixelWidth());
-    assertEquals(SOURCE_HEIGHT / 2, image.getPixelHeight());
+  void preservesAspectRatioForDifferentTargetAspectRatios() throws Exception {
+    assertBestFit(200, 200, 201, 113); // width-limited 1/8
+    assertBestFit(402, 200, 401, 226); // height-limited 1/4
+  }
+
+  @Test
+  void scalesJpegWithLibjpegCeiling() throws Exception {
+    assertScaled(1, 8, 201, 113);
+    assertScaled(1, 2, 801, 451);
+    assertScaled(3, 4, 1201, 676);
+  }
+
+  @Test
+  void rejectsNonPositiveBestFitTargets() {
+    assertThrows(ImageException.class, () -> Image.getJpegBestFit(jpegPath.toString(), 0, 113));
+    assertThrows(ImageException.class, () -> Image.getJpegBestFit(jpegPath.toString(), 201, 0));
+    assertThrows(ImageException.class, () -> Image.getJpegBestFit(jpegPath.toString(), -1, 113));
+    assertThrows(ImageException.class, () -> Image.getJpegBestFit(jpegPath.toString(), 201, -1));
+  }
+
+  @Test
+  void rejectsNonPositiveJpegScaleArguments() {
+    assertThrows(ImageException.class, () -> Image.getJpegScaled(jpegPath.toString(), 0, 1));
+    assertThrows(ImageException.class, () -> Image.getJpegScaled(jpegPath.toString(), 1, 0));
+    assertThrows(ImageException.class, () -> Image.getJpegScaled(jpegPath.toString(), -1, 1));
+    assertThrows(ImageException.class, () -> Image.getJpegScaled(jpegPath.toString(), 1, -1));
+    assertThrows(ImageException.class, () -> Image.getJpegScaled(jpegPath.toString(), Integer.MIN_VALUE, 1));
+  }
+
+  @Test
+  void rejectsJpegScaleWhenDimensionExceedsIntegerRange() {
+    assertThrows(ImageException.class,
+        () -> Image.getJpegScaled(jpegPath.toString(), Integer.MAX_VALUE, 1));
   }
 
   private static void assertBestFit(int targetWidth, int targetHeight, int expectedWidth, int expectedHeight)
       throws Exception {
     Image image = Image.getJpegBestFit(jpegPath.toString(), targetWidth, targetHeight);
+    assertEquals(expectedWidth, image.getWidth());
+    assertEquals(expectedHeight, image.getHeight());
+    assertEquals(expectedWidth, image.getPixelWidth());
+    assertEquals(expectedHeight, image.getPixelHeight());
+  }
+
+  private static void assertScaled(int numerator, int denominator, int expectedWidth, int expectedHeight)
+      throws Exception {
+    Image image = Image.getJpegScaled(jpegPath.toString(), numerator, denominator);
     assertEquals(expectedWidth, image.getWidth());
     assertEquals(expectedHeight, image.getHeight());
     assertEquals(expectedWidth, image.getPixelWidth());

--- a/TotalCrossVM/src/nm/ui/image_Image.c
+++ b/TotalCrossVM/src/nm/ui/image_Image.c
@@ -234,6 +234,15 @@ TC_API void tuiI_nativeResizeJpeg_ssi(NMParams p) // totalcross/ui/image/Image n
 #endif
 }
 //////////////////////////////////////////////////////////////////////////
+static bool validateJpegScaleArguments(Context currentContext, int32 numerator, int32 denominator)
+{
+   if (numerator <= 0 || denominator <= 0) {
+      throwException(currentContext, ImageException, null);
+      return false;
+   }
+   return true;
+}
+//////////////////////////////////////////////////////////////////////////
 TC_API void tuiI_getJpegBestFit_sii(NMParams p) // totalcross/ui/image/Image native public static totalcross.ui.image.Image getJpegBestFit(String path, int targetWidth, int targetHeight) throws java.io.IOException, totalcross.ui.image.ImageException;
 {
    TCObject pathObj = p->obj[0];
@@ -247,6 +256,10 @@ TC_API void tuiI_getJpegBestFit_sii(NMParams p) // totalcross/ui/image/Image nat
    char szPath[MAX_PATHNAME];
    TCZFile tcz;
 
+   p->retO = null;
+   if (!validateJpegScaleArguments(p->currentContext, targetWidth, targetHeight)) {
+      return;
+   }
    String2CharPBuf(pathObj, szPath);
    tcz = tczGetFile(szPath, false);
 
@@ -334,6 +347,10 @@ TC_API void tuiI_getJpegScaled_sii(NMParams p) // totalcross/ui/image/Image nati
    char szPath[MAX_PATHNAME];
    TCZFile tcz;
 
+   p->retO = null;
+   if (!validateJpegScaleArguments(p->currentContext, scaleNumerator, scaleDenominator)) {
+      return;
+   }
    String2CharPBuf(pathObj, szPath);
    tcz = tczGetFile(szPath, false);
 

--- a/TotalCrossVM/third_party/jpeg/JpegLoader.c
+++ b/TotalCrossVM/third_party/jpeg/JpegLoader.c
@@ -96,9 +96,30 @@ static size_t jpegWriteCallback(void *opaque, const void *buffer, size_t count)
    return (size_t)current;
 }
 
-#define F1_8 12.5
-#define F1_4 25
-#define F1_2 50
+static bool jpegBestFitFits(JDIMENSION sourceDimension, int32 scaleDenominator, int32 targetDimension)
+{
+   uint64 decodedDimension = ((uint64)sourceDimension + scaleDenominator - 1) / scaleDenominator;
+   return decodedDimension >= (uint64)targetDimension;
+}
+
+static int32 jpegBestFitScaleDenominatorForDimension(JDIMENSION sourceDimension, int32 targetDimension)
+{
+   if (jpegBestFitFits(sourceDimension, 8, targetDimension))
+      return 8; // 1/8
+   if (jpegBestFitFits(sourceDimension, 4, targetDimension))
+      return 4; // 1/4
+   if (jpegBestFitFits(sourceDimension, 2, targetDimension))
+      return 2; // 1/2
+   return 1; // original size
+}
+
+static int32 jpegBestFitScaleDenominator(JDIMENSION sourceWidth, JDIMENSION sourceHeight,
+      int32 targetWidth, int32 targetHeight)
+{
+   if ((uint64)targetWidth * sourceHeight <= (uint64)targetHeight * sourceWidth)
+      return jpegBestFitScaleDenominatorForDimension(sourceWidth, targetWidth);
+   return jpegBestFitScaleDenominatorForDimension(sourceHeight, targetHeight);
+}
 
 // imageObj+tcz+first4, if reading from a tcz; imageObj+inputStream+bufObj+bufCount, if reading from a totalcross.io.Stream
 void jpegLoad(Context currentContext, TCObject imageObj, TCObject inputStreamObj, TCObject bufObj, TCZFile tcz, const char* first4, int32 size, int32 targetWidthOrScaleNum, int32 targetHeightOrScaleDenom)
@@ -170,21 +191,9 @@ void jpegLoad(Context currentContext, TCObject imageObj, TCObject inputStreamObj
    cinfo.dither_mode = JDITHER_NONE; // 8580 -> 5360
    cinfo.dct_method = JDCT_IFAST;
    if (targetWidthOrScaleNum > 0 && targetHeightOrScaleDenom > 0) {
-      double p1 = targetWidthOrScaleNum * 100.0 / cinfo.image_width;
-      double p2 = targetHeightOrScaleDenom * 100.0 / cinfo.image_height;
-      double p = fmin(p1, p2);
       int32 scale_num2 = 1;
-      int32 scale_denom2;
-
-      if (p <= F1_8) {
-         scale_denom2 = 8; // 1/8
-      } else if (p <= F1_4) {
-         scale_denom2 = 4; // 1/4
-      } else if (p <= F1_2) {
-         scale_denom2 = 2; // 1/2
-      } else {
-         scale_denom2 = 1; // original size
-      }
+      int32 scale_denom2 = jpegBestFitScaleDenominator(cinfo.image_width, cinfo.image_height,
+            targetWidthOrScaleNum, targetHeightOrScaleDenom);
 
       cinfo.scale_num = scale_num2;
       cinfo.scale_denom = scale_denom2;


### PR DESCRIPTION
### What changed
- Hardens the JPEG scaling factories and aligns JavaSE and TCVM behavior.
- Makes `getJpegBestFit` choose native JPEG resolution from libjpeg-equivalent ceiling dimensions instead of nominal percentage thresholds.
- Makes `getJpegScaled` use the same ceiling semantics for computed output dimensions.

### Correctness
- Preserves aspect ratio and chooses the limiting bounding-box axis to avoid unnecessary overdecode.
- Rejects zero and negative arguments consistently before native ratio handling.
- Keeps explicit numerator/denominator scaling semantics while handling odd JPEG dimensions consistently across JavaSE and native builds.

### Safety
- Adds JavaSE overflow guards before allocating scaled images.
- Removes ambiguous native sign handling for invalid public arguments.

### Validation
- Adds focused coverage for 1/8, 1/4, 1/2, arbitrary ratios such as 3/4, boundary cases, invalid arguments, overflow, and deployed native dimensions.
- The change is limited to JPEG factory correctness and does not introduce lazy or deferred decoding behavior.