### PR TITLE
Fix/windowing clickthrough fontname

### DIFF
--- a/.agent/plans/fix-windowing-clickthrough-fontname.md
+++ b/.agent/plans/fix-windowing-clickthrough-fontname.md
@@ -1,0 +1,152 @@
+<!--
+Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+
+SPDX-License-Identifier: LGPL-2.1-only
+-->
+
+# Plan: desktop windowing and font fixes
+
+This ExecPlan follows `.agent/PLANS.md` and `AGENTS.md`.
+
+## Purpose / Big Picture
+
+Make desktop startup behavior deterministic and make the SDL desktop window
+interact correctly with the pointer while preserving the existing application
+contract. At the same time, make Skia and legacy font loading explicit,
+deterministic, and testable, including bold text.
+
+The observable result is a desktop window whose initial size, position,
+fullscreen state, and environment overrides are resolved before SDL creates
+the window, while mouse clicks can pass through when the desktop backend
+requests it. Font loading must select the intended renderer path, resolve TTF
+files reproducibly, reject invalid inputs safely, maintain stable typeface
+indices, and honor bold measurement and rendering.
+
+## Working Set and Resume Protocol
+
+The implementation is concentrated in:
+
+- `TotalCrossVM/src/init/startup.c`, `tcsdl.cpp`, and
+  `nm/ui/WindowStartup.*` for startup resolution;
+- `TotalCrossVM/src/nm/ui/skia/*`, `font_Font.c`,
+  `font_FontMetrics.c`, and PalmFont helpers for font behavior;
+- native startup, ABI, integration, and Skia fixtures under
+  `TotalCrossVM/src/tests` and `TotalCrossVM/src/nm/ui/skia`;
+- `TotalCrossSDK/src/main/java/totalcross/ui/font/Font.java` for the
+  public font documentation and renderer-facing contract.
+
+Build output, downloaded dependencies, test logs, and screenshots remain
+outside versioned source. On resumption, inspect the current worktree,
+the active source paths, and the most recent focused validation log before
+expanding the investigation.
+
+## Progress
+
+- [ ] Consolidate desktop startup resolution and its native tests.
+- [ ] Isolate SDL click-through configuration.
+- [ ] Separate and harden Skia/legacy font loading and bold behavior.
+- [ ] Harden shared native ABI boundaries and retain compatibility-sensitive
+  public APIs.
+- [ ] Run the acceptance matrix and write the final factual report.
+
+## Current Architecture and Scope
+
+Desktop startup is resolved through the native path
+`startup.c` → `desktopWindowStartupOptions` →
+`windowLoadStartupEnvironment()` →
+`windowResolveStartupConfiguration()` → `TCSDL_Init()`. The resolver
+combines command-line `/scr`, `TC_WIDTH`, `TC_HEIGHT`, application
+attributes, display metrics, fullscreen settings, and platform defaults before
+SDL window creation. Command-line startup options must not leak into the
+application argument list.
+
+The native UI layer shares C structs and declarations with C++, Objective-C,
+and Objective-C++. These boundaries require stable fixed-width data fields and
+integer boolean representations where a signature crosses languages. Public
+third-party callback ABIs are compatibility-sensitive and remain outside this
+change unless their internal-only status is proven.
+
+Font creation has two renderer paths. Skia needs deterministic TTF resolution,
+validation, registry ownership, stable indices, and explicit bold propagation.
+The legacy PalmFont path must remain separate and preserve its own fallback
+rules. The Java-facing `Font` contract documents the distinction.
+
+## Plan of Work
+
+1. Resolve desktop startup behavior in one cohesive implementation. Add
+   explicit fullscreen/default handling, command-line and environment
+   precedence, sizing, centering, and argument stripping. Keep the
+   WindowStartup ABI representation compatible across C and C++ from this
+   change.
+2. Add the SDL mouse click-through hint as an isolated backend change.
+3. Consolidate the font loading work: separate Skia and legacy loading,
+   resolve TTF files deterministically, validate inputs, preserve fallback,
+   and update the focused font fixtures.
+4. Harden the Skia typeface registry with dynamic storage, stable indices,
+   invalid-TTF rejection, and registry tests.
+5. Complete bold propagation through measurement and drawing, reset state
+   correctly, update pixel and metric fixtures, document the final
+   `Font` behavior, and remove obsolete warnings.
+6. Harden only proven internal C/C++/Objective-C boundaries. Replace shared
+   boolean fields with fixed-width values, normalize internal boolean
+   parameters and results, and add compile-time and runtime ABI probes.
+7. Produce one final report describing the delivered changes, decisions,
+   limitations, and evidence.
+
+## Decision Log
+
+- Keep `/scr` as the highest-priority explicit startup size source; use
+  environment values independently for width and height when command-line
+  sizing is absent or partial.
+- Represent shared boolean fields as `uint8` and cross-language boolean
+  parameters/results as `int32`, converting at the implementation boundary.
+- Preserve public native-library, scanner, synchronization, and other
+  exported callback ABIs when their compatibility surface cannot be proven
+  internal.
+- Keep Skia typeface registration owned by the native registry rather than
+  relying on a fixed-size table or renderer-specific lookup side effects.
+
+## Validation and Acceptance
+
+Use focused validation first, then the smallest complete family that proves
+the behavior:
+
+- build the native VM and the C/C++ ABI probes on macOS arm64;
+- run the existing WindowStartup tests and a real SDL integration harness;
+- verify explicit, centered, environment-only, and mixed startup dimensions;
+- verify command-line option removal from the application arguments;
+- run the Skia surface/typeface fixture with a real TTF, including plain and
+  bold measurement/rendering;
+- run the relevant SDK build and font-focused checks;
+- run copyright-header validation and `git diff --check`.
+
+Record full tool output in temporary logs and report compact outcomes only.
+Platform builds requiring unavailable credentials, pods, or external services
+must be identified as limitations rather than inferred as passing.
+
+## Risks and Open Questions
+
+- Platform-specific startup defaults can differ between Linux, Windows,
+  macOS, and mobile targets; keep platform selection explicit and testable.
+- Static archives and language linkage can hide ABI mismatches until a target
+  is linked, so both compile-time layout assertions and mixed-language
+  runtime probes are required.
+- Font files may be missing, malformed, or duplicated across search paths;
+  fallback and rejection behavior must remain deterministic.
+- Rewriting renderer state can accidentally alter legacy rendering; fixtures
+  must cover both renderer paths where available.
+
+## Idempotence and Recovery
+
+All source changes are ordinary commits and can be rebuilt from the merge-base.
+Generated build directories, fetched dependencies, logs, and screenshots are
+not source inputs and must not be committed. Before any history operation,
+preserve the current branch pointer and local untracked work. If a validation
+fails, retain its log, repair only the affected slice, and rerun the focused
+command.
+
+## Outcomes & Retrospective
+
+Complete this section in the final report rather than during the initial
+implementation. It must distinguish implemented behavior from platform work
+that could not be executed locally.

--- a/.agent/reports/fix-windowing-clickthrough-fontname.md
+++ b/.agent/reports/fix-windowing-clickthrough-fontname.md
@@ -1,0 +1,91 @@
+<!--
+Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+
+SPDX-License-Identifier: LGPL-2.1-only
+-->
+
+# Report: desktop windowing and font fixes
+
+## Result
+
+The branch history was consolidated into one initial plan, six focused
+implementation commits, and one final report. The functional tree is
+equivalent to the completed implementation before reconstruction. The only
+source-tree differences are the deliberate replacement of intermediate
+planning files with the consolidated plan and this report.
+
+## Objectives and delivered changes
+
+Desktop startup now has one explicit resolution path from native startup
+options through environment loading, shared configuration resolution, and SDL
+window creation. It covers fullscreen defaults and overrides, `/scr`,
+`TC_WIDTH`, `TC_HEIGHT`, partial dimensions, centering, sizing, source
+precedence, and removal of startup options before application arguments are
+delivered. The SDL click-through hint is isolated in its own change.
+
+The font pipeline keeps Skia and legacy PalmFont loading separate. Skia TTF
+lookup is deterministic, malformed font input is rejected safely, fallback is
+preserved, and the typeface registry owns stable dynamic indices. Bold state
+is propagated through measurement and rendering, and stale bold state is not
+retained between calls. The final Java `Font` documentation describes the
+renderer-specific behavior and no longer carries the obsolete warning.
+
+Shared native structures use fixed-width boolean fields where they cross C and
+C++. Internal C/C++/Objective-C boolean parameters and results use `int32`
+with normalization at the implementation boundary. Compile-time layout
+assertions and mixed-language runtime probes cover the changed contracts.
+Compatibility-sensitive public native-library, scanner, synchronization, and
+`TC_API` boolean ABIs were intentionally left unchanged.
+
+## Problems found and decisions
+
+The original branch mixed implementation commits with replacement fixes and
+multiple plans, states, and editorial reports. The intermediate planning
+files were removed from the new branch history. Startup-related ABI changes
+were folded into the startup commit, the SDL hint remained isolated, font
+work was grouped by loading, registry, and bold behavior, and general ABI
+hardening was kept in its own final implementation commit.
+
+The final ABI changes were limited to proven internal boundaries. Boolean
+fields and signatures confined to one language were retained. External
+callback contracts were not changed because their compatibility surface could
+not be proven internal.
+
+## Validation
+
+All validation below ran on macOS arm64 against the reconstructed tree:
+
+- CMake configuration and Ninja build of `tcvm`, WindowStartup tests,
+  integration test, ABI probes, and Skia fixture: passed.
+- `window_startup_native_test`: passed.
+- C and C++ WindowStartup ABI probes: passed.
+- C and C++ GraphicsPrimitives layout probes and bridge probe for every
+  boolean combination: passed.
+- Explicit `window_startup_integration_test`: passed.
+  - `/scr -1,-1,1024,768`: `1024x768`.
+  - `/scr -2,-2,800,600`: `800x600`, centered.
+  - `/scr` precedence over environment: `1024x768`.
+  - Both environment dimensions: `900x700`.
+  - Width-only environment: `900x558`.
+  - Height-only environment: `864x700`.
+  - Application arguments contained `App.tcz /cmd appArg`; `/scr` was
+    absent.
+- Skia fixture with a real Arial TTF: registry, plain/bold style, and surface
+  copy assertions passed.
+- SDK distribution build using `gradlew-agent dist -x test`: passed.
+- Copyright-header validation and `git diff --check`: passed.
+
+The full iOS application archive was not part of this local acceptance run;
+that flow requires external CocoaPods and platform application dependencies.
+The native macOS build and all focused cross-language fixtures completed.
+
+## Worktree and recovery
+
+No push or force-push was performed. The original branch pointer was backed up
+locally before reconstruction. Generated build output, dependency checkouts,
+logs, screenshots, and unrelated pre-existing untracked work remain outside
+the new history and are not part of the deliverable.
+
+## Final outcome
+
+RESULTADO: PASSOU

--- a/TotalCrossSDK/src/main/java/totalcross/ui/font/Font.java
+++ b/TotalCrossSDK/src/main/java/totalcross/ui/font/Font.java
@@ -1,6 +1,7 @@
 // Copyright (C) 1998, 1999 Wabasoft <www.wabasoft.com>   
 // Copyright (C) 2000-2013 SuperWaba Ltda.
-// Copyright (C) 2014-2020 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -18,12 +19,17 @@ import totalcross.util.Hashtable;
  * <ol>
  * <li> To see if the font you created is installed in the target device, query its name after
  * the creation. If the font is not found, its name is changed to match the default font.
- * <li> You may create new fonts based on the TrueType fonts using the tool tc.tools.FontGenerator.
+ * <li> Legacy renderers use generated TotalCross/PalmFont font archives, while Skia renderers use
+ * TrueType (TTF) resources.
+ * <li> A Skia TTF resource may be stored in any TCZ that the VM has already loaded. This generic
+ * TCZ resource storage is different from the generated font-TCZ format used by legacy renderers.
+ * <li> You may create new legacy fonts based on TrueType fonts using the tool
+ * tc.tools.FontGenerator.
  * <li> There are two font sets: the one before TotalCross 1.3, and the one after TotalCross 1.3. The font set is
  * choosen using Settings.useNewFont.
  * <li> The default font size is based in the device's DPI. This allows the font to have the same physical size
  * in inches on different devices.
- * <li> In JavaSE you can choose the default font size passing <code>/fontsize &lt;size&gt;</code> as argument, 
+ * <li> In JavaSE you can choose the default font size passing <code>/fontsize &lt;size&gt;</code> as argument,
  * before the application's name.
  * </ol>
  */
@@ -39,9 +45,10 @@ public final class Font {
   public Object hv_UserFont;
   public FontMetrics fm;
   
+  /** Internal renderer handle. It is not a supported public API. */
   public int skiaIndex = -1;
 
-  /** The default font name. If a specified font is not found, this one is used instead. 
+  /** The default font name. If a specified font is not found, this one is used instead.
    */
   public static final String DEFAULT = "TCFont";
   /** The minimum font size: 7. */
@@ -132,10 +139,13 @@ public final class Font {
 
   /**
    * Gets the instance of a font of the given name, style and size. Font styles are defined
-   * in this class. Font.DEFAULT will be used if the font is not installed on the device. 
-   * This method can be used to check if the created font is in fact installed on the device.
-   * @param name Font.DEFAULT is the default font. You must install other fonts if you want to use them.
-   * @param boldStyle If true, a bold font is used. Otherwise, a plain font is used.
+   * in this class. Font.DEFAULT will be used if the requested font resource is not found.
+   * This method can be used to check if the created font is in fact available on the device.
+   * On legacy renderers, name resolution uses generated TotalCross/PalmFont archives. On Skia,
+   * it uses TTF resources, including resources in TCZ files already loaded by the VM.
+   * @param name Font.DEFAULT is the default font. Other names identify installed font resources.
+   * @param boldStyle If true, the renderer uses its bold behavior. This does not require a
+   * particular bold TTF filename.
    * @param size If you want a text bigger than the standard size, use Font.NORMAL_SIZE+x; or if you want
    * a text smaller than the standard size, use Font.NORMAL_SIZE-x. Size is adjusted to be in the range
    * <code>Font.MIN_FONT_SIZE ... Font.MAX_FONT_SIZE</code>. That is, passing a value out of the bounds won't throw an exception, 
@@ -166,8 +176,6 @@ public final class Font {
   /** Returns this font as Bold */
   @Deprecated
   public Font asBold() {
-    if (name.equals(DEFAULT))
-      System.err.println("System font does not support bold version");
     return getFont(name, true, size, skiaIndex); // guich@450_36: cache the bolded font - guich@580_10: cached now in the Hashtable.
   }
 

--- a/TotalCrossVM/CMakeLists.txt
+++ b/TotalCrossVM/CMakeLists.txt
@@ -916,6 +916,80 @@ if(TC_BUILD_NATIVE_STARTUP_TEST)
     CXX_EXTENSIONS NO
   )
 
+  add_executable(graphics_primitives_abi_c_test
+    ${TC_SRCDIR}/tests/graphics_primitives_abi_c_test.c
+  )
+  target_include_directories(graphics_primitives_abi_c_test PRIVATE
+    "${TC_PLATFORM_GENERATED_INCLUDE_DIR}"
+    "${TC_SRCDIR}"
+  )
+  target_compile_definitions(graphics_primitives_abi_c_test PRIVATE
+    TC_PLATFORM_CONFIGURED=1
+  )
+  target_link_libraries(graphics_primitives_abi_c_test PRIVATE
+    SDL2::SDL2
+    Skia::Skia
+  )
+  target_compile_options(graphics_primitives_abi_c_test PRIVATE
+    $<$<OR:$<C_COMPILER_ID:GNU>,$<C_COMPILER_ID:Clang>,$<C_COMPILER_ID:AppleClang>>:-Wall;-Wextra;-Werror>
+  )
+  set_target_properties(graphics_primitives_abi_c_test PROPERTIES
+    C_STANDARD 11
+    C_STANDARD_REQUIRED YES
+    C_EXTENSIONS NO
+  )
+
+  add_executable(graphics_primitives_abi_cpp_test
+    ${TC_SRCDIR}/tests/graphics_primitives_abi_cpp_test.cpp
+  )
+  target_include_directories(graphics_primitives_abi_cpp_test PRIVATE
+    "${TC_PLATFORM_GENERATED_INCLUDE_DIR}"
+    "${TC_SRCDIR}"
+  )
+  target_compile_definitions(graphics_primitives_abi_cpp_test PRIVATE
+    TC_PLATFORM_CONFIGURED=1
+  )
+  target_link_libraries(graphics_primitives_abi_cpp_test PRIVATE
+    SDL2::SDL2
+    Skia::Skia
+  )
+  target_compile_options(graphics_primitives_abi_cpp_test PRIVATE
+    $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wall;-Wextra;-Werror>
+  )
+  set_target_properties(graphics_primitives_abi_cpp_test PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED YES
+    CXX_EXTENSIONS NO
+  )
+
+  add_executable(graphics_primitives_abi_bridge_test
+    ${TC_SRCDIR}/tests/graphics_primitives_abi_bridge.c
+    ${TC_SRCDIR}/tests/graphics_primitives_abi_bridge_test.cpp
+  )
+  target_include_directories(graphics_primitives_abi_bridge_test PRIVATE
+    "${TC_PLATFORM_GENERATED_INCLUDE_DIR}"
+    "${TC_SRCDIR}"
+  )
+  target_compile_definitions(graphics_primitives_abi_bridge_test PRIVATE
+    TC_PLATFORM_CONFIGURED=1
+  )
+  target_link_libraries(graphics_primitives_abi_bridge_test PRIVATE
+    SDL2::SDL2
+    Skia::Skia
+  )
+  target_compile_options(graphics_primitives_abi_bridge_test PRIVATE
+    $<$<OR:$<C_COMPILER_ID:GNU>,$<C_COMPILER_ID:Clang>,$<C_COMPILER_ID:AppleClang>>:-Wall;-Wextra;-Werror>
+    $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wall;-Wextra;-Werror>
+  )
+  set_target_properties(graphics_primitives_abi_bridge_test PROPERTIES
+    C_STANDARD 11
+    C_STANDARD_REQUIRED YES
+    C_EXTENSIONS NO
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED YES
+    CXX_EXTENSIONS NO
+  )
+
   if(TC_TARGET_MACOS AND TC_WINDOWING_SDL)
     add_executable(window_startup_integration_test
       ${TC_SRCDIR}/tests/window_startup_integration_test.c

--- a/TotalCrossVM/CMakeLists.txt
+++ b/TotalCrossVM/CMakeLists.txt
@@ -946,6 +946,34 @@ if(TC_BUILD_NATIVE_STARTUP_TEST)
         PROPERTY LINK_FLAGS " -Wl,-dead_strip"
       )
     endif()
+
+    if(TC_RENDERER_SKIA)
+      add_executable(skia_surface_test
+        ${TC_SRCDIR}/nm/ui/skia/skia_surface_test.cpp
+      )
+      target_include_directories(skia_surface_test PRIVATE
+        "${TC_PLATFORM_GENERATED_INCLUDE_DIR}"
+        "${TC_SRCDIR}"
+      )
+      target_compile_definitions(skia_surface_test PRIVATE
+        TC_PLATFORM_CONFIGURED=1
+      )
+      add_dependencies(skia_surface_test tcvm)
+      target_link_libraries(skia_surface_test PRIVATE
+        "$<TARGET_FILE:tcvm>"
+        SDL2::SDL2
+        Skia::Skia
+      )
+      set_target_properties(skia_surface_test PROPERTIES
+        BUILD_RPATH "${CMAKE_CURRENT_BINARY_DIR}"
+        CXX_STANDARD 11
+        CXX_STANDARD_REQUIRED YES
+        CXX_EXTENSIONS NO
+      )
+      target_compile_options(skia_surface_test PRIVATE
+        $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wall;-Wextra>
+      )
+    endif()
   endif()
 endif()
 

--- a/TotalCrossVM/CMakeLists.txt
+++ b/TotalCrossVM/CMakeLists.txt
@@ -877,6 +877,76 @@ if(TC_BUILD_NATIVE_STARTUP_TEST)
   target_compile_options(window_startup_native_test PRIVATE
     $<$<OR:$<C_COMPILER_ID:GNU>,$<C_COMPILER_ID:Clang>,$<C_COMPILER_ID:AppleClang>>:-Wall;-Wextra>
   )
+
+  add_executable(window_startup_abi_c_test
+    ${TC_SRCDIR}/tests/window_startup_abi_c_test.c
+  )
+  target_include_directories(window_startup_abi_c_test PRIVATE
+    "${TC_PLATFORM_GENERATED_INCLUDE_DIR}"
+    "${TC_SRCDIR}"
+  )
+  target_compile_definitions(window_startup_abi_c_test PRIVATE
+    TC_PLATFORM_CONFIGURED=1
+  )
+  target_compile_options(window_startup_abi_c_test PRIVATE
+    $<$<OR:$<C_COMPILER_ID:GNU>,$<C_COMPILER_ID:Clang>,$<C_COMPILER_ID:AppleClang>>:-Wall;-Wextra;-Werror>
+  )
+  set_target_properties(window_startup_abi_c_test PROPERTIES
+    C_STANDARD 11
+    C_STANDARD_REQUIRED YES
+    C_EXTENSIONS NO
+  )
+
+  add_executable(window_startup_abi_cpp_test
+    ${TC_SRCDIR}/tests/window_startup_abi_cpp_test.cpp
+  )
+  target_include_directories(window_startup_abi_cpp_test PRIVATE
+    "${TC_PLATFORM_GENERATED_INCLUDE_DIR}"
+    "${TC_SRCDIR}"
+  )
+  target_compile_definitions(window_startup_abi_cpp_test PRIVATE
+    TC_PLATFORM_CONFIGURED=1
+  )
+  target_compile_options(window_startup_abi_cpp_test PRIVATE
+    $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wall;-Wextra;-Werror>
+  )
+  set_target_properties(window_startup_abi_cpp_test PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED YES
+    CXX_EXTENSIONS NO
+  )
+
+  if(TC_TARGET_MACOS AND TC_WINDOWING_SDL)
+    add_executable(window_startup_integration_test
+      ${TC_SRCDIR}/tests/window_startup_integration_test.c
+    )
+    target_include_directories(window_startup_integration_test PRIVATE
+      "${TC_PLATFORM_GENERATED_INCLUDE_DIR}"
+      "${TC_SRCDIR}"
+      "${TC_SRCDIR}/tcvm"
+    )
+    target_compile_definitions(window_startup_integration_test PRIVATE
+      TC_PLATFORM_CONFIGURED=1
+    )
+    add_dependencies(window_startup_integration_test tcvm)
+    target_link_libraries(window_startup_integration_test PRIVATE
+      "$<TARGET_FILE:tcvm>"
+      SDL2::SDL2
+      Skia::Skia
+    )
+    set_target_properties(window_startup_integration_test PROPERTIES
+      BUILD_RPATH "${CMAKE_CURRENT_BINARY_DIR}"
+    )
+    target_compile_options(window_startup_integration_test PRIVATE
+      $<$<OR:$<C_COMPILER_ID:GNU>,$<C_COMPILER_ID:Clang>,$<C_COMPILER_ID:AppleClang>>:-Wall;-Wextra>
+      $<$<OR:$<C_COMPILER_ID:GNU>,$<C_COMPILER_ID:Clang>,$<C_COMPILER_ID:AppleClang>>:-ffunction-sections;-fdata-sections>
+    )
+    if(CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
+      set_property(TARGET window_startup_integration_test APPEND_STRING
+        PROPERTY LINK_FLAGS " -Wl,-dead_strip"
+      )
+    endif()
+  endif()
 endif()
 
 if(TC_ENABLE_COMPILED_DISPATCH)

--- a/TotalCrossVM/src/event/Event.c
+++ b/TotalCrossVM/src/event/Event.c
@@ -75,7 +75,7 @@ sleep:
    return ok;
 }
 
-bool isEventAvailable()
+int32 isEventAvailable()
 {  
    Sleep(1); // avoid 100% cpu - important on Android!
    return privateIsEventAvailable();
@@ -134,16 +134,16 @@ void postEvent(Context currentContext, TotalCrossUiEvent type, int32 key, int32 
    }
 }
 
-void postOnMinimizeOrRestore(bool minimized)
-{                                  
-   isMinimized = minimized;
+void postOnMinimizeOrRestore(int32 minimized)
+{
+   isMinimized = minimized != 0;
    if (mainClass != null)
       executeMethod(lifeContext, (isMinimized ? onMinimize : onRestore), mainClass); // events are always posted to the main execution line
 }
 
-bool initEvent()
+int32 initEvent()
 {
-   return privateInitEvent();
+   return privateInitEvent() != 0;
 }
 
 void destroyEvent()

--- a/TotalCrossVM/src/event/darwin/event.m
+++ b/TotalCrossVM/src/event/darwin/event.m
@@ -15,7 +15,7 @@
 #include "event.h"
 #undef Class
 
-extern bool keepRunning;
+extern int32 keepRunning;
 static bool mainThreadSuspended;
 
 bool allowMainThread()
@@ -23,12 +23,12 @@ bool allowMainThread()
    return !mainThreadSuspended;
 }
 
-bool iphone_privateIsEventAvailable()
+int32 iphone_privateIsEventAvailable()
 {
-   return [DEVICE_CTX->_mainview isEventAvailable];
+   return [DEVICE_CTX->_mainview isEventAvailable] ? 1 : 0;
 }
 
-void screenChange(Context currentContext, int32 newWidth, int32 newHeight, int32 hRes, int32 vRes, bool nothingChanged); // rotate the screen
+void screenChange(Context currentContext, int32 newWidth, int32 newHeight, int32 hRes, int32 vRes, int32 nothingChanged); // rotate the screen
 void setEditText(Context currentContext, TCObject control, NSString *str);
 
 void iphone_privatePumpEvent(Context currentContext)
@@ -113,9 +113,9 @@ void iphone_privatePumpEvent(Context currentContext)
    }
 }
 
-bool iphone_privateInitEvent()
+int32 iphone_privateInitEvent()
 {
-   return true;
+   return 1;
 }
 
 void iphone_privateDestroyEvent()
@@ -126,5 +126,5 @@ void notifyStopVM() // fdie@ the launcher mainthread notifies the vm thread to s
 {
    mainThreadSuspended = true;
    printf("notifyStopVM\n");
-   keepRunning = false;
+   keepRunning = 0;
 }

--- a/TotalCrossVM/src/event/darwin/event_c.h
+++ b/TotalCrossVM/src/event/darwin/event_c.h
@@ -1,5 +1,6 @@
 // Copyright (C) 2000-2013 SuperWaba Ltda.
-// Copyright (C) 2014-2020 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -17,9 +18,9 @@
 extern "C" {
 #endif
 
-bool iphone_privateIsEventAvailable       ();
+int32 iphone_privateIsEventAvailable       ();
 void iphone_privatePumpEvent              ();
-bool iphone_privateInitEvent();
+int32 iphone_privateInitEvent();
 void iphone_privateDestroyEvent();
 
 void notifyStopVM();

--- a/TotalCrossVM/src/event/event.h
+++ b/TotalCrossVM/src/event/event.h
@@ -1,5 +1,6 @@
 // Copyright (C) 2000-2013 SuperWaba Ltda.
-// Copyright (C) 2014-2020 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -14,9 +15,9 @@ extern "C" {
 
 void mainEventLoop(Context currentContext);
 void pumpEvents(Context currentContext);
-bool isEventAvailable();
+int32 isEventAvailable();
 
-bool initEvent();
+int32 initEvent();
 void destroyEvent();
 
 /// hardware events that can be sent by the vm to the running instance
@@ -62,7 +63,7 @@ typedef struct
 
 /// post an event to the running Java application. If mods is -1, the asynch mods will be retrieved; otherwise, pass the mods given in the key event
 void postEvent(Context currentContext, TotalCrossUiEvent type, int32 key, int32 x, int32 y, int32 mods); // guich@tc126_70
-void postOnMinimizeOrRestore(bool isMinimized);
+void postOnMinimizeOrRestore(int32 isMinimized);
 
 #ifdef __cplusplus
 }

--- a/TotalCrossVM/src/event/win/event_c.h
+++ b/TotalCrossVM/src/event/win/event_c.h
@@ -15,7 +15,7 @@
 
 
 void markWholeScreenDirty(Context currentContext);
-void screenChange(Context currentContext, int32 newWidth, int32 newHeight, int hRes, int vRes, bool nothingChanged);
+void screenChange(Context currentContext, int32 newWidth, int32 newHeight, int hRes, int vRes, int32 nothingChanged);
 void getScreenSize(int32 *w, int32* h); // ui/win/gfx_Graphics_c.h
 
 static void hideWinCEStuff()

--- a/TotalCrossVM/src/init/globals.c
+++ b/TotalCrossVM/src/init/globals.c
@@ -49,7 +49,7 @@ bool isMainWindow = false;   // extends MainWindow ?
 #if TC_OS_DESKTOP
 TCWindowStartupOptions desktopWindowStartupOptions = {
    false, -1, -1, -1, -1, -1, -1,
-   TC_INITIAL_WINDOW_NORMAL, false, 0
+   TC_INITIAL_WINDOW_NORMAL, TC_FULLSCREEN_UNSET, TC_FULLSCREEN_UNSET, 0
 };
 #endif
 #if defined(ANDROID)

--- a/TotalCrossVM/src/init/globals.c
+++ b/TotalCrossVM/src/init/globals.c
@@ -217,7 +217,7 @@ jmethodID jfindTCZ;
 
 // event.c
 bool appExitThrown = false;
-bool keepRunning = true; // don't remove from here!
+int32 keepRunning = 1; // don't remove from here!
 bool eventsInitialized = false;
 int32 nextTimerTick = 0;
 bool isDragging = false;

--- a/TotalCrossVM/src/init/globals.h
+++ b/TotalCrossVM/src/init/globals.h
@@ -188,7 +188,7 @@ extern jmethodID jreadTCZ, jfindTCZ;
 
 // event.c
 extern bool appExitThrown;
-extern bool keepRunning;
+extern int32 keepRunning;
 extern bool eventsInitialized;
 extern int32 nextTimerTick;
 extern bool isDragging;

--- a/TotalCrossVM/src/init/startup.c
+++ b/TotalCrossVM/src/init/startup.c
@@ -186,15 +186,19 @@ static bool loadLibraries(Context currentContext, CharP path, bool first)
    return err == NO_ERROR;
 }
 
-static void checkFullScreenPlatform() // guich@tc120_59
+static bool checkFullScreenPlatform() // guich@tc120_59
 {
    if (*tcSettings.fullScreenPlatformsPtr)
    {
       char plat[100];
       String2CharPBuf(*tcSettings.fullScreenPlatformsPtr, plat);
       if (xstrstr(plat, platform) == null)    // if the platform is not inside, set to false
+      {
          *tcSettings.isFullScreenPtr = false;
+         return false;
+      }
    }
+   return true;
 }
 
 #define ISNOTSIGNED 0
@@ -226,17 +230,27 @@ TC_API int32 startProgram(Context currentContext)
    else
    if (currentContext->thrownException == null && keepRunning)
    {
-      checkFullScreenPlatform();
 #if TC_OS_DESKTOP
+      TCWindowStartupOptions startupOptions;
+      TCFullscreenSetting settingsFullscreen;
+      int32 fullscreen;
+      bool platformAllowed = checkFullScreenPlatform();
+
+      startupOptions = desktopWindowStartupOptions;
+      windowLoadStartupEnvironment(&startupOptions);
+      settingsFullscreen = platformAllowed && *tcSettings.isFullScreenPtr
+         ? TC_FULLSCREEN_TRUE
+         : !platformAllowed ? TC_FULLSCREEN_FALSE : TC_FULLSCREEN_UNSET;
+      windowResolveFullscreen(&startupOptions, settingsFullscreen, &fullscreen);
 #if !TC_WINDOWING_SDL
-      if (desktopWindowStartupOptions.initialState == TC_INITIAL_WINDOW_FULLSCREEN
-         || (desktopWindowStartupOptions.initialState == TC_INITIAL_WINDOW_NORMAL && *tcSettings.isFullScreenPtr))
+      if (fullscreen)
          setFullScreen();
 #else
-      if (desktopWindowStartupOptions.initialState == TC_INITIAL_WINDOW_NORMAL && *tcSettings.isFullScreenPtr)
+      if (fullscreen && settingsFullscreen == TC_FULLSCREEN_TRUE)
          TCSDL_SetFullscreen(true);
 #endif
 #else
+      checkFullScreenPlatform();
       if (*tcSettings.isFullScreenPtr)
          setFullScreen();
 #endif

--- a/TotalCrossVM/src/init/tcsdl.cpp
+++ b/TotalCrossVM/src/init/tcsdl.cpp
@@ -203,6 +203,7 @@ int32 TCSDL_Init(ScreenSurface screen, const char *title, int32 fullScreen, int1
 #if __APPLE__
    SDL_SetHint(SDL_HINT_TRACKPAD_IS_TOUCH_ONLY, "1");
 #endif
+   SDL_SetHint(SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, "1");
 
    if (SDL_Init(SDL_INIT_VIDEO) != 0)
    {

--- a/TotalCrossVM/src/init/tcsdl.cpp
+++ b/TotalCrossVM/src/init/tcsdl.cpp
@@ -133,7 +133,7 @@ static bool selectPixelFormat(ScreenSurface screen)
    return false;
 }
 
-bool TCSDL_SetPixelFormatRequest(const char *value)
+int32 TCSDL_SetPixelFormatRequest(const char *value)
 {
    TCSDLRequestedPixelFormat parsed;
    if (!parsePixelFormat(value, &parsed))
@@ -143,7 +143,7 @@ bool TCSDL_SetPixelFormatRequest(const char *value)
    return true;
 }
 
-bool TCSDL_QueryWindowMetrics(ScreenSurface screen, TScreenConfiguration *configuration)
+int32 TCSDL_QueryWindowMetrics(ScreenSurface screen, TScreenConfiguration *configuration)
 {
    int logicalWidth, logicalHeight;
    int physicalWidth, physicalHeight;
@@ -187,7 +187,7 @@ static int32 sdlWindowPosition(TCWindowPositionMode mode, int32 position)
       : mode == TC_WINDOW_POSITION_EXPLICIT ? position : SDL_WINDOWPOS_UNDEFINED;
 }
 
-bool TCSDL_Init(ScreenSurface screen, const char *title, bool fullScreen, int16 appTczAttr)
+int32 TCSDL_Init(ScreenSurface screen, const char *title, int32 fullScreen, int16 appTczAttr)
 {
    SDL_DisplayMode displayMode;
    SDL_Rect displayBounds;
@@ -254,7 +254,7 @@ bool TCSDL_Init(ScreenSurface screen, const char *title, bool fullScreen, int16 
       display.usableHeight = display.height;
 
    options.appTczAttr = appTczAttr;
-   options.legacyFullscreen = fullScreen;
+   options.initialFullscreen = fullScreen != 0 ? TC_FULLSCREEN_TRUE : TC_FULLSCREEN_UNSET;
    windowLoadStartupEnvironment(&options);
    if (!windowResolveStartupConfiguration(&options, &display, &startupConfiguration))
    {
@@ -323,14 +323,14 @@ bool TCSDL_Init(ScreenSurface screen, const char *title, bool fullScreen, int16 
    return true;
 }
 
-bool TCSDL_SetFullscreen(bool fullscreen)
+int32 TCSDL_SetFullscreen(int32 fullscreen)
 {
    if (window == NULL)
       return false;
-   return SDL_SetWindowFullscreen(window, fullscreen ? SDL_WINDOW_FULLSCREEN : 0) == 0;
+   return SDL_SetWindowFullscreen(window, fullscreen != 0 ? SDL_WINDOW_FULLSCREEN : 0) == 0;
 }
 
-bool TCSDL_SetWindowSize(int32 width, int32 height)
+int32 TCSDL_SetWindowSize(int32 width, int32 height)
 {
    if (window == NULL || width <= 0 || height <= 0)
       return false;
@@ -338,7 +338,7 @@ bool TCSDL_SetWindowSize(int32 width, int32 height)
    return true;
 }
 
-bool TCSDL_CreateBackBuffer(ScreenSurface screen)
+int32 TCSDL_CreateBackBuffer(ScreenSurface screen)
 {
    if (screen == NULL || SCREEN_EX(screen) == NULL || renderer == NULL
       || screen->screenW <= 0 || screen->screenH <= 0)

--- a/TotalCrossVM/src/init/tcsdl.h
+++ b/TotalCrossVM/src/init/tcsdl.h
@@ -19,13 +19,13 @@ extern "C" {
     #endif
     #include "GraphicsPrimitives.h"
 
-    bool TCSDL_Init(ScreenSurface screen, const char* title, bool fullScreen, int16 appTczAttr);
-    bool TCSDL_SetPixelFormatRequest(const char* value);
-    bool TCSDL_SetFullscreen(bool fullscreen);
+    int32 TCSDL_Init(ScreenSurface screen, const char* title, int32 fullScreen, int16 appTczAttr);
+    int32 TCSDL_SetPixelFormatRequest(const char* value);
+    int32 TCSDL_SetFullscreen(int32 fullscreen);
     // Returns whether the resize request was submitted; SDL event metrics confirm its result.
-    bool TCSDL_SetWindowSize(int32 width, int32 height);
-    bool TCSDL_QueryWindowMetrics(ScreenSurface screen, TScreenConfiguration* configuration);
-    bool TCSDL_CreateBackBuffer(ScreenSurface screen);
+    int32 TCSDL_SetWindowSize(int32 width, int32 height);
+    int32 TCSDL_QueryWindowMetrics(ScreenSurface screen, TScreenConfiguration* configuration);
+    int32 TCSDL_CreateBackBuffer(ScreenSurface screen);
     void TCSDL_DestroyBackBuffer(ScreenSurface screen);
     void TCSDL_DestroyWindow(ScreenSurface screen);
     void TCSDL_UpdateTexture(int w, int h, int pitch,void *pixels);

--- a/TotalCrossVM/src/init/win/startup_c.h
+++ b/TotalCrossVM/src/init/win/startup_c.h
@@ -191,7 +191,7 @@ static bool isWakeUpCall(CharP args)
    return false;
 }
 
-void screenChange(Context currentContext, int32 newWidth, int32 newHeight, int32 hRes, int32 vRes, bool nothingChanged); // GraphicsPrimitives_c.h
+void screenChange(Context currentContext, int32 newWidth, int32 newHeight, int32 hRes, int32 vRes, int32 nothingChanged); // GraphicsPrimitives_c.h
 
 void appSetFullScreen();
 

--- a/TotalCrossVM/src/nm/map/GoogleMaps.c
+++ b/TotalCrossVM/src/nm/map/GoogleMaps.c
@@ -1,5 +1,6 @@
 // Copyright (C) 2000-2013 SuperWaba Ltda.
-// Copyright (C) 2014-2020 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -10,7 +11,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-    bool iphone_mapsShowAddress(char* addr, int flags);
+    int32 iphone_mapsShowAddress(char* addr, int flags);
 #ifdef __cplusplus
 };
 #endif

--- a/TotalCrossVM/src/nm/sys/Vm.c
+++ b/TotalCrossVM/src/nm/sys/Vm.c
@@ -1,5 +1,6 @@
 // Copyright (C) 2000-2013 SuperWaba Ltda.
-// Copyright (C) 2014-2020 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -18,7 +19,7 @@
 
 void vmVibrate(int32 ms);
 #ifdef darwin
-int32 vmExec(TCHARP szCommand, TCHARP szArgs, int32 launchCode, bool wait);
+int32 vmExec(TCHARP szCommand, TCHARP szArgs, int32 launchCode, int32 wait);
 #endif
 
 CompatibilityResult areArraysCompatible(Context currentContext, TCObject array, CharP ident)

--- a/TotalCrossVM/src/nm/sys/darwin/Registry_c.m
+++ b/TotalCrossVM/src/nm/sys/darwin/Registry_c.m
@@ -94,7 +94,7 @@ void privateSetBlob(Context c, int32 hk, TCHARP key, TCHARP value, uint8* data, 
       throwException(c, ExceptionClass, "Cannot write value.");
 }
 
-bool privateDelete(int32 hk, TCHARP key, TCHARP value)
+int32 privateDelete(int32 hk, TCHARP key, TCHARP value)
 {
    CFStringRef cfValue = CFStringCreateWithCString(kCFAllocatorDefault, value, kCFStringEncodingUTF8);
    CFPreferencesSetAppValue(cfValue, NULL, kCFPreferencesCurrentApplication);

--- a/TotalCrossVM/src/nm/sys/darwin/Vm_c.m
+++ b/TotalCrossVM/src/nm/sys/darwin/Vm_c.m
@@ -14,7 +14,7 @@
 #undef Class
 
 
-int32 vmExec(TCHARP szCommand, TCHARP szArgs, int32 launchCode, bool wait)
+int32 vmExec(TCHARP szCommand, TCHARP szArgs, int32 launchCode, int32 wait)
 {
    bool ret = false;
    NSString *args = [NSString stringWithFormat:@"%s", szArgs];
@@ -38,7 +38,7 @@ int32 vmExec(TCHARP szCommand, TCHARP szArgs, int32 launchCode, bool wait)
    else
    if (strEq(szCommand,"url"))
       ret = [[UIApplication sharedApplication] openURL:[NSURL URLWithString: args]];
-   if (!wait)
+   if (wait == 0)
       keepRunning = false;
     return ret ? 0 : 1;
 }

--- a/TotalCrossVM/src/nm/sys/posix/Registry_c.h
+++ b/TotalCrossVM/src/nm/sys/posix/Registry_c.h
@@ -1,5 +1,6 @@
 // Copyright (C) 2000-2013 SuperWaba Ltda.
-// Copyright (C) 2014-2020 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -13,7 +14,7 @@ void privateGetBlob(NMParams p, int32 hk, TCHARP key, TCHARP value);
 void privateSetInt(Context c, int32 hk, TCHARP key, TCHARP value, int32 data);
 void privateSetString(Context c, int32 hk, TCHARP key, TCHARP value, CharP data);
 void privateSetBlob(Context c, int32 hk, TCHARP key, TCHARP value, uint8* data, int32 len);
-bool privateDelete(int32 hk, TCHARP key, TCHARP value);
+int32 privateDelete(int32 hk, TCHARP key, TCHARP value);
 TCObject privateList(Context c, int32 hk, TCHARP key);
 
 #else

--- a/TotalCrossVM/src/nm/ui/GraphicsPrimitives.h
+++ b/TotalCrossVM/src/nm/ui/GraphicsPrimitives.h
@@ -82,8 +82,8 @@ typedef struct TScreenConfiguration
    double fontScale;
    int32 deviceFontHeight;
    uint32 generation;
-   bool surfaceReady;
-   bool nativeSurfaceChanged;
+   uint8 surfaceReady;
+   uint8 nativeSurfaceChanged;
 } TScreenConfiguration;
 
 typedef struct TScreenSurface // represents a device-dependant surface, there's only ONE per application
@@ -99,7 +99,7 @@ typedef struct TScreenSurface // represents a device-dependant surface, there's 
    int32 deviceFontHeight;
    uint32 surfaceGeneration;
    uint32 pendingChangeFlags;
-   bool surfaceReady;
+   uint8 surfaceReady;
    void *extension; // platform specific data
    int32 shiftY;
    uint32 pixelformat;
@@ -115,7 +115,7 @@ void repaintActiveWindows(Context currentContext);
 ScreenChangeFlags screenApplyConfiguration(ScreenSurface screenSurface, const TScreenConfiguration *configuration);
 ScreenChangeFlags screenConsumePendingChanges(ScreenSurface screenSurface);
 void screenChangeCommitted(Context currentContext, ScreenChangeFlags changes);
-void screenChange(Context currentContext, int32 newWidth, int32 newHeight, int32 hRes, int32 vRes, bool nothingChanged);
+void screenChange(Context currentContext, int32 newWidth, int32 newHeight, int32 hRes, int32 vRes, int32 nothingChanged);
 
 /**
  * The device context points a structure containing platform specific data

--- a/TotalCrossVM/src/nm/ui/GraphicsPrimitivesText_c.h
+++ b/TotalCrossVM/src/nm/ui/GraphicsPrimitivesText_c.h
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
-#ifndef SKIA_H
+#if !TC_RENDERER_SKIA
 #define INTERP(j,f,shift) (j + (((f - j) * transparency) >> shift)) & 0xFF
 
 static uint8 _ands8[8] = {0x80,0x40,0x20,0x10,0x08,0x04,0x02,0x01};

--- a/TotalCrossVM/src/nm/ui/GraphicsPrimitivesText_c.h
+++ b/TotalCrossVM/src/nm/ui/GraphicsPrimitivesText_c.h
@@ -377,15 +377,21 @@ static void drawText(Context currentContext, TCObject g, JCharP text, int32 chrC
    TCObject fontObj = Graphics_font(g);
    double fontSize = Font_size(fontObj) * Graphics_fontScale(g);
    int32 typefaceIndex = Font_skiaIndex(fontObj);
+   bool bold = (Font_style(fontObj) & 1) != 0;
    double ascent, descent, leading;
 
    x += Graphics_transX(g);
    y += Graphics_transY(g);
-   skia_fontMetrics(typefaceIndex, fontSize, &ascent, &descent, &leading);
+   skia_fontMetrics(typefaceIndex, fontSize, bold, &ascent, &descent, &leading);
    skia_setClip(skiaSurfaceForGraphics(g), Get_Clip(g));
-   skia_drawText(skiaSurfaceForGraphics(g), text, chrCount * sizeof(JChar), x, y + ascent, foreColor | Graphics_alpha(g), justifyWidth, fontSize, typefaceIndex);
+   skia_drawText(skiaSurfaceForGraphics(g), text, chrCount * sizeof(JChar), x,
+                 y + ascent, foreColor | Graphics_alpha(g), justifyWidth,
+                 fontSize, typefaceIndex, bold);
    skia_restoreClip(skiaSurfaceForGraphics(g));
 
-   markDirty(currentContext, g, x, y, (int32)ceil(skia_stringWidthD(text, chrCount * sizeof(JChar), typefaceIndex, fontSize)), (int32)ceil(ascent + descent + leading));
+   markDirty(currentContext, g, x, y,
+             (int32)ceil(skia_stringWidthD(text, chrCount * sizeof(JChar),
+                                           typefaceIndex, fontSize, bold)),
+             (int32)ceil(ascent + descent + leading));
 }
 #endif

--- a/TotalCrossVM/src/nm/ui/GraphicsPrimitives_c.h
+++ b/TotalCrossVM/src/nm/ui/GraphicsPrimitives_c.h
@@ -183,7 +183,7 @@ void screenChangeCommitted(Context currentContext, ScreenChangeFlags changes)
    repaintActiveWindows(mainContext);
 }
 
-void screenChange(Context currentContext, int32 newWidth, int32 newHeight, int32 hRes, int32 vRes, bool nothingChanged) // rotate the screen
+void screenChange(Context currentContext, int32 newWidth, int32 newHeight, int32 hRes, int32 vRes, int32 nothingChanged) // rotate the screen
 {
    TScreenConfiguration configuration;
    ScreenChangeFlags changes;
@@ -200,7 +200,7 @@ void screenChange(Context currentContext, int32 newWidth, int32 newHeight, int32
    configuration.surfaceReady = true;
 
    changes = screenApplyConfiguration(&screen, &configuration);
-   if (nothingChanged)
+   if (nothingChanged != 0)
       changes = (ScreenChangeFlags)(changes & ~SCREEN_CHANGE_RECREATE_SURFACE);
    screenConsumePendingChanges(&screen);
    screenChangeCommitted(currentContext, changes);

--- a/TotalCrossVM/src/nm/ui/PalmFont_c.h
+++ b/TotalCrossVM/src/nm/ui/PalmFont_c.h
@@ -720,12 +720,15 @@ UserFont loadUserFontFromFontObj(Context currentContext, TCObject fontObj, JChar
 
 int32 getJCharWidth(Context currentContext, TCObject fontObj, JChar ch) {
   int32 fontSize = Font_size(fontObj);
-  return skia_stringWidth(&ch, sizeof(JChar), Font_skiaIndex(fontObj), fontSize);
+  return skia_stringWidth(&ch, sizeof(JChar), Font_skiaIndex(fontObj), fontSize,
+                          (Font_style(fontObj) & 1) != 0);
 }
 
 int32 getJCharPWidth(Context currentContext, TCObject fontObj, JCharP s, int32 len) {
    int32 fontSize = Font_size(fontObj);
-    return len == 0? 0: skia_stringWidth(s, len * sizeof(JChar), Font_skiaIndex(fontObj), fontSize);
+    return len == 0 ? 0 : skia_stringWidth(s, len * sizeof(JChar),
+                                           Font_skiaIndex(fontObj), fontSize,
+                                           (Font_style(fontObj) & 1) != 0);
 }
 #else
 int32 getJCharWidth(Context currentContext, TCObject fontObj, JChar ch)

--- a/TotalCrossVM/src/nm/ui/PalmFont_c.h
+++ b/TotalCrossVM/src/nm/ui/PalmFont_c.h
@@ -34,6 +34,9 @@ bool fontInit(Context currentContext)
    maxFontSize = *maxfs;
    minFontSize = *minfs;
    normalFontSize = *normal;
+#if TC_RENDERER_SKIA
+   return true;
+#else
    fontsHeap = heapCreate();
    if (fontsHeap == null)
       return false;
@@ -53,6 +56,7 @@ bool fontInit(Context currentContext)
       htFree(&htBaseFonts, null);
    }
    return defaultFont != null;
+#endif
 }
 
 static void destroyUF(int32 i32, VoidP ptr)
@@ -67,6 +71,7 @@ static void destroyUF(int32 i32, VoidP ptr)
 
 void fontDestroy()
 {
+#if !TC_RENDERER_SKIA
    VoidPs *list, *head;
    htTraverse(&htBaseFonts, destroyUF);
 
@@ -84,6 +89,7 @@ void fontDestroy()
    heapDestroy(fontsHeap);
    htFree(&htUF, null);
    htFree(&htBaseFonts, null);
+#endif
 }
 
 static FontFile findFontFile(char* fontName)
@@ -424,7 +430,7 @@ Cleanup: /* CLEANUP */
    return fSuccess ? ob0 : null;
 }
 
-#ifndef SKIA_H
+#if !TC_RENDERER_SKIA
 #ifdef __gl2_h_
 bool lowmemDevice;
 int32 glLoadTexture(Context currentContext, TCObject img, int32* textureId, Pixel *pixels, int32 width, int32 height, int32 onlyAlpha);
@@ -504,7 +510,7 @@ static void reset1font(int32 i32, VoidP ptr)
 
 void resetFontTexture()
 {
-#ifndef SKIA_H
+#if !TC_RENDERER_SKIA
    #ifdef __gl2_h_
    htTraverse(&htBaseFonts, reset1font);
    #endif

--- a/TotalCrossVM/src/nm/ui/Window.c
+++ b/TotalCrossVM/src/nm/ui/Window.c
@@ -26,7 +26,7 @@
  #error No Window backend selected
 #endif
 
-bool windowBackendSetSize(int32 width, int32 height)
+int32 windowBackendSetSize(int32 width, int32 height)
 {
    return windowBackendSetSizeImpl(width, height);
 }

--- a/TotalCrossVM/src/nm/ui/Window.h
+++ b/TotalCrossVM/src/nm/ui/Window.h
@@ -15,7 +15,7 @@
 extern "C" {
 #endif
 
-bool windowBackendSetSize(int32 width, int32 height);
+int32 windowBackendSetSize(int32 width, int32 height);
 
 #ifdef __cplusplus
 }

--- a/TotalCrossVM/src/nm/ui/WindowStartup.c
+++ b/TotalCrossVM/src/nm/ui/WindowStartup.c
@@ -5,7 +5,22 @@
 #include "WindowStartup.h"
 #include "../../tcvm/tcvm.h"
 
+#include <stdio.h>
 #include <stdlib.h>
+
+static bool equalsIgnoreCase(const char *left, const char *right)
+{
+   while (*left != '\0' && *right != '\0')
+   {
+      char leftChar = *left >= 'A' && *left <= 'Z' ? *left + ('a' - 'A') : *left;
+      char rightChar = *right >= 'A' && *right <= 'Z' ? *right + ('a' - 'A') : *right;
+      if (leftChar != rightChar)
+         return false;
+      left++;
+      right++;
+   }
+   return *left == '\0' && *right == '\0';
+}
 
 static int32 environmentDimension(const char *name)
 {
@@ -33,14 +48,37 @@ void windowResetCommandLineOptions(TCWindowStartupOptions *options)
 
 void windowLoadStartupEnvironment(TCWindowStartupOptions *options)
 {
+#if TC_OS_DESKTOP
+   const char *fullscreen;
+#endif
+
    if (options == null)
       return;
    options->environmentWidth = -1;
    options->environmentHeight = -1;
+   options->environmentFullscreen = TC_FULLSCREEN_UNSET;
 #if TC_OS_DESKTOP
    options->environmentWidth = environmentDimension("TC_WIDTH");
    options->environmentHeight = environmentDimension("TC_HEIGHT");
+   fullscreen = getenv("TC_FULLSCREEN");
+   if (fullscreen != null)
+   {
+      options->environmentFullscreen = windowParseFullscreenEnvironment(fullscreen);
+      if (options->environmentFullscreen == TC_FULLSCREEN_UNSET)
+         fprintf(stderr, "Ignoring invalid TC_FULLSCREEN; expected true or false (or 1 or 0).\n");
+   }
 #endif
+}
+
+TCFullscreenSetting windowParseFullscreenEnvironment(const char *value)
+{
+   if (value == null)
+      return TC_FULLSCREEN_UNSET;
+   if (equalsIgnoreCase(value, "true") || equalsIgnoreCase(value, "1"))
+      return TC_FULLSCREEN_TRUE;
+   if (equalsIgnoreCase(value, "false") || equalsIgnoreCase(value, "0"))
+      return TC_FULLSCREEN_FALSE;
+   return TC_FULLSCREEN_UNSET;
 }
 
 static bool hasTczSize(int16 appTczAttr)
@@ -82,9 +120,59 @@ static TCWindowPositionMode resolvePositionMode(int32 position)
       : TC_WINDOW_POSITION_DEFAULT;
 }
 
-bool windowResolveStartupConfiguration(
+static TCWindowStartupPlatform currentPlatform(void)
+{
+#if TC_OS_LINUX
+#if TC_ARCH_ARM_FAMILY
+   return TC_WINDOW_PLATFORM_LINUX_ARM;
+#else
+   return TC_WINDOW_PLATFORM_LINUX_X86;
+#endif
+#elif TC_OS_WINDOWS
+   return TC_WINDOW_PLATFORM_WINDOWS;
+#elif TC_OS_MACOS
+   return TC_WINDOW_PLATFORM_MACOS;
+#else
+   return TC_WINDOW_PLATFORM_LINUX_X86;
+#endif
+}
+
+static bool platformDefaultFullscreen(TCWindowStartupPlatform platform)
+{
+   return platform == TC_WINDOW_PLATFORM_LINUX_ARM;
+}
+
+static bool resolveFullscreen(
+   const TCWindowStartupOptions *options,
+   TCFullscreenSetting settingsFullscreen,
+   TCWindowStartupPlatform platform)
+{
+   if (options->initialState == TC_INITIAL_WINDOW_FULLSCREEN)
+      return true;
+   if (options->initialState == TC_INITIAL_WINDOW_MAXIMIZED)
+      return false;
+   if (options->environmentFullscreen != TC_FULLSCREEN_UNSET)
+      return options->environmentFullscreen == TC_FULLSCREEN_TRUE;
+   if (settingsFullscreen != TC_FULLSCREEN_UNSET)
+      return settingsFullscreen == TC_FULLSCREEN_TRUE;
+   return platformDefaultFullscreen(platform);
+}
+
+int32 windowResolveFullscreen(
+   const TCWindowStartupOptions *options,
+   TCFullscreenSetting settingsFullscreen,
+   int32 *fullscreen)
+{
+   if (options == null || fullscreen == null)
+      return 0;
+   *fullscreen = resolveFullscreen(options, settingsFullscreen, currentPlatform()) != 0;
+   return 1;
+}
+
+int32 windowResolveStartupConfigurationForPlatform(
    const TCWindowStartupOptions *options,
    const TCDisplayMetrics *display,
+   TCWindowStartupPlatform platform,
    TCWindowStartupConfiguration *configuration)
 {
    int32 tczWidth;
@@ -97,7 +185,7 @@ bool windowResolveStartupConfiguration(
 
    if (options == null || display == null || configuration == null
       || display->width <= 0 || display->height <= 0)
-      return false;
+      return 0;
 
    resolveTczSize(options->appTczAttr, display, &tczWidth, &tczHeight);
    tczSizeSource = hasTczSize(options->appTczAttr);
@@ -106,9 +194,7 @@ bool windowResolveStartupConfiguration(
       || tczSizeSource;
    defaultWidth = display->width / 2;
    defaultHeight = display->height / 2;
-   configuration->fullscreen = options->initialState == TC_INITIAL_WINDOW_FULLSCREEN
-      || (options->initialState == TC_INITIAL_WINDOW_NORMAL
-         && options->legacyFullscreen);
+   configuration->fullscreen = resolveFullscreen(options, options->initialFullscreen, platform);
    configuration->maximized = !configuration->fullscreen
       && options->initialState == TC_INITIAL_WINDOW_MAXIMIZED;
    configuration->resizable = (options->appTczAttr & ATTR_RESIZABLE_WINDOW) != 0
@@ -146,4 +232,13 @@ bool windowResolveStartupConfiguration(
    }
 
    return configuration->width > 0 && configuration->height > 0;
+}
+
+int32 windowResolveStartupConfiguration(
+   const TCWindowStartupOptions *options,
+   const TCDisplayMetrics *display,
+   TCWindowStartupConfiguration *configuration)
+{
+   return windowResolveStartupConfigurationForPlatform(
+      options, display, currentPlatform(), configuration);
 }

--- a/TotalCrossVM/src/nm/ui/WindowStartup.h
+++ b/TotalCrossVM/src/nm/ui/WindowStartup.h
@@ -25,9 +25,24 @@ typedef enum
    TC_WINDOW_POSITION_EXPLICIT
 } TCWindowPositionMode;
 
+typedef enum
+{
+   TC_FULLSCREEN_UNSET,
+   TC_FULLSCREEN_FALSE,
+   TC_FULLSCREEN_TRUE
+} TCFullscreenSetting;
+
+typedef enum
+{
+   TC_WINDOW_PLATFORM_LINUX_ARM,
+   TC_WINDOW_PLATFORM_LINUX_X86,
+   TC_WINDOW_PLATFORM_WINDOWS,
+   TC_WINDOW_PLATFORM_MACOS
+} TCWindowStartupPlatform;
+
 typedef struct
 {
-   bool screenSpecified;
+   uint8 screenSpecified;
    int32 x;
    int32 y;
    int32 width;
@@ -37,7 +52,8 @@ typedef struct
    int32 environmentHeight;
 
    TCInitialWindowState initialState;
-   bool legacyFullscreen;
+   TCFullscreenSetting initialFullscreen;     // Settings.isFullScreen before app startup
+   TCFullscreenSetting environmentFullscreen; // TC_FULLSCREEN override
    int16 appTczAttr;
 } TCWindowStartupOptions;
 
@@ -59,16 +75,26 @@ typedef struct
    int32 x;
    int32 y;
 
-   bool fullscreen;
-   bool maximized;
-   bool resizable;
+   uint8 fullscreen;
+   uint8 maximized;
+   uint8 resizable;
 } TCWindowStartupConfiguration;
 
 void windowResetCommandLineOptions(TCWindowStartupOptions *options);
 void windowLoadStartupEnvironment(TCWindowStartupOptions *options);
-bool windowResolveStartupConfiguration(
+TCFullscreenSetting windowParseFullscreenEnvironment(const char *value);
+int32 windowResolveFullscreen(
+   const TCWindowStartupOptions *options,
+   TCFullscreenSetting settingsFullscreen,
+   int32 *fullscreen);
+int32 windowResolveStartupConfiguration(
    const TCWindowStartupOptions *options,
    const TCDisplayMetrics *display,
+   TCWindowStartupConfiguration *configuration);
+int32 windowResolveStartupConfigurationForPlatform(
+   const TCWindowStartupOptions *options,
+   const TCDisplayMetrics *display,
+   TCWindowStartupPlatform platform,
    TCWindowStartupConfiguration *configuration);
 
 #ifdef __cplusplus

--- a/TotalCrossVM/src/nm/ui/Window_test.h
+++ b/TotalCrossVM/src/nm/ui/Window_test.h
@@ -18,7 +18,7 @@ TESTCASE(windowResolveStartupConfiguration)
       int32 environmentWidth;
       int32 environmentHeight;
       TCInitialWindowState initialState;
-      bool legacyFullscreen;
+      bool initialFullscreen;
       int32 expectedWidth;
       int32 expectedHeight;
       TCWindowPositionMode expectedXMode;
@@ -114,7 +114,9 @@ TESTCASE(windowResolveStartupConfiguration)
       options.environmentWidth = cases[i].environmentWidth;
       options.environmentHeight = cases[i].environmentHeight;
       options.initialState = cases[i].initialState;
-      options.legacyFullscreen = cases[i].legacyFullscreen;
+      options.initialFullscreen = cases[i].initialFullscreen
+         ? TC_FULLSCREEN_TRUE : TC_FULLSCREEN_UNSET;
+      options.environmentFullscreen = TC_FULLSCREEN_UNSET;
       options.appTczAttr = cases[i].appTczAttr;
       if (!windowResolveStartupConfiguration(&options, &display, &configuration)
          || configuration.width != cases[i].expectedWidth
@@ -130,6 +132,88 @@ TESTCASE(windowResolveStartupConfiguration)
          TEST_FAIL(tc, "Startup window configuration policy case failed");
          goto finish;
       }
+   }
+#else
+   TEST_SKIP;
+#endif
+   finish: ;
+}
+
+static bool startupFullscreenCase(
+   TCWindowStartupPlatform platform,
+   TCFullscreenSetting initialFullscreen,
+   TCFullscreenSetting environmentFullscreen,
+   TCInitialWindowState initialState,
+   bool expectedFullscreen)
+{
+   TCDisplayMetrics display = { 1600, 1000, 1600, 700 };
+   TCWindowStartupOptions options;
+   TCWindowStartupConfiguration configuration;
+
+   xmemzero(&options, sizeof(options));
+   options.x = -1;
+   options.y = -1;
+   options.environmentWidth = -1;
+   options.environmentHeight = -1;
+   options.initialState = initialState;
+   options.initialFullscreen = initialFullscreen;
+   options.environmentFullscreen = environmentFullscreen;
+   return windowResolveStartupConfigurationForPlatform(
+      &options, &display, platform, &configuration)
+      && configuration.fullscreen == expectedFullscreen;
+}
+
+TESTCASE(windowResolveStartupFullscreenPolicy)
+{
+#if TC_OS_DESKTOP
+   struct FullscreenCase
+   {
+      TCWindowStartupPlatform platform;
+      TCFullscreenSetting initialFullscreen;
+      TCFullscreenSetting environmentFullscreen;
+      TCInitialWindowState initialState;
+      bool expectedFullscreen;
+   } cases[] = {
+      { TC_WINDOW_PLATFORM_LINUX_ARM, TC_FULLSCREEN_UNSET, TC_FULLSCREEN_UNSET,
+        TC_INITIAL_WINDOW_NORMAL, true },
+      { TC_WINDOW_PLATFORM_LINUX_X86, TC_FULLSCREEN_UNSET, TC_FULLSCREEN_UNSET,
+        TC_INITIAL_WINDOW_NORMAL, false },
+      { TC_WINDOW_PLATFORM_WINDOWS, TC_FULLSCREEN_UNSET, TC_FULLSCREEN_UNSET,
+        TC_INITIAL_WINDOW_NORMAL, false },
+      { TC_WINDOW_PLATFORM_MACOS, TC_FULLSCREEN_UNSET, TC_FULLSCREEN_UNSET,
+        TC_INITIAL_WINDOW_NORMAL, false },
+      { TC_WINDOW_PLATFORM_LINUX_ARM, TC_FULLSCREEN_TRUE, TC_FULLSCREEN_UNSET,
+        TC_INITIAL_WINDOW_NORMAL, true },
+      { TC_WINDOW_PLATFORM_LINUX_ARM, TC_FULLSCREEN_FALSE, TC_FULLSCREEN_UNSET,
+        TC_INITIAL_WINDOW_NORMAL, false },
+      { TC_WINDOW_PLATFORM_LINUX_X86, TC_FULLSCREEN_TRUE, TC_FULLSCREEN_UNSET,
+        TC_INITIAL_WINDOW_NORMAL, true },
+      { TC_WINDOW_PLATFORM_LINUX_X86, TC_FULLSCREEN_FALSE, TC_FULLSCREEN_UNSET,
+        TC_INITIAL_WINDOW_NORMAL, false },
+      { TC_WINDOW_PLATFORM_LINUX_ARM, TC_FULLSCREEN_FALSE, TC_FULLSCREEN_TRUE,
+        TC_INITIAL_WINDOW_NORMAL, true },
+      { TC_WINDOW_PLATFORM_LINUX_ARM, TC_FULLSCREEN_TRUE, TC_FULLSCREEN_FALSE,
+        TC_INITIAL_WINDOW_NORMAL, false },
+      { TC_WINDOW_PLATFORM_LINUX_ARM, TC_FULLSCREEN_FALSE, TC_FULLSCREEN_FALSE,
+        TC_INITIAL_WINDOW_FULLSCREEN, true },
+   };
+   int32 i;
+
+   for (i = 0; i < (int32)(sizeof(cases) / sizeof(cases[0])); i++)
+      if (!startupFullscreenCase(cases[i].platform, cases[i].initialFullscreen,
+         cases[i].environmentFullscreen, cases[i].initialState,
+         cases[i].expectedFullscreen))
+      {
+         TEST_FAIL(tc, "Fullscreen startup policy case failed");
+         goto finish;
+      }
+
+   if (windowParseFullscreenEnvironment("TrUe") != TC_FULLSCREEN_TRUE
+      || windowParseFullscreenEnvironment("FaLsE") != TC_FULLSCREEN_FALSE
+      || windowParseFullscreenEnvironment("invalid") != TC_FULLSCREEN_UNSET)
+   {
+      TEST_FAIL(tc, "TC_FULLSCREEN value parsing policy case failed");
+      goto finish;
    }
 #else
    TEST_SKIP;

--- a/TotalCrossVM/src/nm/ui/backend/graphics/gles/gfx_Graphics_c.h
+++ b/TotalCrossVM/src/nm/ui/backend/graphics/gles/gfx_Graphics_c.h
@@ -22,7 +22,7 @@
 #endif
 
 #if defined(darwin) || (defined(TC_OS_IOS) && TC_OS_IOS)
-bool isIpad;
+int32 isIpad;
 #else
 bool isIpad = false;
 #endif
@@ -30,9 +30,9 @@ bool isIpad = false;
 static bool surfaceWillChange;
 
 #if defined(darwin) || (defined(TC_OS_IOS) && TC_OS_IOS)
-void iphone_privateSetSurfaceWillChange(bool willChange)
+void iphone_privateSetSurfaceWillChange(int32 willChange)
 {
-   surfaceWillChange = willChange;
+   surfaceWillChange = willChange != 0;
 }
 #endif
 
@@ -46,7 +46,7 @@ static void resetGlobals()
    lastAlphaMask = -1;
 }
 
-bool initGLES(ScreenSurface screenSurface);
+int32 initGLES(ScreenSurface screenSurface);
 
 void setTimerInterval(int32 t);
 int32 desiredglShiftY;
@@ -243,7 +243,7 @@ JNIEXPORT void JNICALL Java_totalcross_Launcher4A_nativePrepareForResume(
 #endif
 
 #if TC_GLES_ANDROID
-bool initGLES(ScreenSurface screenSurface)
+int32 initGLES(ScreenSurface screenSurface)
 {
    const EGLint attribs[] = {
       EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,

--- a/TotalCrossVM/src/nm/ui/backend/graphics/software/gfx_Graphics_c.h
+++ b/TotalCrossVM/src/nm/ui/backend/graphics/software/gfx_Graphics_c.h
@@ -23,9 +23,6 @@ void graphicsScreenChange(int32 w, int32 h)
 
 bool graphicsStartup(ScreenSurface screen, int16 appTczAttr)
 {
-#ifdef __arm__
-   *(tcSettings.isFullScreenPtr)=true;
-#endif
 #if TC_WINDOWING_SDL
    if (!TCSDL_Init(screen, exeName, *(tcSettings.isFullScreenPtr), appTczAttr))
       return false;

--- a/TotalCrossVM/src/nm/ui/darwin/WindowServices_c.h
+++ b/TotalCrossVM/src/nm/ui/darwin/WindowServices_c.h
@@ -6,24 +6,24 @@
 extern "C" {
 #endif
 
-void windowSetSIP(Context currentContext, int32 sipOption, TCObject control, bool numeric);
-bool windowGetSIP(void);
+void windowSetSIP(Context currentContext, int32 sipOption, TCObject control, int32 numeric);
+int32 windowGetSIP(void);
 void windowGetSafeAreaInsets(int32 *top, int32 *left, int32 *bottom, int32 *right);
 
 #ifdef __cplusplus
 }
 #endif
 
-static bool windowPlatformIsSIPShown(void)
+static int32 windowPlatformIsSIPShown(void)
 {
-   return windowGetSIP();
+   return windowGetSIP() != 0;
 }
 
 static void windowPlatformSetSIP(
    Context currentContext,
    int32 sipOption,
    TCObject control,
-   bool numeric)
+   int32 numeric)
 {
    windowSetSIP(currentContext, sipOption, control, numeric);
 }

--- a/TotalCrossVM/src/nm/ui/darwin/Window_c.m
+++ b/TotalCrossVM/src/nm/ui/darwin/Window_c.m
@@ -17,12 +17,12 @@
 bool allowMainThread();
 extern int isShown; // mainview.m
 
-bool windowGetSIP()
+int32 windowGetSIP()
 {
-   return isShown;
+   return isShown != 0;
 }
 
-void windowSetSIP(Context currentContext, int32 sipOption, TCObject control, bool numeric)
+void windowSetSIP(Context currentContext, int32 sipOption, TCObject control, int32 numeric)
 {
    NSString *str = nil;
    if (control)
@@ -33,7 +33,7 @@ void windowSetSIP(Context currentContext, int32 sipOption, TCObject control, boo
      TValue ret = executeMethod(currentContext, m, control);
 	  str = [ [ NSString alloc ] initWithCharacters: String_charsStart(ret.asObj) length: String_charsLen(ret.asObj) ];
    }
-   SipArguments *args = [ [ SipArguments alloc ] init: SipArgsMake(sipOption, (__bridge id)control, numeric, str) ];
+   SipArguments *args = [ [ SipArguments alloc ] init: SipArgsMake(sipOption, (__bridge id)control, numeric != 0, str) ];
    if (DEVICE_CTX && DEVICE_CTX->_mainview && allowMainThread)
       [ DEVICE_CTX->_mainview  performSelectorOnMainThread:@selector(showSIP:) withObject:args waitUntilDone: YES ];
    if (str) [str release];

--- a/TotalCrossVM/src/nm/ui/darwin/mainview.m
+++ b/TotalCrossVM/src/nm/ui/darwin/mainview.m
@@ -21,7 +21,7 @@ bool allowMainThread();
 int keyboardH;
 UIWindow* window;
 void Sleep(int ms);
-void iphone_privateSetSurfaceWillChange(bool willChange);
+void iphone_privateSetSurfaceWillChange(int32 willChange);
 static bool callingCamera;
 UIWindow* barwindow;
 static bool callingBarcode;
@@ -31,7 +31,7 @@ static char documentChars[4096];
 static char barcode[2048];
 static NSMutableString *currBarcode;
 extern double screenContentScale;
-extern bool isIpad;
+extern int32 isIpad;
 
 @implementation MainViewController
 static bool wasNumeric;
@@ -43,7 +43,7 @@ static bool wasNumeric;
     return self;
 }
 
-bool initGLES(ScreenSurface screen)
+int32 initGLES(ScreenSurface screen)
 {
    deviceCtx = screen->extension = (TScreenSurfaceEx*)malloc(sizeof(TScreenSurfaceEx));
    memset(screen->extension, 0, sizeof(TScreenSurfaceEx));
@@ -78,11 +78,11 @@ bool initGLES(ScreenSurface screen)
    lastOrientationSentToVM = [child_view getOrientation];
 }
 
-bool iosLowMemory;
+int32 iosLowMemory;
 - (void)didReceiveMemoryWarning
 {
    [super didReceiveMemoryWarning];
-   iosLowMemory = true;
+   iosLowMemory = 1;
 }
 
 - (void)sendSafeAreaInsetsIfChanged
@@ -745,10 +745,10 @@ char* iphone_readBarcode(char* mode)
    return barcode;
 }
 
-bool iphone_mapsShowAddress(char* addr, int flags)
+int32 iphone_mapsShowAddress(char* addr, int flags)
 {
    NSString* string = [NSString stringWithFormat:@"%s", addr];
-   return [DEVICE_CTX->_mainview mapsShowAddress:string flags:flags];
+   return [DEVICE_CTX->_mainview mapsShowAddress:string flags:flags] ? 1 : 0;
 }
 
 void iphone_dialNumber(char* number)

--- a/TotalCrossVM/src/nm/ui/font_Font.c
+++ b/TotalCrossVM/src/nm/ui/font_Font.c
@@ -14,61 +14,123 @@
 
 #define PLAIN 0
 #define BOLD 1
+
+#if TC_RENDERER_SKIA
+static bool hasTTFSuffix(CharP name)
+{
+   int32 len = xstrlen(name);
+   return len >= 4 && toLower(name[len - 4]) == '.' && toLower(name[len - 3]) == 't' &&
+      toLower(name[len - 2]) == 't' && toLower(name[len - 1]) == 'f';
+}
+
+static CharP createSkiaResourceName(CharP fontName)
+{
+   CharP baseName = xstrcmp(fontName, "TCFont") == 0 ? "Roboto Regular" : fontName;
+   int32 baseLen = xstrlen(baseName);
+   bool hasSuffix = hasTTFSuffix(baseName);
+   int32 resourceLen = baseLen + (hasSuffix ? 0 : 4);
+   CharP resourceName = (CharP)xmalloc(resourceLen + 1);
+
+   if (resourceName != null)
+   {
+      xstrcpy(resourceName, baseName);
+      if (!hasSuffix)
+         xstrcat(resourceName, ".ttf");
+   }
+   return resourceName;
+}
+
+static int32 loadSkiaTypeface(CharP resourceName)
+{
+   int32 fontIdx = skia_getTypefaceIndex(resourceName);
+   TCZFile file;
+
+   if (fontIdx < 0 && (file = tczGetFile(resourceName, false)) != null)
+   {
+      uint8 *buffer = (uint8 *)xmalloc(file->uncompressedSize);
+      if (buffer != null)
+      {
+         tczRead(file, buffer, file->uncompressedSize);
+         fontIdx = skia_makeTypeface(resourceName, buffer, file->uncompressedSize);
+         xfree(buffer);
+      }
+      tczClose(file);
+   }
+   return fontIdx < 0 ? -1 : fontIdx;
+}
+#endif
+
 //////////////////////////////////////////////////////////////////////////
 TC_API void tufF_fontCreate(NMParams p) // totalcross/ui/font/Font native void fontCreate();
 {
-   char name[128];
-   TCObject obj, fontName;
-   FontFile ff;
+   TCObject obj = p->obj[0];
+#if TC_RENDERER_SKIA
+   CharP name = String2CharP(Font_name(obj));
+   CharP resourceName;
+   int32 fontIdx;
+   bool useDefaultName = false;
 
-   obj = p->obj[0];
-   fontName = Font_name(obj);
-   String2CharPBuf(fontName, name);
-#ifdef SKIA_H
-	// get ttf from tcz
-	TCZFile file;
-   char nameTTF[128];
-   if (xstrcmp(name, "TCFont") == 0) {
-      xstrcpy(nameTTF, "Roboto Regular");
-   } else {
-      xstrcpy(nameTTF, name);
-   }
-   int len = xstrlen(nameTTF);
-   // if it doesn't end with .ttf
-   if(!(nameTTF[len-4] == '.' && nameTTF[len-3] == 't' && nameTTF[len-2] == 't' && nameTTF[len-1] == 'f')) {
-      xstrcat(nameTTF, ".ttf");
-   }
-
-   int32 fontIdx = skia_getTypefaceIndex(nameTTF);
-   if (fontIdx == -1)
+   if (name == null)
    {
-      file = tczGetFile(nameTTF, false);
-      if (file != null)
+      throwException(p->currentContext, OutOfMemoryError, "Cannot convert font name");
+      return;
+   }
+   resourceName = createSkiaResourceName(name);
+   if (resourceName == null)
+   {
+      xfree(name);
+      throwException(p->currentContext, OutOfMemoryError, "Cannot create font resource name");
+      return;
+   }
+   fontIdx = loadSkiaTypeface(resourceName);
+   if (fontIdx < 0)
+   {
+      useDefaultName = true;
+      if (xstrcmp(name, defaultFontName) != 0)
       {
-         uint8 *buffer = (uint8 *)xmalloc(file->uncompressedSize);
-         if (buffer != null)
+         xfree(resourceName);
+         resourceName = createSkiaResourceName(defaultFontName);
+         if (resourceName == null)
          {
-            tczRead(file, buffer, file->uncompressedSize);
-            fontIdx = skia_makeTypeface(
-               nameTTF,
-               buffer,
-               file->uncompressedSize);
-            xfree(buffer);
+            xfree(name);
+            Font_skiaIndex(obj) = -1;
+            throwException(p->currentContext, OutOfMemoryError, "Cannot create default font resource name");
+            return;
          }
-         tczClose(file);
+         fontIdx = loadSkiaTypeface(resourceName);
       }
    }
-   Font_skiaIndex(obj) = fontIdx;
-   // save reference to SkTypeFace at Font_hvUserFont
-#endif  
-   // the only thing we can store here is the font file, because the UserFont will vary for char ranges
-   ff = name[0] == '$' ? null : loadFontFile(name); //  bruno@tc114_37: native fonts always start with '$'
+   if (useDefaultName)
+   {
+      TCObject defaultName = createStringObjectFromCharP(p->currentContext, defaultFontName, xstrlen(defaultFontName));
+      if (defaultName == null)
+      {
+         xfree(resourceName);
+         xfree(name);
+         Font_skiaIndex(obj) = -1;
+         throwException(p->currentContext, OutOfMemoryError, "Cannot set default font name");
+         return;
+      }
+      Font_name(obj) = defaultName;
+      setObjectLock(defaultName, UNLOCKED);
+   }
+   Font_skiaIndex(obj) = fontIdx < 0 ? -1 : fontIdx;
+   xfree(resourceName);
+   xfree(name);
+#else
+   char name[128];
+   FontFile ff;
+
+   String2CharPBuf(Font_name(obj), name);
+   // The only thing we can store here is the font file, because the UserFont
+   // will vary for char ranges.
+   ff = name[0] == '$' ? null : loadFontFile(name); // bruno@tc114_37: native fonts always start with '$'
    if (ff == null)
    {
-      // if the original font file was not found, use the default font.
+      // If the original font file was not found, use the default font.
       ff = defaultFont;
-      // replace the name so the user can know that the font was not found
-      Font_name(obj) = createStringObjectFromCharP(p->currentContext, defaultFontName,6);
+      // Replace the name so the user can know that the font was not found.
+      Font_name(obj) = createStringObjectFromCharP(p->currentContext, defaultFontName, 6);
       setObjectLock(Font_name(obj), UNLOCKED);
    }
    if (Font_hvUserFont(obj) == null) // alloc space for the pointer
@@ -78,6 +140,7 @@ TC_API void tufF_fontCreate(NMParams p) // totalcross/ui/font/Font native void f
    }
    if (Font_hvUserFont(obj) != null) // alloc space for the pointer
       xmoveptr(ARRAYOBJ_START(Font_hvUserFont(obj)), &ff);
+#endif
 }
 
 #ifdef ENABLE_TEST_SUITE

--- a/TotalCrossVM/src/nm/ui/font_FontMetrics.c
+++ b/TotalCrossVM/src/nm/ui/font_FontMetrics.c
@@ -15,7 +15,9 @@ TC_API void tufFM_fontMetricsCreate(NMParams p) // totalcross/ui/font/FontMetric
    TCObject fm = p->obj[0],font = FontMetrics_font(fm);
 #if TC_RENDERER_SKIA
    double ascent, descent, leading;
-   skia_fontMetrics(Font_skiaIndex(font), Font_size(font), &ascent, &descent, &leading);
+   skia_fontMetrics(Font_skiaIndex(font), Font_size(font),
+                    (Font_style(font) & 1) != 0,
+                    &ascent, &descent, &leading);
    FontMetrics_ascentD(fm) = ascent;
    FontMetrics_descentD(fm) = descent;
    FontMetrics_leadingD(fm) = leading;
@@ -37,7 +39,8 @@ TC_API void tufFM_charWidth_c(NMParams p) // totalcross/ui/font/FontMetrics nati
 #if TC_RENDERER_SKIA
    TCObject font = FontMetrics_font(p->obj[0]);
    JChar ch = (JChar)p->i32[0];
-   p->retI = skia_stringWidth(&ch, sizeof(JChar), Font_skiaIndex(font), Font_size(font));
+   p->retI = skia_stringWidth(&ch, sizeof(JChar), Font_skiaIndex(font),
+                              Font_size(font), (Font_style(font) & 1) != 0);
 #else
    p->retI = getJCharWidth(p->currentContext, FontMetrics_font(p->obj[0]), (JChar)p->i32[0]);
 #endif
@@ -47,7 +50,9 @@ TC_API void tufFM_charWidthD_c(NMParams p) // totalcross/ui/font/FontMetrics nat
 {
 #if TC_RENDERER_SKIA
    JChar ch = (JChar)p->i32[0];
-   p->retD = skia_stringWidthD(&ch, sizeof(JChar), Font_skiaIndex(FontMetrics_font(p->obj[0])), Font_size(FontMetrics_font(p->obj[0])));
+   TCObject font = FontMetrics_font(p->obj[0]);
+   p->retD = skia_stringWidthD(&ch, sizeof(JChar), Font_skiaIndex(font),
+                               Font_size(font), (Font_style(font) & 1) != 0);
 #else
    p->retD = getJCharWidth(p->currentContext, FontMetrics_font(p->obj[0]), (JChar)p->i32[0]);
 #endif
@@ -60,7 +65,12 @@ TC_API void tufFM_stringWidth_s(NMParams p) // totalcross/ui/font/FontMetrics na
       throwNullArgumentException(p->currentContext, "s");
 #if TC_RENDERER_SKIA
    else
-      p->retI = skia_stringWidth(String_charsStart(s), String_charsLen(s) * sizeof(JChar), Font_skiaIndex(FontMetrics_font(p->obj[0])), Font_size(FontMetrics_font(p->obj[0])));
+   {
+      TCObject font = FontMetrics_font(p->obj[0]);
+      p->retI = skia_stringWidth(String_charsStart(s), String_charsLen(s) * sizeof(JChar),
+                                  Font_skiaIndex(font), Font_size(font),
+                                  (Font_style(font) & 1) != 0);
+   }
 #else
    else
       p->retI = getJCharPWidth(p->currentContext, FontMetrics_font(p->obj[0]), String_charsStart(s), String_charsLen(s));
@@ -74,7 +84,12 @@ TC_API void tufFM_stringWidthD_s(NMParams p) // totalcross/ui/font/FontMetrics n
       throwNullArgumentException(p->currentContext, "s");
 #if TC_RENDERER_SKIA
    else
-      p->retD = skia_stringWidthD(String_charsStart(s), String_charsLen(s) * sizeof(JChar), Font_skiaIndex(FontMetrics_font(p->obj[0])), Font_size(FontMetrics_font(p->obj[0])));
+   {
+      TCObject font = FontMetrics_font(p->obj[0]);
+      p->retD = skia_stringWidthD(String_charsStart(s), String_charsLen(s) * sizeof(JChar),
+                                  Font_skiaIndex(font), Font_size(font),
+                                  (Font_style(font) & 1) != 0);
+   }
 #else
    else
       p->retD = getJCharPWidth(p->currentContext, FontMetrics_font(p->obj[0]), String_charsStart(s), String_charsLen(s));
@@ -88,7 +103,12 @@ TC_API void tufFM_stringWidthAtSizeD_sd(NMParams p) // totalcross/ui/font/FontMe
       throwNullArgumentException(p->currentContext, "s");
 #if TC_RENDERER_SKIA
    else
-      p->retD = skia_stringWidthD(String_charsStart(s), String_charsLen(s) * sizeof(JChar), Font_skiaIndex(FontMetrics_font(p->obj[0])), p->dbl[0]);
+   {
+      TCObject font = FontMetrics_font(p->obj[0]);
+      p->retD = skia_stringWidthD(String_charsStart(s), String_charsLen(s) * sizeof(JChar),
+                                  Font_skiaIndex(font), p->dbl[0],
+                                  (Font_style(font) & 1) != 0);
+   }
 #else
    else
       p->retD = getJCharPWidth(p->currentContext, FontMetrics_font(p->obj[0]), String_charsStart(s), String_charsLen(s)) * p->dbl[0] / Font_size(FontMetrics_font(p->obj[0]));
@@ -99,7 +119,10 @@ TC_API void tufFM_lineHeightAtSizeD_d(NMParams p) // totalcross/ui/font/FontMetr
 {
 #if TC_RENDERER_SKIA
    double ascent, descent, leading;
-   skia_fontMetrics(Font_skiaIndex(FontMetrics_font(p->obj[0])), p->dbl[0], &ascent, &descent, &leading);
+   TCObject font = FontMetrics_font(p->obj[0]);
+   skia_fontMetrics(Font_skiaIndex(font), p->dbl[0],
+                    (Font_style(font) & 1) != 0,
+                    &ascent, &descent, &leading);
    p->retD = ascent + descent + leading;
 #else
    p->retD = (FontMetrics_heightD(p->obj[0]) ? FontMetrics_heightD(p->obj[0]) : FontMetrics_ascent(p->obj[0]) + FontMetrics_descent(p->obj[0])) * p->dbl[0] / Font_size(FontMetrics_font(p->obj[0]));
@@ -110,7 +133,10 @@ TC_API void tufFM_descentAtSizeD_d(NMParams p) // totalcross/ui/font/FontMetrics
 {
 #if TC_RENDERER_SKIA
    double ascent, descent, leading;
-   skia_fontMetrics(Font_skiaIndex(FontMetrics_font(p->obj[0])), p->dbl[0], &ascent, &descent, &leading);
+   TCObject font = FontMetrics_font(p->obj[0]);
+   skia_fontMetrics(Font_skiaIndex(font), p->dbl[0],
+                    (Font_style(font) & 1) != 0,
+                    &ascent, &descent, &leading);
    p->retD = descent;
 #else
    p->retD = FontMetrics_descentD(p->obj[0]) * p->dbl[0] / Font_size(FontMetrics_font(p->obj[0]));
@@ -121,7 +147,10 @@ TC_API void tufFM_ascentAtSizeD_d(NMParams p) // totalcross/ui/font/FontMetrics 
 {
 #if TC_RENDERER_SKIA
    double ascent, descent, leading;
-   skia_fontMetrics(Font_skiaIndex(FontMetrics_font(p->obj[0])), p->dbl[0], &ascent, &descent, &leading);
+   TCObject font = FontMetrics_font(p->obj[0]);
+   skia_fontMetrics(Font_skiaIndex(font), p->dbl[0],
+                    (Font_style(font) & 1) != 0,
+                    &ascent, &descent, &leading);
    p->retD = ascent;
 #else
    p->retD = FontMetrics_ascentD(p->obj[0]) * p->dbl[0] / Font_size(FontMetrics_font(p->obj[0]));
@@ -138,7 +167,12 @@ TC_API void tufFM_stringWidth_Cii(NMParams p) // totalcross/ui/font/FontMetrics 
    else
    if (checkArrayRange(p->currentContext, charArray, start, count))
 #if TC_RENDERER_SKIA
-      p->retI = skia_stringWidth(((JCharP)ARRAYOBJ_START(charArray))+start, count * sizeof(JChar), Font_skiaIndex(FontMetrics_font(p->obj[0])), Font_size(FontMetrics_font(p->obj[0])));
+   {
+      TCObject font = FontMetrics_font(p->obj[0]);
+      p->retI = skia_stringWidth(((JCharP)ARRAYOBJ_START(charArray)) + start,
+                                 count * sizeof(JChar), Font_skiaIndex(font),
+                                 Font_size(font), (Font_style(font) & 1) != 0);
+   }
 #else
       p->retI = getJCharPWidth(p->currentContext, FontMetrics_font(p->obj[0]), ((JCharP)ARRAYOBJ_START(charArray))+start, count);
 #endif
@@ -151,7 +185,12 @@ TC_API void tufFM_sbWidth_s(NMParams p) // totalcross/ui/font/FontMetrics native
       throwNullArgumentException(p->currentContext, "s"); // throw NPE
 #if TC_RENDERER_SKIA
    else
-      p->retI = skia_stringWidth(StringBuffer_charsStart(s), StringBuffer_count(s) * sizeof(JChar), Font_skiaIndex(FontMetrics_font(p->obj[0])), Font_size(FontMetrics_font(p->obj[0])));
+   {
+      TCObject font = FontMetrics_font(p->obj[0]);
+      p->retI = skia_stringWidth(StringBuffer_charsStart(s), StringBuffer_count(s) * sizeof(JChar),
+                                  Font_skiaIndex(font), Font_size(font),
+                                  (Font_style(font) & 1) != 0);
+   }
 #else
    else
       p->retI = getJCharPWidth(p->currentContext, FontMetrics_font(p->obj[0]), StringBuffer_charsStart(s), StringBuffer_count(s));
@@ -168,7 +207,12 @@ TC_API void tufFM_sbWidth_sii(NMParams p) // totalcross/ui/font/FontMetrics nati
    else
    if (checkArrayRange(p->currentContext, StringBuffer_chars(s), start, count))
 #if TC_RENDERER_SKIA
-      p->retI = skia_stringWidth(StringBuffer_charsStart(s)+start, count * sizeof(JChar), Font_skiaIndex(FontMetrics_font(p->obj[0])), Font_size(FontMetrics_font(p->obj[0])));
+   {
+      TCObject font = FontMetrics_font(p->obj[0]);
+      p->retI = skia_stringWidth(StringBuffer_charsStart(s) + start,
+                                 count * sizeof(JChar), Font_skiaIndex(font),
+                                 Font_size(font), (Font_style(font) & 1) != 0);
+   }
 #else
       p->retI = getJCharPWidth(p->currentContext, FontMetrics_font(p->obj[0]), StringBuffer_charsStart(s)+start, count);
 #endif
@@ -183,7 +227,12 @@ TC_API void tufFM_charWidth_si(NMParams p) // totalcross/ui/font/FontMetrics nat
    else
    if (checkArrayRange(p->currentContext, StringBuffer_chars(s), i, 1)) // check only index "i"
 #if TC_RENDERER_SKIA
-      p->retI = skia_stringWidth(StringBuffer_charsStart(s)+i, sizeof(JChar), Font_skiaIndex(FontMetrics_font(p->obj[0])), Font_size(FontMetrics_font(p->obj[0])));
+   {
+      TCObject font = FontMetrics_font(p->obj[0]);
+      p->retI = skia_stringWidth(StringBuffer_charsStart(s) + i, sizeof(JChar),
+                                 Font_skiaIndex(font), Font_size(font),
+                                 (Font_style(font) & 1) != 0);
+   }
 #else
       p->retI = getJCharWidth(p->currentContext, FontMetrics_font(p->obj[0]), StringBuffer_charsStart(s)[i]);
 #endif

--- a/TotalCrossVM/src/nm/ui/font_Font_test.h
+++ b/TotalCrossVM/src/nm/ui/font_Font_test.h
@@ -1,18 +1,25 @@
 // Copyright (C) 2000-2013 SuperWaba Ltda.
-// Copyright (C) 2014-2020 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
-
-
 
 TCObject testfont;
 TESTCASE(tufF_fontCreate_f) // totalcross/ui/font/Font native static void fontCreate(Font obj);
 {
    TNMParams p;
-   int32 *style, *size, *maxfs, *minfs, *normal, *tabSize;
+   int32 *style, *size, *skiaIndex, *maxfs, *minfs, *normal, *tabSize;
    TCObject *name, *hvUserFont;
    TCClass c;
    TCObject font;
+#if TC_RENDERER_SKIA
+   CharP resourceName;
+   CharP missingName;
+   TCObject customFont;
+   TCObject missingFont;
+   char longName[160];
+   int32 i;
+#endif
    font = createObject(currentContext, "totalcross.ui.font.Font");
    setObjectLock(font, UNLOCKED);
    ASSERT1_EQUALS(NotNull, font);
@@ -27,6 +34,10 @@ TESTCASE(tufF_fontCreate_f) // totalcross/ui/font/Font native static void fontCr
    size = getInstanceFieldInt(font, "size", "totalcross.ui.font.Font");
    ASSERT1_EQUALS(NotNull, size);
    ASSERT2_EQUALS(Ptr, size, &Font_size(font));
+
+   skiaIndex = getInstanceFieldInt(font, "skiaIndex", "totalcross.ui.font.Font");
+   ASSERT1_EQUALS(NotNull, skiaIndex);
+   ASSERT2_EQUALS(Ptr, skiaIndex, &Font_skiaIndex(font));
 
    name = getInstanceFieldObject(font, "name", "totalcross.ui.font.Font");
    ASSERT1_EQUALS(NotNull, name);
@@ -48,7 +59,33 @@ TESTCASE(tufF_fontCreate_f) // totalcross/ui/font/Font native static void fontCr
    ASSERT1_EQUALS(True, *normal > 0);
    ASSERT1_EQUALS(True, *tabSize > 0);
 
+#if TC_RENDERER_SKIA
+   resourceName = createSkiaResourceName("a");
+   ASSERT2_EQUALS(Sz, resourceName, "a.ttf");
+   xfree(resourceName);
+   resourceName = createSkiaResourceName("a.ttf");
+   ASSERT2_EQUALS(Sz, resourceName, "a.ttf");
+   xfree(resourceName);
+   resourceName = createSkiaResourceName("a.TTF");
+   ASSERT2_EQUALS(Sz, resourceName, "a.TTF");
+   xfree(resourceName);
+   resourceName = createSkiaResourceName("a.TtF");
+   ASSERT2_EQUALS(Sz, resourceName, "a.TtF");
+   xfree(resourceName);
+   resourceName = createSkiaResourceName("TCFont");
+   ASSERT2_EQUALS(Sz, resourceName, "Roboto Regular.ttf");
+   xfree(resourceName);
+   for (i = 0; i < 159; i++)
+      longName[i] = 'x';
+   longName[159] = 0;
+   resourceName = createSkiaResourceName(longName);
+   ASSERT2_EQUALS(I32, xstrlen(resourceName), 163);
+   xfree(resourceName);
+#endif
+
+#if !TC_RENDERER_SKIA
    ASSERT1_EQUALS(NotNull, defaultFont);
+#endif
 
    // fill in a font and test if it loads
    Font_name(font) = createStringObjectFromCharP(currentContext, "TCFont",-1);
@@ -58,7 +95,40 @@ TESTCASE(tufF_fontCreate_f) // totalcross/ui/font/Font native static void fontCr
    p.currentContext = currentContext;
    p.obj = &font;
    tufF_fontCreate(&p);
+#if TC_RENDERER_SKIA
+   ASSERT1_EQUALS(Null, *hvUserFont);
+
+   if (skia_getTypefaceIndex("Roboto Regular.ttf") >= 0)
+   {
+      customFont = createObject(currentContext, "totalcross.ui.font.Font");
+      ASSERT1_EQUALS(NotNull, customFont);
+      setObjectLock(customFont, UNLOCKED);
+      Font_name(customFont) = createStringObjectFromCharP(currentContext, "Roboto Regular", -1);
+      setObjectLock(Font_name(customFont), UNLOCKED);
+      Font_size(customFont) = 9;
+      p.obj = &customFont;
+      tufF_fontCreate(&p);
+      ASSERT1_EQUALS(True, Font_skiaIndex(customFont) >= 0);
+      missingName = String2CharP(Font_name(customFont));
+      ASSERT2_EQUALS(Sz, missingName, "Roboto Regular");
+      xfree(missingName);
+   }
+
+   missingFont = createObject(currentContext, "totalcross.ui.font.Font");
+   ASSERT1_EQUALS(NotNull, missingFont);
+   setObjectLock(missingFont, UNLOCKED);
+   Font_name(missingFont) = createStringObjectFromCharP(currentContext, "Missing", -1);
+   setObjectLock(Font_name(missingFont), UNLOCKED);
+   Font_size(missingFont) = 9;
+   p.obj = &missingFont;
+   tufF_fontCreate(&p);
+   ASSERT1_EQUALS(Null, Font_hvUserFont(missingFont));
+   missingName = String2CharP(Font_name(missingFont));
+   ASSERT2_EQUALS(Sz, missingName, "TCFont");
+   xfree(missingName);
+#else
    ASSERT1_EQUALS(NotNull, *hvUserFont);
+#endif
 
    testfont = font; // will be used in the fontmetrics tests
    finish: ;

--- a/TotalCrossVM/src/nm/ui/macos/WindowServices_c.h
+++ b/TotalCrossVM/src/nm/ui/macos/WindowServices_c.h
@@ -4,16 +4,16 @@
 
 #include "../Window.h"
 
-static bool windowPlatformIsSIPShown(void)
+static int32 windowPlatformIsSIPShown(void)
 {
-   return false;
+   return 0;
 }
 
 static void windowPlatformSetSIP(
    Context currentContext,
    int32 sipOption,
    TCObject control,
-   bool numeric)
+   int32 numeric)
 {
    UNUSED(currentContext)
    UNUSED(sipOption)

--- a/TotalCrossVM/src/nm/ui/skia/skia.cpp
+++ b/TotalCrossVM/src/nm/ui/skia/skia.cpp
@@ -139,9 +139,7 @@ SkPaint alphaPaint; // used for alphaMask
 SkBitmap bitmap;
 SkFont   skFont;
 
-#define TYPEFACE_LEN 32
-sk_sp<SkTypeface> typefaces[TYPEFACE_LEN];
-int typefaceIdx = 0;
+std::vector<sk_sp<SkTypeface>> typefaces;
 
 std::vector<std::unique_ptr<SkiaImageSurface>> imageSurfaces;
 
@@ -231,15 +229,20 @@ int32 skia_makeTypeface(char* name, void *data, int32 size)
     SKIA_TRACE()
     std::string key = name;
     int32 idx = skia_getTypefaceIndex(name);
-    
-    if (idx == -1 && typefaceIdx < TYPEFACE_LEN - 1) {
-        sk_sp<SkData> typefaceData = SkData::MakeWithCopy(data, size);
-        sk_sp<SkTypeface> typeface = SkTypeface::MakeFromData(typefaceData);
-        idx = typefaceIdx;
-        typefaces[typefaceIdx++] = typeface;
-        typefaceIndexMap[key] = idx;
+
+    if (idx >= 0) {
+        return idx;
     }
-    
+
+    sk_sp<SkData> typefaceData = SkData::MakeWithCopy(data, size);
+    sk_sp<SkTypeface> typeface = SkTypeface::MakeFromData(typefaceData);
+    if (!typeface) {
+        return -1;
+    }
+
+    idx = (int32)typefaces.size();
+    typefaces.push_back(typeface);
+    typefaceIndexMap[key] = idx;
     return idx;
 }
 
@@ -255,7 +258,7 @@ int32 skia_getTypefaceIndex(char* name) {
 }
 
 sk_sp<SkTypeface> skia_getTypeface(int32 typefaceIndex) {
-    if (typefaceIndex >= 0 && typefaceIndex < typefaceIdx) {
+    if (typefaceIndex >= 0 && typefaceIndex < (int32)typefaces.size()) {
         return typefaces[typefaceIndex];
     } else {
         return SkTypeface::MakeFromName(nullptr, SkFontStyle());

--- a/TotalCrossVM/src/nm/ui/skia/skia.cpp
+++ b/TotalCrossVM/src/nm/ui/skia/skia.cpp
@@ -278,21 +278,21 @@ static void configureSkFont(int32 typefaceIndex, double fontSize, bool bold)
     skFont.setEmbolden(bold);
 }
 
-int32 skia_stringWidth(const void *text, int32 charCount, int32 typefaceIndex, double fontSize, bool bold)
+int32 skia_stringWidth(const void *text, int32 charCount, int32 typefaceIndex, double fontSize, int32 bold)
 {
     return (int32)ceil(skia_stringWidthD(text, charCount, typefaceIndex, fontSize, bold));
 }
 
-double skia_stringWidthD(const void *text, int32 charCount, int32 typefaceIndex, double fontSize, bool bold)
+double skia_stringWidthD(const void *text, int32 charCount, int32 typefaceIndex, double fontSize, int32 bold)
 {
-    configureSkFont(typefaceIndex, fontSize, bold);
+    configureSkFont(typefaceIndex, fontSize, bold != 0);
     return skFont.measureText(text, charCount, SkTextEncoding::kUTF16);
 }
 
-void skia_fontMetrics(int32 typefaceIndex, double fontSize, bool bold, double* ascent, double* descent, double* leading)
+void skia_fontMetrics(int32 typefaceIndex, double fontSize, int32 bold, double* ascent, double* descent, double* leading)
 {
     SkFont metricsFont(skia_getTypeface(typefaceIndex), fontSize);
-    metricsFont.setEmbolden(bold);
+    metricsFont.setEmbolden(bold != 0);
     SkFontMetrics metrics;
     metricsFont.getMetrics(&metrics);
     *ascent = -metrics.fAscent;

--- a/TotalCrossVM/src/nm/ui/skia/skia.cpp
+++ b/TotalCrossVM/src/nm/ui/skia/skia.cpp
@@ -265,7 +265,7 @@ sk_sp<SkTypeface> skia_getTypeface(int32 typefaceIndex) {
     }
 }
 
-int32 skia_stringWidth(const void *text, int32 charCount, int32 typefaceIndex, double fontSize)
+static void configureSkFont(int32 typefaceIndex, double fontSize, bool bold)
 {
     const auto newTypeFace = skia_getTypeface(typefaceIndex);
 
@@ -275,24 +275,24 @@ int32 skia_stringWidth(const void *text, int32 charCount, int32 typefaceIndex, d
     if(skFont.getSize() != fontSize) {
         skFont.setSize(fontSize);
     }
-    return (int32)ceil(skia_stringWidthD(text, charCount, typefaceIndex, fontSize));
+    skFont.setEmbolden(bold);
 }
 
-double skia_stringWidthD(const void *text, int32 charCount, int32 typefaceIndex, double fontSize)
+int32 skia_stringWidth(const void *text, int32 charCount, int32 typefaceIndex, double fontSize, bool bold)
 {
-    const auto newTypeFace = skia_getTypeface(typefaceIndex);
-    if (skFont.getTypeface() != newTypeFace.get()) {
-        skFont.setTypeface(newTypeFace);
-    }
-    if (skFont.getSize() != fontSize) {
-        skFont.setSize(fontSize);
-    }
+    return (int32)ceil(skia_stringWidthD(text, charCount, typefaceIndex, fontSize, bold));
+}
+
+double skia_stringWidthD(const void *text, int32 charCount, int32 typefaceIndex, double fontSize, bool bold)
+{
+    configureSkFont(typefaceIndex, fontSize, bold);
     return skFont.measureText(text, charCount, SkTextEncoding::kUTF16);
 }
 
-void skia_fontMetrics(int32 typefaceIndex, double fontSize, double* ascent, double* descent, double* leading)
+void skia_fontMetrics(int32 typefaceIndex, double fontSize, bool bold, double* ascent, double* descent, double* leading)
 {
     SkFont metricsFont(skia_getTypeface(typefaceIndex), fontSize);
+    metricsFont.setEmbolden(bold);
     SkFontMetrics metrics;
     metricsFont.getMetrics(&metrics);
     *ascent = -metrics.fAscent;

--- a/TotalCrossVM/src/nm/ui/skia/skia.h
+++ b/TotalCrossVM/src/nm/ui/skia/skia.h
@@ -31,9 +31,9 @@ void flushSkia();
 
 int skia_makeTypeface(char* name, void *data, int32 size);
 int32 skia_getTypefaceIndex(char* name);
-int32 skia_stringWidth(const void *text, int32 charCount, int32 typefaceIndex, double fontSize, bool bold);
-double skia_stringWidthD(const void *text, int32 charCount, int32 typefaceIndex, double fontSize, bool bold);
-void skia_fontMetrics(int32 typefaceIndex, double fontSize, bool bold, double* ascent, double* descent, double* leading);
+int32 skia_stringWidth(const void *text, int32 charCount, int32 typefaceIndex, double fontSize, int32 bold);
+double skia_stringWidthD(const void *text, int32 charCount, int32 typefaceIndex, double fontSize, int32 bold);
+void skia_fontMetrics(int32 typefaceIndex, double fontSize, int32 bold, double* ascent, double* descent, double* leading);
 
 int skia_makeBitmap(int32 id, void *data, int32 w, int32 h);
 void skia_deleteBitmap(int32 id);
@@ -50,15 +50,15 @@ void skia_setPixel(int32 skiaSurface, int32 x, int32 y, Pixel pixel);
 void skia_drawLine(int32 skiaSurface, int32 x1, int32 y1, int32 x2, int32 y2, Pixel pixel);
 void skia_drawRect(int32 skiaSurface, int32 x, int32 y, int32 w, int32 h, Pixel pixel);
 void skia_fillRect(int32 skiaSurface, int32 x, int32 y, int32 w, int32 h, Pixel pixel);
-void skia_drawText(int32 skiaSurface, const void *text, int32 chrCount, double x0, double y0, Pixel foreColor, int32 justifyWidth, double fontSize, int32 typefaceIndex, bool bold);
-void skia_ellipseDrawAndFill(int32 skiaSurface, int32 xc, int32 yc, int32 rx, int32 ry, Pixel pc1, Pixel pc2, bool fill, bool gradient);
-void skia_fillPolygon(int32 skiaSurface, int32 *xPoints, int32 *yPoints, int32 nPoints, int32 tx, int32 ty, Pixel c1, Pixel c2, bool gradient, bool isPie);
+void skia_drawText(int32 skiaSurface, const void *text, int32 chrCount, double x0, double y0, Pixel foreColor, int32 justifyWidth, double fontSize, int32 typefaceIndex, int32 bold);
+void skia_ellipseDrawAndFill(int32 skiaSurface, int32 xc, int32 yc, int32 rx, int32 ry, Pixel pc1, Pixel pc2, int32 fill, int32 gradient);
+void skia_fillPolygon(int32 skiaSurface, int32 *xPoints, int32 *yPoints, int32 nPoints, int32 tx, int32 ty, Pixel c1, Pixel c2, int32 gradient, int32 isPie);
 void skia_drawPolygon(int32 skiaSurface, int32 *xPoints, int32 *yPoints, int32 nPoints, int32 tx, int32 ty, Pixel pixel);
-void skia_arcPiePointDrawAndFill(int32 skiaSurface, int32 xc, int32 yc, int32 rx, int32 ry, double startAngle, double endAngle, Pixel c, Pixel c2, bool fill, bool pie, bool gradient);
+void skia_arcPiePointDrawAndFill(int32 skiaSurface, int32 xc, int32 yc, int32 rx, int32 ry, double startAngle, double endAngle, Pixel c, Pixel c2, int32 fill, int32 pie, int32 gradient);
 void skia_drawRoundRect(int32 skiaSurface, int32 x, int32 y, int32 w, int32 h, int32 r, Pixel c);
 void skia_fillRoundRect(int32 skiaSurface, int32 x, int32 y, int32 w, int32 h, int32 r, Pixel c);
-void skia_drawRoundGradient(int32 skiaSurface, int32 startX, int32 startY, int32 endX, int32 endY, int32 topLeftRadius, int32 topRightRadius, int32 bottomLeftRadius, int32 bottomRightRadius, int32 startColor, int32 endColor, bool vertical);
-int skia_getsetRGB(int32 skiaSurface, void *dataObj, int32 offset, int32 x, int32 y, int32 w, int32 h, bool isGet);
+void skia_drawRoundGradient(int32 skiaSurface, int32 startX, int32 startY, int32 endX, int32 endY, int32 topLeftRadius, int32 topRightRadius, int32 bottomLeftRadius, int32 bottomRightRadius, int32 startColor, int32 endColor, int32 vertical);
+int32 skia_getsetRGB(int32 skiaSurface, void *dataObj, int32 offset, int32 x, int32 y, int32 w, int32 h, int32 isGet);
 void skia_shiftScreen(float w, float h, float glShiftY);
 #ifdef __cplusplus
 }

--- a/TotalCrossVM/src/nm/ui/skia/skia.h
+++ b/TotalCrossVM/src/nm/ui/skia/skia.h
@@ -31,9 +31,9 @@ void flushSkia();
 
 int skia_makeTypeface(char* name, void *data, int32 size);
 int32 skia_getTypefaceIndex(char* name);
-int32 skia_stringWidth(const void *text, int32 charCount, int32 typefaceIndex, double fontSize);
-double skia_stringWidthD(const void *text, int32 charCount, int32 typefaceIndex, double fontSize);
-void skia_fontMetrics(int32 typefaceIndex, double fontSize, double* ascent, double* descent, double* leading);
+int32 skia_stringWidth(const void *text, int32 charCount, int32 typefaceIndex, double fontSize, bool bold);
+double skia_stringWidthD(const void *text, int32 charCount, int32 typefaceIndex, double fontSize, bool bold);
+void skia_fontMetrics(int32 typefaceIndex, double fontSize, bool bold, double* ascent, double* descent, double* leading);
 
 int skia_makeBitmap(int32 id, void *data, int32 w, int32 h);
 void skia_deleteBitmap(int32 id);
@@ -50,7 +50,7 @@ void skia_setPixel(int32 skiaSurface, int32 x, int32 y, Pixel pixel);
 void skia_drawLine(int32 skiaSurface, int32 x1, int32 y1, int32 x2, int32 y2, Pixel pixel);
 void skia_drawRect(int32 skiaSurface, int32 x, int32 y, int32 w, int32 h, Pixel pixel);
 void skia_fillRect(int32 skiaSurface, int32 x, int32 y, int32 w, int32 h, Pixel pixel);
-void skia_drawText(int32 skiaSurface, const void *text, int32 chrCount, double x0, double y0, Pixel foreColor, int32 justifyWidth, double fontSize, int32 typefaceIndex);
+void skia_drawText(int32 skiaSurface, const void *text, int32 chrCount, double x0, double y0, Pixel foreColor, int32 justifyWidth, double fontSize, int32 typefaceIndex, bool bold);
 void skia_ellipseDrawAndFill(int32 skiaSurface, int32 xc, int32 yc, int32 rx, int32 ry, Pixel pc1, Pixel pc2, bool fill, bool gradient);
 void skia_fillPolygon(int32 skiaSurface, int32 *xPoints, int32 *yPoints, int32 nPoints, int32 tx, int32 ty, Pixel c1, Pixel c2, bool gradient, bool isPie);
 void skia_drawPolygon(int32 skiaSurface, int32 *xPoints, int32 *yPoints, int32 nPoints, int32 tx, int32 ty, Pixel pixel);

--- a/TotalCrossVM/src/nm/ui/skia/skia_internal.h
+++ b/TotalCrossVM/src/nm/ui/skia/skia_internal.h
@@ -129,9 +129,7 @@ extern std::vector<std::unique_ptr<SkiaImageSurface>> imageSurfaces;
 SkCanvas* skiaGetCanvas(int32 surfaceId);
 SkBitmap* skiaGetBitmap(int32 surfaceId);
 
-#define TYPEFACE_LEN 32
-extern sk_sp<SkTypeface> typefaces[TYPEFACE_LEN];
-extern int typefaceIdx;
+extern std::vector<sk_sp<SkTypeface>> typefaces;
 extern std::map<std::string, int> typefaceIndexMap;
 
 sk_sp<SkTypeface> skia_getTypeface(int32 typefaceIndex);

--- a/TotalCrossVM/src/nm/ui/skia/skia_primitives.cpp
+++ b/TotalCrossVM/src/nm/ui/skia/skia_primitives.cpp
@@ -45,7 +45,7 @@ void skia_fillRect(int32 skiaSurface, int32 x, int32 y, int32 w, int32 h, Pixel 
     targetCanvas->drawRect(SkRect::MakeXYWH(x, y, w, h), backPaint);
 }
 
-void skia_drawText(int32 skiaSurface, const void *text, int32 chrCount, double x0, double y0, Pixel foreColor, int32 justifyWidth, double fontSize, int32 typefaceIndex)
+void skia_drawText(int32 skiaSurface, const void *text, int32 chrCount, double x0, double y0, Pixel foreColor, int32 justifyWidth, double fontSize, int32 typefaceIndex, bool bold)
 {
     SKIA_TRACE()
     SkCanvas* targetCanvas = skiaGetCanvas(skiaSurface);
@@ -58,6 +58,7 @@ void skia_drawText(int32 skiaSurface, const void *text, int32 chrCount, double x
     if(skFont.getSize() != fontSize) {
         skFont.setSize(fontSize);
     }
+    skFont.setEmbolden(bold);
     if(backPaint.getColor() != foreColor){
         backPaint.setColor(skiaColorFromPixel(foreColor));
     }

--- a/TotalCrossVM/src/nm/ui/skia/skia_primitives.cpp
+++ b/TotalCrossVM/src/nm/ui/skia/skia_primitives.cpp
@@ -45,7 +45,7 @@ void skia_fillRect(int32 skiaSurface, int32 x, int32 y, int32 w, int32 h, Pixel 
     targetCanvas->drawRect(SkRect::MakeXYWH(x, y, w, h), backPaint);
 }
 
-void skia_drawText(int32 skiaSurface, const void *text, int32 chrCount, double x0, double y0, Pixel foreColor, int32 justifyWidth, double fontSize, int32 typefaceIndex, bool bold)
+void skia_drawText(int32 skiaSurface, const void *text, int32 chrCount, double x0, double y0, Pixel foreColor, int32 justifyWidth, double fontSize, int32 typefaceIndex, int32 bold)
 {
     SKIA_TRACE()
     SkCanvas* targetCanvas = skiaGetCanvas(skiaSurface);
@@ -58,20 +58,20 @@ void skia_drawText(int32 skiaSurface, const void *text, int32 chrCount, double x
     if(skFont.getSize() != fontSize) {
         skFont.setSize(fontSize);
     }
-    skFont.setEmbolden(bold);
+    skFont.setEmbolden(bold != 0);
     if(backPaint.getColor() != foreColor){
         backPaint.setColor(skiaColorFromPixel(foreColor));
     }
     targetCanvas->drawTextBlob(SkTextBlob::MakeFromText(text,chrCount,skFont,SkTextEncoding::kUTF16),x0,y0,backPaint);
 }
 
-void skia_ellipseDrawAndFill(int32 skiaSurface, int32 xc, int32 yc, int32 rx, int32 ry, Pixel pc1, Pixel pc2, bool fill, bool gradient)
+void skia_ellipseDrawAndFill(int32 skiaSurface, int32 xc, int32 yc, int32 rx, int32 ry, Pixel pc1, Pixel pc2, int32 fill, int32 gradient)
 {
     SKIA_TRACE()
     SkCanvas* targetCanvas = skiaGetCanvas(skiaSurface);
     if (!targetCanvas) return;
-    if (fill) {
-        if (gradient) {
+    if (fill != 0) {
+        if (gradient != 0) {
             SkPoint points[3] = {
                     SkPoint::Make(xc, yc - ry),
                     SkPoint::Make(xc, yc + ry),
@@ -125,7 +125,7 @@ void skia_drawPolygon(int32 skiaSurface, int32 *xPoints, int32 *yPoints, int32 n
     targetCanvas->translate(-tx, -ty);
 }
 
-void skia_fillPolygon(int32 skiaSurface, int32 *xPoints, int32 *yPoints, int32 nPoints, int32 tx, int32 ty, Pixel c1, Pixel c2, bool gradient, bool isPie)
+void skia_fillPolygon(int32 skiaSurface, int32 *xPoints, int32 *yPoints, int32 nPoints, int32 tx, int32 ty, Pixel c1, Pixel c2, int32 gradient, int32 isPie)
 {
     SKIA_TRACE()
     SkCanvas* targetCanvas = skiaGetCanvas(skiaSurface);
@@ -133,7 +133,7 @@ void skia_fillPolygon(int32 skiaSurface, int32 *xPoints, int32 *yPoints, int32 n
     SkPath path = _skia_makePath(xPoints, yPoints, nPoints);
 
     backPaint.setColor(skiaColorFromPixel(c1));
-    if (gradient) {
+    if (gradient != 0) {
         int32 minY, maxY;
         _skia_getPathBounds(xPoints, yPoints, nPoints, &minY, &maxY);
         SkPoint points[2] = {
@@ -150,7 +150,7 @@ void skia_fillPolygon(int32 skiaSurface, int32 *xPoints, int32 *yPoints, int32 n
     targetCanvas->drawPath(path, backPaint);
     targetCanvas->translate(-tx, -ty);
 
-    if (gradient) {
+    if (gradient != 0) {
         backPaint.setShader(nullptr);
     }
 }
@@ -196,17 +196,18 @@ SkPath _skia_makeArcPath(const SkRect& oval, SkScalar startAngle, SkScalar sweep
 
     return path;
 }
-void skia_arcPiePointDrawAndFill(int32 skiaSurface, int32 xc, int32 yc, int32 rx, int32 ry, double startAngle, double endAngle, Pixel c, Pixel c2, bool fill, bool pie, bool gradient)
+void skia_arcPiePointDrawAndFill(int32 skiaSurface, int32 xc, int32 yc, int32 rx, int32 ry, double startAngle, double endAngle, Pixel c, Pixel c2, int32 fill, int32 pie, int32 gradient)
 {
     double start = -startAngle;
     double sweepAngle = -(endAngle - startAngle);
+    const bool usePie = pie != 0;
     SKIA_TRACE()
     SkCanvas* targetCanvas = skiaGetCanvas(skiaSurface);
     if (!targetCanvas) return;
-    if (fill) {
+    if (fill != 0) {
         backPaint.setColor(skiaColorFromPixel(c2));
-        if (gradient) {
-            SkPath arcPath = _skia_makeArcPath(SkRect::MakeXYWH(xc - rx, yc - ry, rx * 2, ry * 2), start, sweepAngle, pie);
+        if (gradient != 0) {
+            SkPath arcPath = _skia_makeArcPath(SkRect::MakeXYWH(xc - rx, yc - ry, rx * 2, ry * 2), start, sweepAngle, usePie);
             SkRect r = arcPath.computeTightBounds();
 
             SkPoint points[2] = {
@@ -221,16 +222,16 @@ void skia_arcPiePointDrawAndFill(int32 skiaSurface, int32 xc, int32 yc, int32 rx
             targetCanvas->drawPath(arcPath, backPaint);
             backPaint.setShader(nullptr);
         } else {
-            targetCanvas->drawArc(SkRect::MakeXYWH(xc - rx, yc - ry, rx * 2, ry * 2), start, sweepAngle, pie, backPaint);
+            targetCanvas->drawArc(SkRect::MakeXYWH(xc - rx, yc - ry, rx * 2, ry * 2), start, sweepAngle, usePie, backPaint);
             forePaint.setColor(skiaColorFromPixel(c));
             SkScalar strokeWidth = forePaint.getStrokeWidth();
             forePaint.setStrokeWidth(2);
-            targetCanvas->drawArc(SkRect::MakeXYWH(xc - rx, yc - ry, rx * 2, ry * 2), start, sweepAngle, pie, forePaint);
+            targetCanvas->drawArc(SkRect::MakeXYWH(xc - rx, yc - ry, rx * 2, ry * 2), start, sweepAngle, usePie, forePaint);
             forePaint.setStrokeWidth(strokeWidth);
         }
     } else {
         forePaint.setColor(skiaColorFromPixel(c));
-        targetCanvas->drawArc(SkRect::MakeXYWH(xc - rx, yc - ry, rx * 2, ry * 2), start, sweepAngle, pie, forePaint);
+        targetCanvas->drawArc(SkRect::MakeXYWH(xc - rx, yc - ry, rx * 2, ry * 2), start, sweepAngle, usePie, forePaint);
     }
 }
 
@@ -252,7 +253,7 @@ void skia_fillRoundRect(int32 skiaSurface, int32 x, int32 y, int32 w, int32 h, i
     targetCanvas->drawRRect(SkRRect::MakeRectXY(SkRect::MakeXYWH(x, y, w, h), r, r), backPaint);
 }
 
-void skia_drawRoundGradient(int32 skiaSurface, int32 startX, int32 startY, int32 endX, int32 endY, int32 topLeftRadius, int32 topRightRadius, int32 bottomLeftRadius, int32 bottomRightRadius, int32 startColor, int32 endColor, bool vertical)
+void skia_drawRoundGradient(int32 skiaSurface, int32 startX, int32 startY, int32 endX, int32 endY, int32 topLeftRadius, int32 topRightRadius, int32 bottomLeftRadius, int32 bottomRightRadius, int32 startColor, int32 endColor, int32 vertical)
 {
     SKIA_TRACE()
     SkCanvas* targetCanvas = skiaGetCanvas(skiaSurface);
@@ -260,7 +261,7 @@ void skia_drawRoundGradient(int32 skiaSurface, int32 startX, int32 startY, int32
     int32 w = endX - startX;
     int32 h = endY - startY;
     SkPoint points[2];
-    if (vertical) {
+    if (vertical != 0) {
         points[0] = SkPoint::Make(startX, startY);
         points[1] = SkPoint::Make(startX, startY + h * 2);
     } else {

--- a/TotalCrossVM/src/nm/ui/skia/skia_surface.cpp
+++ b/TotalCrossVM/src/nm/ui/skia/skia_surface.cpp
@@ -219,8 +219,8 @@ void skia_setPixel(int32 skiaSurface, int32 x, int32 y, Pixel pixel) {
     }
 }
 
-int skia_getsetRGB(int32 skiaSurface, void* pixels, int32 offset,
-                   int32 x, int32 y, int32 w, int32 h, bool isGet) {
+int32 skia_getsetRGB(int32 skiaSurface, void* pixels, int32 offset,
+                   int32 x, int32 y, int32 w, int32 h, int32 isGet) {
     SKIA_TRACE()
 
     SkCanvas* targetCanvas = skiaGetCanvas(skiaSurface);
@@ -241,7 +241,7 @@ int skia_getsetRGB(int32 skiaSurface, void* pixels, int32 offset,
 
     Pixel* pixelBuffer = static_cast<Pixel*>(pixels) + offset;
 
-    if (isGet) {
+    if (isGet != 0) {
         if (!targetCanvas->readPixels(pixelBitmap, x, y)) {
             return 0;
         }

--- a/TotalCrossVM/src/nm/ui/skia/skia_surface_test.cpp
+++ b/TotalCrossVM/src/nm/ui/skia/skia_surface_test.cpp
@@ -5,7 +5,7 @@
 #include "skia.h"
 
 #include <cstdio>
-#include <cstring>
+#include <cstdint>
 #include <fstream>
 #include <vector>
 
@@ -86,9 +86,83 @@ static bool testTypefaceRegistry(const char* fontPath) {
     return true;
 }
 
+static bool testBoldStyle(const char* fontPath) {
+    std::vector<unsigned char> fontData;
+    if (!readBinaryFile(fontPath, fontData)) {
+        return false;
+    }
+
+    char name[] = "skia-bold-style-font";
+    const int32 typefaceIndex = skia_makeTypeface(
+        name, fontData.data(), static_cast<int32>(fontData.size()));
+    if (typefaceIndex < 0) {
+        std::fputs("unable to load the bold-style font fixture\n", stderr);
+        return false;
+    }
+
+    const std::uint16_t text[] = {'A'};
+    const double plainWidthBefore = skia_stringWidthD(
+        text, sizeof(text), typefaceIndex, 32, false);
+    const double boldWidth = skia_stringWidthD(
+        text, sizeof(text), typefaceIndex, 32, true);
+    const double plainWidthAfter = skia_stringWidthD(
+        text, sizeof(text), typefaceIndex, 32, false);
+    if (plainWidthBefore != plainWidthAfter || boldWidth < 0) {
+        std::fputs("Skia bold state leaked into a later plain measurement\n", stderr);
+        return false;
+    }
+
+    constexpr int width = 64;
+    constexpr int height = 64;
+    Pixel plainPixels[width * height] = {};
+    Pixel boldPixels[width * height] = {};
+    Pixel resetPixels[width * height] = {};
+    const int plainSurface = skia_makeBitmap(-1, plainPixels, width, height);
+    const int boldSurface = skia_makeBitmap(-1, boldPixels, width, height);
+    const int resetSurface = skia_makeBitmap(-1, resetPixels, width, height);
+    if (plainSurface < 0 || boldSurface < 0 || resetSurface < 0) {
+        std::fputs("unable to create Skia bold-style test surfaces\n", stderr);
+        return false;
+    }
+
+    skia_drawText(plainSurface, text, sizeof(text), 4, 40, 0xFF000000, 0, 32,
+                  typefaceIndex, false);
+    skia_drawText(boldSurface, text, sizeof(text), 4, 40, 0xFF000000, 0, 32,
+                  typefaceIndex, true);
+    skia_drawText(resetSurface, text, sizeof(text), 4, 40, 0xFF000000, 0, 32,
+                  typefaceIndex, false);
+
+    bool boldChangedPixels = false;
+    for (int y = 0; y < height; ++y) {
+        for (int x = 0; x < width; ++x) {
+            const Pixel plainPixel = skia_getPixel(plainSurface, x, y);
+            const Pixel boldPixel = skia_getPixel(boldSurface, x, y);
+            const Pixel resetPixel = skia_getPixel(resetSurface, x, y);
+            if (plainPixel != resetPixel) {
+                std::fputs("Skia bold state leaked into a later plain draw\n", stderr);
+                return false;
+            }
+            if (plainPixel != boldPixel) {
+                boldChangedPixels = true;
+            }
+        }
+    }
+    skia_deleteBitmap(plainSurface);
+    skia_deleteBitmap(boldSurface);
+    skia_deleteBitmap(resetSurface);
+    if (!boldChangedPixels) {
+        std::fputs("Skia bold draw did not alter the rendered glyph\n", stderr);
+        return false;
+    }
+    std::puts("skia bold-style assertions passed");
+    return true;
+}
+
 int main(int argc, char** argv) {
-    if (argc > 1 && !testTypefaceRegistry(argv[1])) {
-        return 1;
+    if (argc > 1) {
+        if (!testTypefaceRegistry(argv[1]) || !testBoldStyle(argv[1])) {
+            return 1;
+        }
     }
     Pixel sourcePixels[4] = { 0xFF102030, 0xFF405060, 0xFF708090, 0xFFA0B0C0 };
     Pixel destinationPixels[16] = {};

--- a/TotalCrossVM/src/nm/ui/skia/skia_surface_test.cpp
+++ b/TotalCrossVM/src/nm/ui/skia/skia_surface_test.cpp
@@ -6,6 +6,8 @@
 
 #include <cstdio>
 #include <cstring>
+#include <fstream>
+#include <vector>
 
 static bool expectEqual(Pixel actual, Pixel expected, const char* message) {
     if (actual == expected) {
@@ -15,7 +17,79 @@ static bool expectEqual(Pixel actual, Pixel expected, const char* message) {
     return false;
 }
 
-int main() {
+static bool readBinaryFile(const char* path, std::vector<unsigned char>& data) {
+    std::ifstream input(path, std::ios::binary | std::ios::ate);
+    if (!input) {
+        std::fprintf(stderr, "unable to open font fixture: %s\n", path);
+        return false;
+    }
+    const std::streamoff size = input.tellg();
+    if (size <= 0) {
+        std::fprintf(stderr, "font fixture is empty: %s\n", path);
+        return false;
+    }
+    data.resize(static_cast<size_t>(size));
+    input.seekg(0, std::ios::beg);
+    if (!input.read(reinterpret_cast<char*>(data.data()), size)) {
+        std::fprintf(stderr, "unable to read font fixture: %s\n", path);
+        return false;
+    }
+    return true;
+}
+
+static bool testTypefaceRegistry(const char* fontPath) {
+    std::vector<unsigned char> fontData;
+    if (!readBinaryFile(fontPath, fontData)) {
+        return false;
+    }
+
+    unsigned char invalidData[] = {0, 1, 2, 3};
+    char invalidName[] = "skia-invalid-font";
+    if (skia_makeTypeface(invalidName, invalidData, sizeof(invalidData)) != -1 ||
+        skia_getTypefaceIndex(invalidName) != -1) {
+        std::fputs("invalid TTF data entered the typeface registry\n", stderr);
+        return false;
+    }
+
+    char repeatedName[] = "skia-repeated-font";
+    const int32 repeatedIndex = skia_makeTypeface(
+        repeatedName, fontData.data(), static_cast<int32>(fontData.size()));
+    if (repeatedIndex < 0 ||
+        skia_makeTypeface(repeatedName, fontData.data(), static_cast<int32>(fontData.size())) != repeatedIndex ||
+        skia_getTypefaceIndex(repeatedName) != repeatedIndex) {
+        std::fputs("valid typeface names were not cached stably\n", stderr);
+        return false;
+    }
+
+    int32 indices[40];
+    for (int i = 0; i < 40; ++i) {
+        char name[64];
+        std::snprintf(name, sizeof(name), "skia-capacity-font-%d", i);
+        indices[i] = skia_makeTypeface(
+            name, fontData.data(), static_cast<int32>(fontData.size()));
+        if (indices[i] < 0 || (i > 0 && indices[i] <= indices[i - 1]) ||
+            skia_getTypefaceIndex(name) != indices[i]) {
+            std::fputs("typeface registry did not retain stable capacity entries\n", stderr);
+            return false;
+        }
+    }
+
+    for (int i = 0; i < 40; ++i) {
+        char name[64];
+        std::snprintf(name, sizeof(name), "skia-capacity-font-%d", i);
+        if (skia_getTypefaceIndex(name) != indices[i]) {
+            std::fputs("typeface registry indices changed after insertion\n", stderr);
+            return false;
+        }
+    }
+    std::puts("skia typeface registry assertions passed");
+    return true;
+}
+
+int main(int argc, char** argv) {
+    if (argc > 1 && !testTypefaceRegistry(argv[1])) {
+        return 1;
+    }
     Pixel sourcePixels[4] = { 0xFF102030, 0xFF405060, 0xFF708090, 0xFFA0B0C0 };
     Pixel destinationPixels[16] = {};
     const int source = skia_makeBitmap(-1, sourcePixels, 2, 2);

--- a/TotalCrossVM/src/nm/ui/win/gfx_Graphics_c.h
+++ b/TotalCrossVM/src/nm/ui/win/gfx_Graphics_c.h
@@ -86,7 +86,8 @@ bool graphicsStartup(ScreenSurface screen, int16 appTczAttr)
    display.usableWidth = rect.right - rect.left;
    display.usableHeight = rect.bottom - rect.top;
    startupOptions.appTczAttr = appTczAttr;
-   startupOptions.legacyFullscreen = *tcSettings.isFullScreenPtr;
+   startupOptions.initialFullscreen = *tcSettings.isFullScreenPtr
+      ? TC_FULLSCREEN_TRUE : TC_FULLSCREEN_UNSET;
    windowLoadStartupEnvironment(&startupOptions);
    if (!windowResolveStartupConfiguration(&startupOptions, &display, &configuration))
       return false;

--- a/TotalCrossVM/src/palmdb/palmdb.c
+++ b/TotalCrossVM/src/palmdb/palmdb.c
@@ -1,5 +1,6 @@
 // Copyright (C) 2000-2013 SuperWaba Ltda.
-// Copyright (C) 2014-2020 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -272,7 +273,7 @@ finish:
    return errNone;
 }
 
-bool PDBMatchExact(TCHARP filePath, VoidP userVars)
+int32 PDBMatchExact(TCHARP filePath, VoidP userVars)
 {
    FileMatches_Vars* vars = (FileMatches_Vars*) userVars;
    DatabaseHeader dbh;
@@ -895,7 +896,7 @@ int32 listDatabases(TCHARP searchPath, HandlePDBSearchProcType proc, void *userV
    return 0;
 }
 #else
-bool PDBMatchByTypeCreator(TCHARP fileName, VoidP userVars)
+int32 PDBMatchByTypeCreator(TCHARP fileName, VoidP userVars)
 {
    FileMatches_Vars* vars = (FileMatches_Vars*) userVars;
    DatabaseHeader dbh;

--- a/TotalCrossVM/src/palmdb/palmdb.h
+++ b/TotalCrossVM/src/palmdb/palmdb.h
@@ -1,5 +1,6 @@
 // Copyright (C) 2000-2013 SuperWaba Ltda.
-// Copyright (C) 2014-2020 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -291,7 +292,7 @@ typedef struct
    _HANDLE  fileRef;
 } FileMatches_Vars;
 
-typedef bool (*HandlePDBSearchProcType) (TCHARP fileName, VoidP userVars);
+typedef int32 (*HandlePDBSearchProcType) (TCHARP fileName, VoidP userVars);
 
  #define DmGetLastErr()                                  myDmGetLastErr()
  #define DmReleaseRecord(dbP, index, dirty)              myDmReleaseRecord(dbP, index, dirty)

--- a/TotalCrossVM/src/palmdb/posix/palmdb_c.h
+++ b/TotalCrossVM/src/palmdb/posix/palmdb_c.h
@@ -1,5 +1,6 @@
 // Copyright (C) 2000-2013 SuperWaba Ltda.
-// Copyright (C) 2014-2020 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -24,7 +25,7 @@ Err  PDBGetLastErr()
    return errno;
 }
 
-bool PDBCreateFile(TCHARP fullPath, bool createIt, bool readOnly, PDBFileRef* fileRef)
+int32 PDBCreateFile(TCHARP fullPath, int32 createIt, int32 readOnly, PDBFileRef* fileRef)
 {
    if (readOnly)
    {
@@ -50,7 +51,7 @@ bool PDBCreateFile(TCHARP fullPath, bool createIt, bool readOnly, PDBFileRef* fi
    return *fileRef != NULL;
 }
 
-bool  PDBCloseFile(PDBFileRef fileRef)
+int32 PDBCloseFile(PDBFileRef fileRef)
 {
    return fclose(fileRef) == 0;
 }
@@ -65,7 +66,7 @@ bool  PDBRemove(TCHARP fileName)
    return remove(fileName) == 0;
 }
 
-bool  PDBRead(PDBFileRef fileRef, VoidP buf, int32 size, int32* read)
+int32 PDBRead(PDBFileRef fileRef, VoidP buf, int32 size, int32* read)
 {
    return (*read = (int32)fread(buf, 1, size, fileRef)) > 0;
 }

--- a/TotalCrossVM/src/palmdb/rapi/palmdb_c.h
+++ b/TotalCrossVM/src/palmdb/rapi/palmdb_c.h
@@ -1,5 +1,6 @@
 // Copyright (C) 2000-2013 SuperWaba Ltda.
-// Copyright (C) 2014-2020 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -85,7 +86,7 @@ Err inline PDBGetLastErr()
    return procCeGetLastError();
 }
 
-bool PDBCreateFile(TCHARP fullPath, bool createIt, bool readOnly, PDBFileRef* fileRef)
+int32 PDBCreateFile(TCHARP fullPath, int32 createIt, int32 readOnly, PDBFileRef* fileRef)
 {
    return (*fileRef = procCeCreateFile(toWChar(fullPath),
       readOnly ? GENERIC_READ:(GENERIC_READ|GENERIC_WRITE), // font files must be open in readonly, or two instances will not be able to run
@@ -98,7 +99,7 @@ bool PDBCreateFile(TCHARP fullPath, bool createIt, bool readOnly, PDBFileRef* fi
       null)) != INVALID_HANDLE_VALUE;
 }
 
-bool PDBCloseFile(PDBFileRef fileRef)
+int32 PDBCloseFile(PDBFileRef fileRef)
 {
    return procCeCloseHandle(fileRef) == TRUE;
 }
@@ -113,7 +114,7 @@ bool inline PDBRemove(TCHARP fileName)
    return procCeDeleteFile(toWChar(fileName)) == TRUE;
 }
 
-bool PDBRead(PDBFileRef fileRef, VoidP buf, int32 size, int32* read)
+int32 PDBRead(PDBFileRef fileRef, VoidP buf, int32 size, int32* read)
 {
    return procCeReadFile(fileRef, buf, size, (LPDWORD) read, null) == TRUE;
 }

--- a/TotalCrossVM/src/palmdb/win/palmdb_c.h
+++ b/TotalCrossVM/src/palmdb/win/palmdb_c.h
@@ -1,5 +1,6 @@
 // Copyright (C) 2000-2013 SuperWaba Ltda.
-// Copyright (C) 2014-2020 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -19,7 +20,7 @@ Err PDBGetLastErr()
    return GetLastError();
 }
 
-bool PDBCreateFile(TCHARP fullPath, bool createIt, bool readOnly, PDBFileRef* fileRef)
+int32 PDBCreateFile(TCHARP fullPath, int32 createIt, int32 readOnly, PDBFileRef* fileRef)
 {
    return (*fileRef = CreateFile(fullPath,
       readOnly ? GENERIC_READ:(GENERIC_READ|GENERIC_WRITE), // font files must be open in readonly, or two instances will not be able to run
@@ -30,7 +31,7 @@ bool PDBCreateFile(TCHARP fullPath, bool createIt, bool readOnly, PDBFileRef* fi
       null)) != INVALID_HANDLE_VALUE;
 }
 
-bool PDBCloseFile(PDBFileRef fileRef)
+int32 PDBCloseFile(PDBFileRef fileRef)
 {
    return CloseHandle(fileRef);
 }
@@ -45,7 +46,7 @@ bool PDBRemove(TCHARP fileName)
    return DeleteFile(fileName);
 }
 
-bool PDBRead(PDBFileRef fileRef, VoidP buf, int32 size, int32* read)
+int32 PDBRead(PDBFileRef fileRef, VoidP buf, int32 size, int32* read)
 {
    return ReadFile(fileRef, buf, size, read, null);
 }

--- a/TotalCrossVM/src/sync/Conduit.cpp
+++ b/TotalCrossVM/src/sync/Conduit.cpp
@@ -1,5 +1,6 @@
 // Copyright (C) 2000-2013 SuperWaba Ltda.
-// Copyright (C) 2014-2020 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -340,7 +341,7 @@ typedef struct
    int32 stringsCount;
 } CLC_Vars;
 
-static bool clcAddFile(TCHAR* fileName, void *userVars)
+static int32 clcAddFile(TCHAR* fileName, void *userVars)
 {
    CLC_Vars *vars = (CLC_Vars*) userVars;
    DatabaseHeader dbh;

--- a/TotalCrossVM/src/sync/Conduit.h
+++ b/TotalCrossVM/src/sync/Conduit.h
@@ -1,5 +1,6 @@
 // Copyright (C) 2000-2013 SuperWaba Ltda.
-// Copyright (C) 2014-2020 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -112,9 +113,9 @@ extern "C" {
 
  #include "../palmdb/palmdb.h"
  typedef HANDLE PDBFileRef;
- extern bool PDBCreateFile(TCHARP fullPath, bool createIt, bool readOnly, PDBFileRef* fileRef);
- extern bool PDBRead(PDBFileRef fileRef, VoidP buf, int32 size, int32* read);
- extern bool PDBCloseFile(PDBFileRef fileRef);
+ extern int32 PDBCreateFile(TCHARP fullPath, int32 createIt, int32 readOnly, PDBFileRef* fileRef);
+ extern int32 PDBRead(PDBFileRef fileRef, VoidP buf, int32 size, int32* read);
+ extern int32 PDBCloseFile(PDBFileRef fileRef);
 
  enum ActionCode
  {

--- a/TotalCrossVM/src/tcvm/objectmemorymanager.c
+++ b/TotalCrossVM/src/tcvm/objectmemorymanager.c
@@ -1,5 +1,6 @@
 // Copyright (C) 2000-2013 SuperWaba Ltda.
-// Copyright (C) 2014-2020 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2014-2021 TotalCross Global Mobile Platform Ltda.
+// Copyright (C) 2022-2026 Amalgam Solucoes em TI Ltda
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -381,7 +382,7 @@ static TCObject allocObjWith(uint32 size)
    return o;
 }
 
-extern bool iosLowMemory;
+extern int32 iosLowMemory;
 static int32 consecutiveSkips;
 
 static TCObject allocObject(Context currentContext, uint32 size, TCClass cls, int32 alen)
@@ -392,7 +393,7 @@ static TCObject allocObject(Context currentContext, uint32 size, TCClass cls, in
 #ifdef darwin
    if (iosLowMemory/* && size > 1024*/)
    {    
-      iosLowMemory = false;
+      iosLowMemory = 0;
       debug("IOS low memory. Free: %d",getFreeMemory(0));
       //iosLowMemory = getFreeMemory(0) <= 10*1024*1024;
       //throwException(currentContext, OutOfMemoryError, "iOS low memory warning");

--- a/TotalCrossVM/src/tests/graphics_primitives_abi_asserts.h
+++ b/TotalCrossVM/src/tests/graphics_primitives_abi_asserts.h
@@ -1,0 +1,99 @@
+// Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#ifndef GRAPHICS_PRIMITIVES_ABI_ASSERTS_H
+#define GRAPHICS_PRIMITIVES_ABI_ASSERTS_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+#define TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(condition, message) static_assert(condition, message)
+#define TC_GRAPHICS_PRIMITIVES_ABI_ALIGNOF(type) alignof(type)
+#else
+#define TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(condition, message) _Static_assert(condition, message)
+#define TC_GRAPHICS_PRIMITIVES_ABI_ALIGNOF(type) _Alignof(type)
+#endif
+
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(sizeof(TScreenConfiguration) == 48,
+   "TScreenConfiguration size changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(TC_GRAPHICS_PRIMITIVES_ABI_ALIGNOF(TScreenConfiguration) == 8,
+   "TScreenConfiguration alignment changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenConfiguration, width) == 0,
+   "TScreenConfiguration.width offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenConfiguration, height) == 4,
+   "TScreenConfiguration.height offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenConfiguration, hRes) == 8,
+   "TScreenConfiguration.hRes offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenConfiguration, vRes) == 12,
+   "TScreenConfiguration.vRes offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenConfiguration, contentScale) == 16,
+   "TScreenConfiguration.contentScale offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenConfiguration, fontScale) == 24,
+   "TScreenConfiguration.fontScale offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenConfiguration, deviceFontHeight) == 32,
+   "TScreenConfiguration.deviceFontHeight offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenConfiguration, generation) == 36,
+   "TScreenConfiguration.generation offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenConfiguration, surfaceReady) == 40,
+   "TScreenConfiguration.surfaceReady offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenConfiguration, nativeSurfaceChanged) == 41,
+   "TScreenConfiguration.nativeSurfaceChanged offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(sizeof(((TScreenConfiguration *)0)->surfaceReady) == 1,
+   "TScreenConfiguration.surfaceReady size changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(sizeof(((TScreenConfiguration *)0)->nativeSurfaceChanged) == 1,
+   "TScreenConfiguration.nativeSurfaceChanged size changed");
+
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(sizeof(TScreenSurface) == 104,
+   "TScreenSurface size changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(TC_GRAPHICS_PRIMITIVES_ABI_ALIGNOF(TScreenSurface) == 8,
+   "TScreenSurface alignment changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenSurface, pixels) == 0,
+   "TScreenSurface.pixels offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenSurface, mainWindowPixels) == 8,
+   "TScreenSurface.mainWindowPixels offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenSurface, pitch) == 16,
+   "TScreenSurface.pitch offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenSurface, bpp) == 20,
+   "TScreenSurface.bpp offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenSurface, screenX) == 24,
+   "TScreenSurface.screenX offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenSurface, screenY) == 28,
+   "TScreenSurface.screenY offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenSurface, screenW) == 32,
+   "TScreenSurface.screenW offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenSurface, screenH) == 36,
+   "TScreenSurface.screenH offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenSurface, minScreenW) == 40,
+   "TScreenSurface.minScreenW offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenSurface, minScreenH) == 44,
+   "TScreenSurface.minScreenH offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenSurface, hRes) == 48,
+   "TScreenSurface.hRes offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenSurface, vRes) == 52,
+   "TScreenSurface.vRes offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenSurface, contentScale) == 56,
+   "TScreenSurface.contentScale offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenSurface, fontScale) == 64,
+   "TScreenSurface.fontScale offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenSurface, deviceFontHeight) == 72,
+   "TScreenSurface.deviceFontHeight offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenSurface, surfaceGeneration) == 76,
+   "TScreenSurface.surfaceGeneration offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenSurface, pendingChangeFlags) == 80,
+   "TScreenSurface.pendingChangeFlags offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenSurface, surfaceReady) == 84,
+   "TScreenSurface.surfaceReady offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(sizeof(((TScreenSurface *)0)->surfaceReady) == 1,
+   "TScreenSurface.surfaceReady size changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenSurface, extension) == 88,
+   "TScreenSurface.extension offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenSurface, shiftY) == 96,
+   "TScreenSurface.shiftY offset changed");
+TC_GRAPHICS_PRIMITIVES_ABI_ASSERT(offsetof(TScreenSurface, pixelformat) == 100,
+   "TScreenSurface.pixelformat offset changed");
+
+#undef TC_GRAPHICS_PRIMITIVES_ABI_ASSERT
+#undef TC_GRAPHICS_PRIMITIVES_ABI_ALIGNOF
+
+#endif

--- a/TotalCrossVM/src/tests/graphics_primitives_abi_bridge.c
+++ b/TotalCrossVM/src/tests/graphics_primitives_abi_bridge.c
@@ -1,0 +1,31 @@
+// Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "../tcvm/tc_platform.h"
+#include "../nm/ui/GraphicsPrimitives.h"
+#include "graphics_primitives_abi_asserts.h"
+
+int32 graphicsPrimitivesCReadConfiguration(const TScreenConfiguration *configuration,
+   uint8 expectedSurfaceReady, uint8 expectedNativeSurfaceChanged)
+{
+   return configuration->surfaceReady == expectedSurfaceReady &&
+      configuration->nativeSurfaceChanged == expectedNativeSurfaceChanged;
+}
+
+void graphicsPrimitivesCWriteConfiguration(TScreenConfiguration *configuration,
+   uint8 surfaceReady, uint8 nativeSurfaceChanged)
+{
+   configuration->surfaceReady = surfaceReady;
+   configuration->nativeSurfaceChanged = nativeSurfaceChanged;
+}
+
+int32 graphicsPrimitivesCReadSurface(const TScreenSurface *surface, uint8 expectedSurfaceReady)
+{
+   return surface->surfaceReady == expectedSurfaceReady;
+}
+
+void graphicsPrimitivesCWriteSurface(TScreenSurface *surface, uint8 surfaceReady)
+{
+   surface->surfaceReady = surfaceReady;
+}

--- a/TotalCrossVM/src/tests/graphics_primitives_abi_bridge_test.cpp
+++ b/TotalCrossVM/src/tests/graphics_primitives_abi_bridge_test.cpp
@@ -1,0 +1,69 @@
+// Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "../tcvm/tc_platform.h"
+#include "../nm/ui/GraphicsPrimitives.h"
+#include "graphics_primitives_abi_asserts.h"
+
+#include <cstdio>
+#include <cstring>
+
+extern "C" {
+int32 graphicsPrimitivesCReadConfiguration(const TScreenConfiguration *configuration,
+   uint8 expectedSurfaceReady, uint8 expectedNativeSurfaceChanged);
+void graphicsPrimitivesCWriteConfiguration(TScreenConfiguration *configuration,
+   uint8 surfaceReady, uint8 nativeSurfaceChanged);
+int32 graphicsPrimitivesCReadSurface(const TScreenSurface *surface, uint8 expectedSurfaceReady);
+void graphicsPrimitivesCWriteSurface(TScreenSurface *surface, uint8 surfaceReady);
+}
+
+static int checkConfigurationBridge(uint8 surfaceReady, uint8 nativeSurfaceChanged)
+{
+   TScreenConfiguration configuration;
+   std::memset(&configuration, 0, sizeof(configuration));
+   configuration.surfaceReady = surfaceReady;
+   configuration.nativeSurfaceChanged = nativeSurfaceChanged;
+   if (!graphicsPrimitivesCReadConfiguration(&configuration, surfaceReady, nativeSurfaceChanged)) {
+      return 0;
+   }
+
+   std::memset(&configuration, 0, sizeof(configuration));
+   graphicsPrimitivesCWriteConfiguration(&configuration, surfaceReady, nativeSurfaceChanged);
+   return configuration.surfaceReady == surfaceReady &&
+      configuration.nativeSurfaceChanged == nativeSurfaceChanged;
+}
+
+static int checkSurfaceBridge(uint8 surfaceReady)
+{
+   TScreenSurface surface;
+   std::memset(&surface, 0, sizeof(surface));
+   surface.surfaceReady = surfaceReady;
+   if (!graphicsPrimitivesCReadSurface(&surface, surfaceReady)) {
+      return 0;
+   }
+
+   std::memset(&surface, 0, sizeof(surface));
+   graphicsPrimitivesCWriteSurface(&surface, surfaceReady);
+   return surface.surfaceReady == surfaceReady;
+}
+
+int main()
+{
+   for (uint8 surfaceReady = 0; surfaceReady <= 1; ++surfaceReady) {
+      for (uint8 nativeSurfaceChanged = 0; nativeSurfaceChanged <= 1; ++nativeSurfaceChanged) {
+         if (!checkConfigurationBridge(surfaceReady, nativeSurfaceChanged)) {
+            std::fprintf(stderr, "configuration bridge failed for %u,%u\n",
+               surfaceReady, nativeSurfaceChanged);
+            return 1;
+         }
+      }
+      if (!checkSurfaceBridge(surfaceReady)) {
+         std::fprintf(stderr, "surface bridge failed for %u\n", surfaceReady);
+         return 1;
+      }
+   }
+
+   std::puts("GraphicsPrimitives C/C++ bridge checks passed for all boolean combinations");
+   return 0;
+}

--- a/TotalCrossVM/src/tests/graphics_primitives_abi_c_test.c
+++ b/TotalCrossVM/src/tests/graphics_primitives_abi_c_test.c
@@ -1,0 +1,15 @@
+// Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "../tcvm/tc_platform.h"
+#include "../nm/ui/GraphicsPrimitives.h"
+#include "graphics_primitives_abi_asserts.h"
+
+#include <stdio.h>
+
+int main(void)
+{
+   puts("GraphicsPrimitives C ABI checks passed");
+   return 0;
+}

--- a/TotalCrossVM/src/tests/graphics_primitives_abi_cpp_test.cpp
+++ b/TotalCrossVM/src/tests/graphics_primitives_abi_cpp_test.cpp
@@ -1,0 +1,15 @@
+// Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "../tcvm/tc_platform.h"
+#include "../nm/ui/GraphicsPrimitives.h"
+#include "graphics_primitives_abi_asserts.h"
+
+#include <cstdio>
+
+int main()
+{
+   std::puts("GraphicsPrimitives C++ ABI checks passed");
+   return 0;
+}

--- a/TotalCrossVM/src/tests/tc_tests.c
+++ b/TotalCrossVM/src/tests/tc_tests.c
@@ -5,7 +5,7 @@
 
 #include "tcvm.h"
 
-#define TEST_COUNT 349
+#define TEST_COUNT 350
 
 // Function prototypes
 void test_VM_PrimitiveTypeSizes(struct TestSuite *tc, Context currentContext);// tcvm/tcvm_test.h
@@ -177,6 +177,7 @@ void test_tuMW_setTimerInterval_i(struct TestSuite *tc, Context currentContext);
 void test_tuW_pumpEvents(struct TestSuite *tc, Context currentContext);// nm/ui/Window_test.h
 void test_tuW_setSIP_icb(struct TestSuite *tc, Context currentContext);// nm/ui/Window_test.h
 void test_windowResolveStartupConfiguration(struct TestSuite *tc, Context currentContext);// nm/ui/Window_test.h
+void test_windowResolveStartupFullscreenPolicy(struct TestSuite *tc, Context currentContext);// nm/ui/Window_test.h
 void test_tueE_isAvailable(struct TestSuite *tc, Context currentContext);// nm/ui/event_Event_test.h
 void test_startup_filterApplicationCommandLine(struct TestSuite *tc, Context currentContext);// init/startup_test.h
 void test_tufFM_charWidth_c(struct TestSuite *tc, Context currentContext);// nm/ui/font_FontMetrics_test.h - depends on testtufFM_fontMetricsCreate
@@ -711,6 +712,7 @@ void fillTestCaseArray(testFunc *tests)
    tests[346] = test_VM_Cleanup;
    tests[347] = test_startup_filterApplicationCommandLine;
    tests[348] = test_windowResolveStartupConfiguration;
+   tests[349] = test_windowResolveStartupFullscreenPolicy;
 }
 
 void startTestSuite(Context currentContext)

--- a/TotalCrossVM/src/tests/window_startup_abi_asserts.h
+++ b/TotalCrossVM/src/tests/window_startup_abi_asserts.h
@@ -1,0 +1,81 @@
+// Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#ifndef WINDOW_STARTUP_ABI_ASSERTS_H
+#define WINDOW_STARTUP_ABI_ASSERTS_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+#define TC_WINDOW_STARTUP_ABI_ASSERT(condition, message) static_assert(condition, message)
+#define TC_WINDOW_STARTUP_ABI_ALIGNOF(type) alignof(type)
+#else
+#define TC_WINDOW_STARTUP_ABI_ASSERT(condition, message) _Static_assert(condition, message)
+#define TC_WINDOW_STARTUP_ABI_ALIGNOF(type) _Alignof(type)
+#endif
+
+TC_WINDOW_STARTUP_ABI_ASSERT(sizeof(uint8) == 1, "uint8 must be one byte");
+
+TC_WINDOW_STARTUP_ABI_ASSERT(sizeof(TCWindowStartupOptions) == 44,
+   "TCWindowStartupOptions size changed");
+TC_WINDOW_STARTUP_ABI_ASSERT(TC_WINDOW_STARTUP_ABI_ALIGNOF(TCWindowStartupOptions) == 4,
+   "TCWindowStartupOptions alignment changed");
+TC_WINDOW_STARTUP_ABI_ASSERT(offsetof(TCWindowStartupOptions, screenSpecified) == 0,
+   "TCWindowStartupOptions.screenSpecified offset changed");
+TC_WINDOW_STARTUP_ABI_ASSERT(sizeof(((TCWindowStartupOptions *)0)->screenSpecified) == 1,
+   "TCWindowStartupOptions.screenSpecified size changed");
+TC_WINDOW_STARTUP_ABI_ASSERT(offsetof(TCWindowStartupOptions, x) == 4,
+   "TCWindowStartupOptions.x offset changed");
+TC_WINDOW_STARTUP_ABI_ASSERT(offsetof(TCWindowStartupOptions, y) == 8,
+   "TCWindowStartupOptions.y offset changed");
+TC_WINDOW_STARTUP_ABI_ASSERT(offsetof(TCWindowStartupOptions, width) == 12,
+   "TCWindowStartupOptions.width offset changed");
+TC_WINDOW_STARTUP_ABI_ASSERT(offsetof(TCWindowStartupOptions, height) == 16,
+   "TCWindowStartupOptions.height offset changed");
+TC_WINDOW_STARTUP_ABI_ASSERT(offsetof(TCWindowStartupOptions, environmentWidth) == 20,
+   "TCWindowStartupOptions.environmentWidth offset changed");
+TC_WINDOW_STARTUP_ABI_ASSERT(offsetof(TCWindowStartupOptions, environmentHeight) == 24,
+   "TCWindowStartupOptions.environmentHeight offset changed");
+TC_WINDOW_STARTUP_ABI_ASSERT(offsetof(TCWindowStartupOptions, initialState) == 28,
+   "TCWindowStartupOptions.initialState offset changed");
+TC_WINDOW_STARTUP_ABI_ASSERT(offsetof(TCWindowStartupOptions, initialFullscreen) == 32,
+   "TCWindowStartupOptions.initialFullscreen offset changed");
+TC_WINDOW_STARTUP_ABI_ASSERT(offsetof(TCWindowStartupOptions, environmentFullscreen) == 36,
+   "TCWindowStartupOptions.environmentFullscreen offset changed");
+TC_WINDOW_STARTUP_ABI_ASSERT(offsetof(TCWindowStartupOptions, appTczAttr) == 40,
+   "TCWindowStartupOptions.appTczAttr offset changed");
+
+TC_WINDOW_STARTUP_ABI_ASSERT(sizeof(TCWindowStartupConfiguration) == 28,
+   "TCWindowStartupConfiguration size changed");
+TC_WINDOW_STARTUP_ABI_ASSERT(TC_WINDOW_STARTUP_ABI_ALIGNOF(TCWindowStartupConfiguration) == 4,
+   "TCWindowStartupConfiguration alignment changed");
+TC_WINDOW_STARTUP_ABI_ASSERT(offsetof(TCWindowStartupConfiguration, width) == 0,
+   "TCWindowStartupConfiguration.width offset changed");
+TC_WINDOW_STARTUP_ABI_ASSERT(offsetof(TCWindowStartupConfiguration, height) == 4,
+   "TCWindowStartupConfiguration.height offset changed");
+TC_WINDOW_STARTUP_ABI_ASSERT(offsetof(TCWindowStartupConfiguration, xMode) == 8,
+   "TCWindowStartupConfiguration.xMode offset changed");
+TC_WINDOW_STARTUP_ABI_ASSERT(offsetof(TCWindowStartupConfiguration, yMode) == 12,
+   "TCWindowStartupConfiguration.yMode offset changed");
+TC_WINDOW_STARTUP_ABI_ASSERT(offsetof(TCWindowStartupConfiguration, x) == 16,
+   "TCWindowStartupConfiguration.x offset changed");
+TC_WINDOW_STARTUP_ABI_ASSERT(offsetof(TCWindowStartupConfiguration, y) == 20,
+   "TCWindowStartupConfiguration.y offset changed");
+TC_WINDOW_STARTUP_ABI_ASSERT(offsetof(TCWindowStartupConfiguration, fullscreen) == 24,
+   "TCWindowStartupConfiguration.fullscreen offset changed");
+TC_WINDOW_STARTUP_ABI_ASSERT(offsetof(TCWindowStartupConfiguration, maximized) == 25,
+   "TCWindowStartupConfiguration.maximized offset changed");
+TC_WINDOW_STARTUP_ABI_ASSERT(offsetof(TCWindowStartupConfiguration, resizable) == 26,
+   "TCWindowStartupConfiguration.resizable offset changed");
+TC_WINDOW_STARTUP_ABI_ASSERT(sizeof(((TCWindowStartupConfiguration *)0)->fullscreen) == 1,
+   "TCWindowStartupConfiguration.fullscreen size changed");
+TC_WINDOW_STARTUP_ABI_ASSERT(sizeof(((TCWindowStartupConfiguration *)0)->maximized) == 1,
+   "TCWindowStartupConfiguration.maximized size changed");
+TC_WINDOW_STARTUP_ABI_ASSERT(sizeof(((TCWindowStartupConfiguration *)0)->resizable) == 1,
+   "TCWindowStartupConfiguration.resizable size changed");
+
+#undef TC_WINDOW_STARTUP_ABI_ASSERT
+#undef TC_WINDOW_STARTUP_ABI_ALIGNOF
+
+#endif

--- a/TotalCrossVM/src/tests/window_startup_abi_c_test.c
+++ b/TotalCrossVM/src/tests/window_startup_abi_c_test.c
@@ -1,0 +1,14 @@
+// Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "../nm/ui/WindowStartup.h"
+#include "window_startup_abi_asserts.h"
+
+#include <stdio.h>
+
+int main(void)
+{
+   puts("WindowStartup C ABI checks passed");
+   return 0;
+}

--- a/TotalCrossVM/src/tests/window_startup_abi_cpp_test.cpp
+++ b/TotalCrossVM/src/tests/window_startup_abi_cpp_test.cpp
@@ -1,0 +1,14 @@
+// Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "../nm/ui/WindowStartup.h"
+#include "window_startup_abi_asserts.h"
+
+#include <cstdio>
+
+int main()
+{
+   std::puts("WindowStartup C++ ABI checks passed");
+   return 0;
+}

--- a/TotalCrossVM/src/tests/window_startup_integration_test.c
+++ b/TotalCrossVM/src/tests/window_startup_integration_test.c
@@ -1,0 +1,146 @@
+// Copyright (C) 2026 Amalgam Solucoes em TI Ltda
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Keep the real desktop parser in this test translation unit while avoiding
+ * duplicate VM entry points from the linked tcvm library. */
+#define exitProgram tcWindowStartupIntegration_exitProgram
+#define startProgram tcWindowStartupIntegration_startProgram
+#define startVM tcWindowStartupIntegration_startVM
+#define executeProgram tcWindowStartupIntegration_executeProgram
+#define wokeUp tcWindowStartupIntegration_wokeUp
+#include "../init/startup.c"
+#undef exitProgram
+#undef startProgram
+#undef startVM
+#undef executeProgram
+#undef wokeUp
+
+#include "../init/tcsdl.h"
+
+static int failures;
+
+static void failCase(const char *name, const char *reason)
+{
+   fprintf(stderr, "FAIL case=%s reason=%s\n", name, reason);
+   failures++;
+}
+
+static void clearWindowEnvironment(void)
+{
+   unsetenv("TC_WIDTH");
+   unsetenv("TC_HEIGHT");
+   unsetenv("TC_FULLSCREEN");
+}
+
+static void runCase(const char *name, const char *commandLine,
+   const char *widthEnvironment, const char *heightEnvironment,
+   int expectedWidth, int expectedHeight, bool expectCentered)
+{
+   char vmCommandLine[512];
+   char applicationCommandLine[256];
+   DesktopCommandLineOptions commandOptions;
+   TScreenSurface screen;
+   SDL_Rect displayBounds;
+   int width = 0;
+   int height = 0;
+   int x = 0;
+   int y = 0;
+
+   clearWindowEnvironment();
+   if (widthEnvironment != NULL)
+      setenv("TC_WIDTH", widthEnvironment, 1);
+   if (heightEnvironment != NULL)
+      setenv("TC_HEIGHT", heightEnvironment, 1);
+
+   memset(&screen, 0, sizeof(screen));
+   strcpy(vmCommandLine, commandLine);
+   applicationCommandLine[0] = '\0';
+   if (!prepareDesktopCommandLines(vmCommandLine, applicationCommandLine,
+      sizeof(applicationCommandLine), &commandOptions))
+   {
+      failCase(name, "startup command-line parsing failed");
+      return;
+   }
+
+   if (strstr(vmCommandLine, "/scr") != NULL
+      || strstr(applicationCommandLine, "/scr") != NULL)
+   {
+      failCase(name, "/scr was not removed from the delivered command line");
+      return;
+   }
+
+   if (!TCSDL_Init(&screen, "TotalCross startup integration", false, 0))
+   {
+      failCase(name, "TCSDL_Init failed");
+      return;
+   }
+
+   TCSDL_GetWindowSize(&screen, &width, &height);
+   if (SCREEN_EX(&screen) == NULL || SCREEN_EX(&screen)->window == NULL)
+   {
+      failCase(name, "SDL window handle was not available");
+      TCSDL_DestroyWindow(&screen);
+      return;
+   }
+   SDL_GetWindowPosition(SCREEN_EX(&screen)->window, &x, &y);
+   SDL_GetDisplayBounds(0, &displayBounds);
+
+   printf("case=%s expected=%dx%d obtained=%dx%d position=%d,%d vm=\"%s\" app=\"%s\"\n",
+      name, expectedWidth, expectedHeight, width, height, x, y,
+      vmCommandLine, applicationCommandLine);
+
+   if (width != expectedWidth || height != expectedHeight)
+      failCase(name, "created SDL window dimensions differed");
+   if (expectCentered
+      && (abs((x * 2 + width) - (displayBounds.x * 2 + displayBounds.w)) > 4
+         || abs((y * 2 + height) - (displayBounds.y * 2 + displayBounds.h)) > 4))
+      failCase(name, "created SDL window was not centered");
+
+   TCSDL_DestroyWindow(&screen);
+}
+
+int main(void)
+{
+   SDL_Rect displayBounds;
+   int defaultWidth;
+   int defaultHeight;
+
+   if (SDL_Init(SDL_INIT_VIDEO) != 0
+      || SDL_GetDisplayBounds(0, &displayBounds) != 0
+      || displayBounds.w <= 0 || displayBounds.h <= 0)
+   {
+      fprintf(stderr, "Unable to query SDL display bounds: %s\n", SDL_GetError());
+      SDL_Quit();
+      return 2;
+   }
+   defaultWidth = displayBounds.w / 2;
+   defaultHeight = displayBounds.h / 2;
+   SDL_Quit();
+
+   runCase("scr-explicit", "App.tcz /scr -1,-1,1024,768 /cmd appArg",
+      NULL, NULL, 1024, 768, false);
+   runCase("scr-centered", "App.tcz /scr -2,-2,800,600 /cmd appArg",
+      NULL, NULL, 800, 600, true);
+   runCase("scr-precedence", "App.tcz /scr -1,-1,1024,768 /cmd appArg",
+      "900", "700", 1024, 768, false);
+   runCase("env-both", "App.tcz /cmd appArg", "900", "700",
+      900, 700, false);
+   runCase("env-width-only", "App.tcz /cmd appArg", "900", NULL,
+      900, defaultHeight, false);
+   runCase("env-height-only", "App.tcz /cmd appArg", NULL, "700",
+      defaultWidth, 700, false);
+
+   clearWindowEnvironment();
+   if (failures != 0)
+   {
+      fprintf(stderr, "integration_failures=%d\n", failures);
+      return 1;
+   }
+   puts("WindowStartup integration passed");
+   return 0;
+}

--- a/TotalCrossVM/src/tests/window_startup_native_test.c
+++ b/TotalCrossVM/src/tests/window_startup_native_test.c
@@ -33,11 +33,12 @@ int main(void)
    testSuite.fail = testFail;
    testSuite.output = testOutput;
    test_windowResolveStartupConfiguration(&testSuite, null);
+   test_windowResolveStartupFullscreenPolicy(&testSuite, null);
    if (testSuite.failed != 0)
    {
-      fprintf(stderr, "windowResolveStartupConfiguration failed\n");
+      fprintf(stderr, "WindowStartup tests failed\n");
       return 1;
    }
-   puts("windowResolveStartupConfiguration passed");
+   puts("WindowStartup tests passed");
    return 0;
 }


### PR DESCRIPTION
### What changed
- Consolidates desktop startup, SDL interaction, Skia font handling, and native ABI hardening.
- Centralizes `/scr`, fullscreen, environment overrides, sizing, positioning, and precedence through a shared `WindowStartup` path before window creation.
- Enables SDL mouse-focus click-through on desktop without changing other windowing backends.

### Fonts and rendering
- Separates Skia TTF loading from legacy PalmFont handling with deterministic lookup, safe fallback, and invalid-font rejection.
- Replaces the fixed-capacity Skia typeface registry with dynamic storage while preserving stable indices.
- Propagates bold style consistently through Skia text measurement and rendering, including proper state reset between calls.

### ABI and compatibility
- Uses fixed-width boolean fields in shared C/C++ structures and explicit integer representations for internal cross-language boolean APIs.
- Preserves existing public compatibility-sensitive native callback ABIs.
- Adds native startup integration coverage for real `/scr` and environment precedence behavior.

### Validation
- Adds C/C++ ABI probes, startup integration tests, and Skia font fixtures.
- macOS arm64 native VM build, startup tests, ABI probes, font validation, SDK distribution build, and `git diff --check` passed.